### PR TITLE
feat(agent-session): add the dsh external-runtime main-agent provider

### DIFF
--- a/completions/bash/agent-session
+++ b/completions/bash/agent-session
@@ -230,7 +230,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --format)
@@ -292,7 +292,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --event)
@@ -325,7 +325,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --forward-notify-argv-json)
@@ -358,7 +358,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --expected-preview-digest)
@@ -1635,7 +1635,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --cwd)
@@ -1844,7 +1844,7 @@ _agent__session() {
             fi
             case "${prev}" in
                 --agent)
-                    COMPREPLY=($(compgen -W "codex claude hermes" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude hermes dsh" -- "${cur}"))
                     return 0
                     ;;
                 --cwd)

--- a/completions/bash/main-agent
+++ b/completions/bash/main-agent
@@ -314,7 +314,7 @@ _main__agent() {
             fi
             case "${prev}" in
                 --provider)
-                    COMPREPLY=($(compgen -W "codex claude" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "codex claude dsh" -- "${cur}"))
                     return 0
                     ;;
                 --format)

--- a/completions/zsh/_agent-session
+++ b/completions/zsh/_agent-session
@@ -32,7 +32,10 @@ _agent-session() {
         case $line[1] in
             (start)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Agent to run]:AGENT:(codex claude hermes)' \
+'--agent=[Agent to run]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '--cwd=[Working directory for the agent session. Defaults to the current directory]:PATH:_files -/' \
 '--title=[Human-readable session title]:TITLE:_default' \
 '--id=[Short explicit session id. Usually auto-generated]:ID:_default' \
@@ -56,7 +59,10 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (run)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Agent to run]:AGENT:(codex claude hermes)' \
+'--agent=[Agent to run]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '--cwd=[Working directory for the agent session. Defaults to the current directory]:PATH:_files -/' \
 '--title=[Human-readable session title]:TITLE:_default' \
 '--id=[Short explicit session id. Usually auto-generated]:ID:_default' \
@@ -213,28 +219,37 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (hook)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Provider whose hook payload is on stdin]:AGENT:(codex claude hermes)' \
+'--agent=[Provider whose hook payload is on stdin]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '--event=[Provider event name when the raw payload does not carry one]:EVENT:_default' \
 '--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
 '--host=[Hostname used in generated ssh attach commands]:HOST:_default' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
 (notify)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Provider whose notification payload is supplied as the final argument]:AGENT:(codex claude hermes)' \
+'--agent=[Provider whose notification payload is supplied as the final argument]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '--forward-notify-argv-json=[JSON argv for an existing singular notifier composed by activity setup]:JSON:_default' \
 '--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
 '--host=[Hostname used in generated ssh attach commands]:HOST:_default' \
-'-h[Print help]' \
-'--help[Print help]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
 ':payload -- Provider-authored JSON passed by Codex in argv; content is discarded after parsing but is transiently visible to same-host process inspection:_default' \
 && ret=0
 ;;
 (doctor)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Limit diagnostics to one provider]:AGENT:(codex claude hermes)' \
+'--agent=[Limit diagnostics to one provider]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
@@ -245,7 +260,10 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 ;;
 (setup)
 _arguments "${_arguments_options[@]}" : \
-'--agent=[Provider to configure]:AGENT:(codex claude hermes)' \
+'--agent=[Provider to configure]:AGENT:((codex\:""
+claude\:""
+hermes\:""
+dsh\:"DeepSeek Harness workers managed by an external runtime (the dsh-runtime-kit bundle); never tmux-launched by this crate"))' \
 '(--dry-run)--expected-preview-digest=[Digest returned by the reviewed Codex repair preview. Required when applying Codex repair and rejected if either planned file changed]:SHA256:_default' \
 '--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \

--- a/completions/zsh/_main-agent
+++ b/completions/zsh/_main-agent
@@ -32,7 +32,7 @@ _main-agent() {
         case $line[1] in
             (capabilities)
 _arguments "${_arguments_options[@]}" : \
-'--provider=[Provider runtime whose deployed hook surface must admit checkpoint writes]:PROVIDER:(codex claude)' \
+'--provider=[Provider runtime whose deployed hook surface must admit checkpoint writes]:PROVIDER:(codex claude dsh)' \
 '--format=[]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--state-dir=[agent-session state directory]:PATH:_files -/' \

--- a/crates/agent-session/docs/README.md
+++ b/crates/agent-session/docs/README.md
@@ -34,6 +34,10 @@ or integrating a specific subsystem.
 - [Main Agent orchestration v1](specs/main-agent-orchestration-v1.md): durable
   run/assignment schemas, authenticated facade, rehydration, and relationship
   lifecycle.
+- [Main Agent DSH external runtime v1](specs/main-agent-dsh-external-runtime-v1.md):
+  the `launch.agent = "dsh"` worker transport owned by the external
+  dsh-runtime-kit plugin — capabilities probe, external launch contract, and
+  the liveness sidecar.
 
 ## Evidence and migration reports
 

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -125,7 +125,7 @@ Consumption. The reader resolves one of four dispositions:
 | --- | --- | --- |
 | never attached | no sidecar exists | `missing` |
 | running | valid sidecar, lane `open`, pinned harness proven live | `running` |
-| proven stopped | lane `terminated` with the harness not proven live, or the pinned harness proven gone (ESRCH, or a starttime mismatch proving pid reuse) | `stopped` |
+| proven stopped | the pinned harness is proven gone (ESRCH, or a starttime mismatch proving pid reuse) — required whether the lane reads `open` or `terminated` | `stopped` |
 | unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; or the harness state is undecidable (see the platform rule below) | `unknown` |
 
 Platform rule for the incarnation pin: where a starttime source exists (Linux
@@ -137,11 +137,23 @@ and pid reuse remains an accepted residual risk, exactly as it is for the tmux
 process-group probe on the same platforms. Plugins should always write
 `start_time` where the platform can read it.
 
-- Destructive operations require positive evidence: record deletion is
-  admitted only for a never-attached or proven-stopped lane. A running lane
-  refuses, and an unproven lane refuses with
-  `coordination-runtime-unverified` — a corrupted sidecar must never authorize
-  destroying a live lane's record.
+- Destructive operations require positive evidence: record deletion (and the
+  `remove-console-record` maintenance action) is admitted only for a
+  never-attached or proven-stopped lane. A running lane refuses, and an
+  unproven lane refuses with `coordination-runtime-unverified` — a corrupted
+  sidecar must never authorize destroying a live lane's record.
+- A proven-stopped lane must additionally be corroborated by its coordination
+  broker: the sidecar path must be the one this CLI derives for the record, and
+  the lane's broker heartbeat must be absent or stale. The sidecar is writable
+  by the lane's own worker, so sidecar evidence alone is forgeable; requiring
+  the separately maintained heartbeat to be gone means a forged stop must also
+  surrender coordination authority, which is itself observable. This raises the
+  bar — it is not an OS boundary, and the same-uid caveat above still stands.
+- A never-attached lane is terminal for pre-claim recovery: while its
+  assignment is still `starting` and holds no claim, `worker cancel` and
+  `worker reassign` treat it exactly as they treat a runtime that died during
+  startup. Its `missing` status must not be read as "evidence unavailable",
+  which would leave the assignment with no recovery route at all.
 - An idle-but-resumable lane is *running*: cold resume is always available
   while the harness lives and the lane is open.
 - `lane.state == "terminated"` is a **plugin assertion**, deliberately weaker
@@ -161,9 +173,15 @@ sidecar instead of the provider hook spool: a valid open lane under a live
 harness whose sidecar carries a known `turn.phase` reports that phase with
 `source.kind: "runtime"`, `provider: "dsh"`, and authoritative confidence
 (the harness observes its own agent directly, so the signal is authoritative
-rather than inferred). Any other state yields no activity evidence, and
-diagnosis degrades conservatively. The classification table itself is not
-modified.
+rather than inferred). This projection is the shared one, so every activity
+consumer — diagnosis, views, claim gates — reads the same evidence.
+
+Any other state yields no activity evidence, and diagnosis then distinguishes
+proven absence from missing evidence: a never-attached or proven-stopped lane
+has no turn to report and is classified as *absent* activity, while an unproven
+lane is *unavailable* and keeps the fail-closed guards engaged. Classifying a
+closed lane as unavailable instead would fence the cancel/reassign routes that
+lane needs. The classification table itself is not modified.
 
 ## Typed refusals
 
@@ -172,6 +190,28 @@ modified.
   store-side unchanged once the sidecar proves the lane stopped.
 - `agent-session resume`/provider resume surfaces: dsh sessions are not
   CLI-resumable (same typed-refusal pattern as Hermes).
+- `agent-session delete`, `maintenance` `remove-console-record`: an unproven
+  lane refuses with `coordination-runtime-unverified`.
+
+## Closing out an unproven lane
+
+An unproven lane is closed out by producing evidence, never by forcing the
+refusal. In order:
+
+1. Ask the owning plugin to publish a fresh sidecar for the recorded launch. A
+   plugin that still owns the lane can always re-derive `harness` and
+   `lane.state`, which resolves the disposition either way.
+2. If the harness is genuinely gone, confirm the recorded pid is not live and
+   remove the stale sidecar file. The lane then reads as never attached, which
+   is a terminal pre-claim disposition, and the assignment can be cancelled or
+   reassigned.
+3. If the harness is undecidable because the platform has no starttime source,
+   the lane's own broker heartbeat is the remaining evidence: once it is stale
+   the operator can stop the harness process, after which the pid probe decides.
+
+The CLI intentionally offers no force flag for this path. A force flag would be
+indistinguishable from the forged-stop case the corroboration rule exists to
+prevent, and the recovery above needs no new authority.
 
 ## Non-goals (v1)
 

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -13,7 +13,7 @@ that issue.
 ## Division of responsibility
 
 | Concern | Owner |
-|---|---|
+| --- | --- |
 | Run/assignment/checkpoint records, revision fencing, idempotency | `main-agent` (this crate, unchanged) |
 | Worker session record + capability/checkpoint file minting | `main-agent worker start` (dsh arm) |
 | Spawning the worker agent, delivering the bootstrap prompt | dsh-runtime-kit plugin |

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -126,7 +126,16 @@ Consumption. The reader resolves one of four dispositions:
 | never attached | no sidecar exists | `missing` |
 | running | valid sidecar, lane `open`, pinned harness proven live | `running` |
 | proven stopped | lane `terminated` with the harness not proven live, or the pinned harness proven gone (ESRCH, or a starttime mismatch proving pid reuse) | `stopped` |
-| unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; or the harness state is undecidable (EPERM without a readable starttime, no `start_time`, unreadable `/proc`) | `unknown` |
+| unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; or the harness state is undecidable (see the platform rule below) | `unknown` |
+
+Platform rule for the incarnation pin: where a starttime source exists (Linux
+`/proc`), a liveness claim without a verified `start_time` match is *undecided*
+rather than live, so a recycled pid can never masquerade as a live harness —
+including when `kill` reports `EPERM`. On platforms with no starttime source the
+pid signal is the only liveness evidence that exists, so it is decisive there
+and pid reuse remains an accepted residual risk, exactly as it is for the tmux
+process-group probe on the same platforms. Plugins should always write
+`start_time` where the platform can read it.
 
 - Destructive operations require positive evidence: record deletion is
   admitted only for a never-attached or proven-stopped lane. A running lane

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -1,0 +1,152 @@
+# Main Agent DSH external-runtime provider (v1)
+
+This spec defines how the `main-agent` orchestration facade supports
+`launch.agent = "dsh"` workers whose runtime is owned by an external harness
+(the DeepSeek Harness `dsh-runtime-kit` bundle) instead of a tmux-managed
+provider CLI session. The durable store, revision fencing, idempotency
+receipts, claims, and acceptance protocol are unchanged; only the transport
+and liveness evidence differ.
+
+Tracking: sympoies/dsh-runtime-kit#6 (M1). The consuming plugin work is M2 in
+that issue.
+
+## Division of responsibility
+
+| Concern | Owner |
+|---|---|
+| Run/assignment/checkpoint records, revision fencing, idempotency | `main-agent` (this crate, unchanged) |
+| Worker session record + capability/checkpoint file minting | `main-agent worker start` (dsh arm) |
+| Spawning the worker agent, delivering the bootstrap prompt | dsh-runtime-kit plugin |
+| Per-lane broker heartbeat process | dsh-runtime-kit plugin (spawns `agent-session broker heartbeat`) |
+| Liveness/turn evidence | plugin-maintained sidecar file (schema below) |
+| Worker-side bootstrap/checkpoint | worker agent runs the existing `main-agent bootstrap` / `main-agent checkpoint` verbs |
+| Stop/interrupt of a lane runtime | plugin (`worker stop-runtime` returns a typed refusal for dsh) |
+
+## `capabilities --provider dsh`
+
+`main-agent capabilities --provider dsh --format json` returns
+`main-agent.capabilities.v1` with:
+
+- `capabilities.runtime_checkpoint_file`: `"main-agent.runtime-checkpoint-file.v1"`.
+- `capabilities.runtime_hook_checkpoint_write`: always `null`. DSH policy v1
+  admits only native allow/block decisions; there is no hook checkpoint-write
+  admission layer, and none is required — the store fences every checkpoint.
+- `capabilities.run_wide_closeout`: `"main-agent.run-wide-closeout.v1"`.
+- `capabilities.external_runtime`: `"main-agent.external-runtime.v1"` — the
+  worker transport contract in this spec.
+- `compatible`: true iff the same-directory sibling `agent-hook` reports a
+  doctor record for product `dsh` with `dispatch_supported: true` and
+  `registration_owner: "dsh-runtime-kit"`. For codex/claude the existing
+  predicate (hook checkpoint-write admission) is unchanged.
+
+## `worker start` external arm
+
+For `launch.agent = "dsh"` the shared path (validation, claims, digests,
+replay, assignment record, packet storage, fences) is unchanged. At the
+launch boundary the arm diverges:
+
+- The session record is created through the normal record path with
+  `runtime.kind = "dsh_external"`, an empty `tmux_session`, and a CLI-minted
+  `launch_id` (the worker incarnation). No process is spawned and no prompt
+  is pasted.
+- `--await-ready` must be `0s`; a non-zero value is `invalid-input`
+  (`dsh-await-ready-unsupported`). Readiness is observed with
+  `worker wait`/`worker show` after the plugin delivers the prompt; the
+  authenticated-checkpoint readiness proof is store-only and unchanged.
+- Provider-stop canary, account handoff, and submit-key recovery remain
+  codex/claude-only; the existing gates already exclude dsh.
+- The result stays `main-agent.worker-start-result.v1` and additionally
+  carries (dsh only):
+
+```jsonc
+"delivery": { "state": "external-launch-pending", "proof": "external-runtime-transfer" },
+"external_launch": {
+  "schema_version": "main-agent.external-launch.v1",
+  "launch_id": "<runtime.launch_id>",
+  "prompt": "<byte-stable dsh bootstrap prompt; contains no environment values>",
+  "worker_env": {
+    "AGENT_SESSION_ID": "<worker session id>",
+    "AGENT_SESSION_STATE_DIR": "<state dir>",
+    "AGENT_SESSION_RUNTIME_ID": "<launch_id>",
+    "AGENT_SESSION_CAPABILITY_FILE": "<capability path for (session, launch_id)>",
+    "AGENT_SESSION_CHECKPOINT_FILE": "<checkpoint path for (session, launch_id)>"
+  },
+  "broker_heartbeat_argv": ["<agent-session bin>", "--state-dir", "<state dir>", "broker", "heartbeat", "--session", "<id>", "--incarnation", "<launch_id>", "--generation", "1", "--capability-file", "<capability path>", "--format", "json"],
+  "broker_stop_argv": ["<agent-session bin>", "--state-dir", "<state dir>", "broker", "stop", "--session", "<id>", "--capability-file", "<capability path>", "--format", "json"],
+  "liveness_file": "<session dir>/dsh-runtime-liveness.json"
+}
+```
+
+The plugin must deliver `prompt` verbatim as the worker's initial message,
+run `broker_heartbeat_argv` as a supervised background process for the lane's
+lifetime (worker authentication reads the capability file that the heartbeat
+maintains), run `broker_stop_argv` at lane end, and arrange the worker's
+`main-agent`/`agent-session` invocations to carry `worker_env`. The prompt is
+deliberately environment-free so it stays a byte-stable replay contract; env
+delivery is a plugin responsibility (per-child instruction context or a
+wrapping native tool).
+
+The dsh prompt is a fifth byte-stable replay variant alongside the four
+existing prompts; `ensure_worker_launch_matches` accepts it for replay
+matching exactly like the others.
+
+## Liveness sidecar — `main-agent.dsh-runtime-liveness.v1`
+
+Path: `<session dir>/dsh-runtime-liveness.json`, written and refreshed only by
+the plugin (owner-only file mode). Fields:
+
+```jsonc
+{
+  "schema_version": "main-agent.dsh-runtime-liveness.v1",
+  "launch_id": "<must equal runtime.launch_id>",
+  "harness": {
+    // process identity of the DSH harness process, TmuxRuntimeIdentity-shaped:
+    "pane_pid": <harness pid>,
+    "process_group_id": <pgid or null>,
+    "process_session_id": <sid or null>,
+    "control_group": "<cgroup path or null>",
+    "pid_namespace": "<pid ns identity or null>",
+    "pane_start_time": <starttime ticks or null>
+  },
+  "lane": { "state": "open" | "terminated" },
+  "updated_at": "<epoch seconds>"
+}
+```
+
+Consumption:
+
+- `session_status` for a `dsh_external` record: `missing` when the sidecar is
+  absent; `stopped` when `lane.state == "terminated"`, when `launch_id` does
+  not match the record, or when the harness process identity proves stopped;
+  otherwise `running`. An idle-but-resumable lane is *running* — cold resume
+  is always available while the harness lives and the lane is open.
+- `coordination_runtime_evidence` for a `dsh_external` record builds the
+  runtime identity from `harness` (validated against `launch_id`) and reuses
+  the existing process-liveness proof. Unknown stays conservative exactly as
+  for tmux runtimes.
+
+## Diagnose/supervise evidence
+
+Store, claim, packet, worktree, and coordination evidence are provider-neutral
+and unchanged. For `dsh` workers the activity evidence is derived from the
+sidecar (`lane.state` + harness liveness) instead of the provider hook spool:
+an open lane with a live harness reports a waiting/working turn phase at
+observed confidence, so a healthy dsh lane classifies on the same table as the
+managed products without the provider-hook activity pipeline. The
+classification table itself is not modified.
+
+## Typed refusals
+
+- `worker stop-runtime`, `worker stop-claimed-runtime`: `dsh-runtime-plugin-owned`
+  — the plugin interrupts the lane; `worker reconcile-stopped` then proceeds
+  store-side unchanged once the sidecar proves the lane stopped.
+- `agent-session resume`/provider resume surfaces: dsh sessions are not
+  CLI-resumable (same typed-refusal pattern as Hermes).
+
+## Non-goals (v1)
+
+- No provider hook activity pipeline for dsh (`agent-session activity` events
+  may arrive later via the agent-hook DSH ingress work; this spec does not
+  depend on it).
+- No `AssignmentInput` schema change (worker-start digests must stay stable).
+- No provider-stop canary, account handoff, or submit-key recovery for dsh.

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -93,47 +93,68 @@ matching exactly like the others.
 ## Liveness sidecar — `main-agent.dsh-runtime-liveness.v1`
 
 Path: `<session dir>/dsh-runtime-liveness.json`, written and refreshed only by
-the plugin (owner-only file mode). Fields:
+the plugin. The reader requires an owner-only (`0600`-class), single-link,
+non-symlink regular file at exactly that path, at most 64 KiB, and rejects
+unknown fields at every level. Fields:
 
 ```jsonc
 {
   "schema_version": "main-agent.dsh-runtime-liveness.v1",
   "launch_id": "<must equal runtime.launch_id>",
   "harness": {
-    // process identity of the DSH harness process, TmuxRuntimeIdentity-shaped:
-    "pane_pid": <harness pid>,
-    "process_group_id": <pgid or null>,
-    "process_session_id": <sid or null>,
-    "control_group": "<cgroup path or null>",
-    "pid_namespace": "<pid ns identity or null>",
-    "pane_start_time": <starttime ticks or null>
+    "pid": <harness pid>,
+    // Linux /proc starttime ticks. Required to prove the exact incarnation:
+    // without it liveness is undecidable and destructive operations refuse.
+    "start_time": <starttime ticks, optional>
   },
   "lane": { "state": "open" | "terminated" },
+  // Optional turn evidence; absent means diagnosis degrades conservatively.
+  "turn": {
+    "phase": "working" | "waiting",
+    "phase_changed_at": "<epoch seconds>",
+    "current_turn": { "started_at": "<epoch seconds>", "last_progress_at": "<epoch seconds, optional>" },
+    "last_turn": { "completed_at": "<epoch seconds>", "outcome": "completed" | "failed" | "interrupted" }
+  },
   "updated_at": "<epoch seconds>"
 }
 ```
 
-Consumption:
+Consumption. The reader resolves one of four dispositions:
 
-- `session_status` for a `dsh_external` record: `missing` when the sidecar is
-  absent; `stopped` when `lane.state == "terminated"`, when `launch_id` does
-  not match the record, or when the harness process identity proves stopped;
-  otherwise `running`. An idle-but-resumable lane is *running* — cold resume
-  is always available while the harness lives and the lane is open.
-- `coordination_runtime_evidence` for a `dsh_external` record builds the
-  runtime identity from `harness` (validated against `launch_id`) and reuses
-  the existing process-liveness proof. Unknown stays conservative exactly as
-  for tmux runtimes.
+| Disposition | When | `session_status` |
+| --- | --- | --- |
+| never attached | no sidecar exists | `missing` |
+| running | valid sidecar, lane `open`, pinned harness proven live | `running` |
+| proven stopped | lane `terminated` with the harness not proven live, or the pinned harness proven gone (ESRCH, or a starttime mismatch proving pid reuse) | `stopped` |
+| unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; or the harness state is undecidable (EPERM without a readable starttime, no `start_time`, unreadable `/proc`) | `unknown` |
+
+- Destructive operations require positive evidence: record deletion is
+  admitted only for a never-attached or proven-stopped lane. A running lane
+  refuses, and an unproven lane refuses with
+  `coordination-runtime-unverified` — a corrupted sidecar must never authorize
+  destroying a live lane's record.
+- An idle-but-resumable lane is *running*: cold resume is always available
+  while the harness lives and the lane is open.
+- `lane.state == "terminated"` is a **plugin assertion**, deliberately weaker
+  than the tmux kernel-backed proof: the sidecar lives in the same-uid state
+  dir a lane's own worker can reach. It is therefore corroborated against the
+  pinned harness identity, and a still-live harness makes the assertion
+  unproven rather than proven.
+- `coordination_runtime_evidence` builds the runtime identity from `harness`
+  (validated against `launch_id`) and reuses the existing process-liveness
+  proof. Unproven stays conservative exactly as for tmux runtimes.
 
 ## Diagnose/supervise evidence
 
 Store, claim, packet, worktree, and coordination evidence are provider-neutral
 and unchanged. For `dsh` workers the activity evidence is derived from the
-sidecar (`lane.state` + harness liveness) instead of the provider hook spool:
-an open lane with a live harness reports a waiting/working turn phase at
-observed confidence, so a healthy dsh lane classifies on the same table as the
-managed products without the provider-hook activity pipeline. The
-classification table itself is not modified.
+sidecar instead of the provider hook spool: a valid open lane under a live
+harness whose sidecar carries a known `turn.phase` reports that phase with
+`source.kind: "runtime"`, `provider: "dsh"`, and authoritative confidence
+(the harness observes its own agent directly, so the signal is authoritative
+rather than inferred). Any other state yields no activity evidence, and
+diagnosis degrades conservatively. The classification table itself is not
+modified.
 
 ## Typed refusals
 

--- a/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-orchestration-v1.md
@@ -511,6 +511,21 @@ healthy installation to the other provider. Either mixed-deployment direction
 therefore fails before worker launch. The `1.25.11` registry floor alone does
 not prove this additive paired API.
 
+`main-agent capabilities --provider dsh --format json` reports the
+external-runtime contract instead: `capabilities.runtime_hook_checkpoint_write`
+is always `null` (DSH policy v1 admits only native allow/block decisions and
+the store fences every checkpoint), `capabilities.external_runtime` is
+`main-agent.external-runtime.v1` when the sibling `agent-hook` doctor reports
+`dispatch_supported:true` with `registration_owner:"dsh-runtime-kit"`, and
+`compatible` follows that probe. DSH workers are never tmux-launched:
+`worker start` with `launch.agent:"dsh"` requires `--await-ready 0s`, performs
+the identical store bookkeeping, and returns a
+`main-agent.external-launch.v1` payload (byte-stable environment-free prompt,
+exact worker environment, broker heartbeat/stop argv, and the liveness sidecar
+path) that the external dsh-runtime-kit plugin executes. See
+`main-agent-dsh-external-runtime-v1.md` for the full external-runtime
+contract.
+
 The current controller incarnation MUST also pass `main-agent self readiness
 --format json` before `init` or mutation. This authenticates the session and
 requires its exact runtime-derived `AGENT_SESSION_CHECKPOINT_FILE` path to

--- a/crates/agent-session/docs/specs/serve-api-v1.md
+++ b/crates/agent-session/docs/specs/serve-api-v1.md
@@ -110,8 +110,15 @@ recorded in `sympoies/nils-cli#1409`.
   must require both the global protocol advertisement and the per-session
   capability before presenting managed handoff controls.
   Sessions report
-  `running`, `stopped`, or `unknown` live status plus a boolean `resumable` field and best-effort `repo_name` derived from
-  the recorded `cwd`. New interactive records also expose optional
+  `running`, `stopped`, `unknown`, or `missing` live status plus a boolean `resumable` field and best-effort `repo_name` derived from
+  the recorded `cwd`. `missing` is reported only for an external-runtime record
+  (`runtime.kind = "dsh_external"`) whose owning plugin never attached to the
+  recorded launch; consumers must treat it as "no runtime exists for this
+  launch", never as a terminated runtime that could be resumed. Every
+  external-runtime record reports `resumable: false` — it carries no provider
+  resume identity — and its runtime is owned by the external plugin, so the
+  input path refuses it with `dsh-runtime-plugin-owned`. Resume and input
+  controls belong to that plugin, not to this daemon. New interactive records also expose optional
   `runtime_started_at`, `turn_state`, `last_prompt`, `last_prompt_state`,
   `last_prompt_continuity`, and `startup`; a profiled
   session also

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -3383,18 +3383,20 @@ pub(crate) fn doctor(
                     reported_config_path,
                 )
             }
-            AgentKind::Claude | AgentKind::Hermes => match provider_configured(agent, &path) {
-                Ok(configured) => (configured, None, None, None, None, None, path.clone()),
-                Err(error) => (
-                    false,
-                    Some(error.code().to_string()),
-                    None,
-                    None,
-                    None,
-                    None,
-                    path.clone(),
-                ),
-            },
+            AgentKind::Claude | AgentKind::Hermes | AgentKind::Dsh => {
+                match provider_configured(agent, &path) {
+                    Ok(configured) => (configured, None, None, None, None, None, path.clone()),
+                    Err(error) => (
+                        false,
+                        Some(error.code().to_string()),
+                        None,
+                        None,
+                        None,
+                        None,
+                        path.clone(),
+                    ),
+                }
+            }
         };
         let activity_summary = activity_by_provider
             .get(agent.as_str())
@@ -3430,6 +3432,13 @@ pub(crate) fn doctor(
                     "Hermes 0.18.2 shell approval hooks use projected non-empty tool_call_id for exact correlation; missing/empty-id tuple fallback retains conservative multiplicity until completion, a new turn, or a runtime boundary",
                     "Hermes shell hooks require first-use consent unless explicitly accepted",
                     "Run activity setup --agent hermes --dry-run, apply it, then approve and verify with hermes hooks doctor",
+                ),
+                AgentKind::Dsh => (
+                    "unverified",
+                    "dsh lifecycle state is owned by the external dsh-runtime-kit runtime; no provider hook completion signal exists",
+                    "no provider attention correlation exists; the external runtime's liveness sidecar is the only runtime evidence",
+                    "the external dsh-runtime-kit bundle owns Cordis registration; no files are managed here",
+                    "Use main-agent capabilities --provider dsh for the external-runtime readiness contract",
                 ),
             };
         let audited = version
@@ -3468,6 +3477,7 @@ pub(crate) fn doctor(
                 "hook",
             ),
             AgentKind::Hermes => (if audited { "supported" } else { "unverified" }, "hook"),
+            AgentKind::Dsh => ("unverified", "external-runtime"),
         };
         let mut guidance = if matches!(classification, "unavailable" | "unverified") {
             format!(
@@ -3744,6 +3754,9 @@ fn audited_floor(agent: AgentKind) -> (u64, u64, u64) {
         AgentKind::Codex => (0, 144, 1),
         AgentKind::Claude => (2, 1, 206),
         AgentKind::Hermes => (0, 18, 2),
+        // No provider activity pipeline exists for dsh; the config-path gate
+        // refuses `--agent dsh` before any floor comparison can run.
+        AgentKind::Dsh => (u64::MAX, 0, 0),
     }
 }
 
@@ -3775,6 +3788,13 @@ fn provider_config_path(agent: AgentKind) -> Result<std::path::PathBuf, CliError
         AgentKind::Codex => home.join(".codex/hooks.json"),
         AgentKind::Claude => home.join(".claude/settings.json"),
         AgentKind::Hermes => home.join(".hermes/config.yaml"),
+        AgentKind::Dsh => {
+            return Err(CliError::usage(
+                "unsupported-activity-agent",
+                "dsh lifecycle state is owned by the external dsh-runtime-kit runtime; there is no provider activity configuration to manage",
+                Some(json!({ "agent": agent.as_str() })),
+            ));
+        }
     })
 }
 
@@ -3911,6 +3931,9 @@ fn provider_specs(agent: AgentKind) -> Vec<ProviderSpec> {
                 matcher: None,
             },
         ],
+        // No provider activity hooks exist for dsh; lifecycle evidence is
+        // owned by the external dsh-runtime-kit runtime.
+        AgentKind::Dsh => Vec::new(),
     }
 }
 
@@ -3926,7 +3949,7 @@ fn retired_provider_specs(agent: AgentKind) -> Vec<ProviderSpec> {
                 matcher: None,
             },
         ],
-        AgentKind::Codex | AgentKind::Hermes => Vec::new(),
+        AgentKind::Codex | AgentKind::Hermes | AgentKind::Dsh => Vec::new(),
     }
 }
 
@@ -3955,6 +3978,8 @@ fn provider_configured(agent: AgentKind, path: &Path) -> Result<bool, CliError> 
         }
         AgentKind::Claude => json_provider_configured(agent, path),
         AgentKind::Hermes => hermes_configured(path),
+        // Unreachable in practice: provider_config_path refuses dsh first.
+        AgentKind::Dsh => Ok(false),
     }
 }
 

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -1816,6 +1816,14 @@ fn replay_matches_document(dir: &Path, document: &ActivityDocument) -> bool {
 }
 
 pub(crate) fn state_for_view(context: &CliContext, record: &SessionRecord) -> Option<TurnState> {
+    // A plugin-owned dsh lane reports its turn through the liveness sidecar
+    // instead of this store's activity document, and its unhealthy markers
+    // belong to a tmux runtime it never had. Projecting it here keeps every
+    // activity consumer — claim gates, views, prompt baselines — reading the
+    // same evidence as `main-agent worker diagnose`.
+    if crate::dsh_external::is_external_record(record) {
+        return crate::dsh_external::external_turn_state(record);
+    }
     let dir = session_dir(context, &record.id);
     if let Some(runtime) = record.runtime.as_ref() {
         match runtime_unhealthy_marker(&dir, &runtime.launch_id, runtime.generation) {

--- a/crates/agent-session/src/cli.rs
+++ b/crates/agent-session/src/cli.rs
@@ -1064,6 +1064,9 @@ pub enum AgentKind {
     Codex,
     Claude,
     Hermes,
+    /// DeepSeek Harness workers managed by an external runtime (the
+    /// dsh-runtime-kit bundle); never tmux-launched by this crate.
+    Dsh,
 }
 
 impl AgentKind {
@@ -1072,6 +1075,7 @@ impl AgentKind {
             Self::Codex => "codex",
             Self::Claude => "claude",
             Self::Hermes => "hermes",
+            Self::Dsh => "dsh",
         }
     }
 
@@ -1082,6 +1086,7 @@ impl AgentKind {
             "codex" => Some(Self::Codex),
             "claude" => Some(Self::Claude),
             "hermes" => Some(Self::Hermes),
+            "dsh" => Some(Self::Dsh),
             _ => None,
         }
     }

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -161,7 +161,10 @@ pub(crate) fn ensure_recorded_liveness_path(
     context: &CliContext,
     record: SessionRecord,
 ) -> Result<SessionRecord, CliError> {
-    if !is_external_record(&record) || recorded_liveness_path(&record).is_some() {
+    // Repair a missing key (a crash between the two writes) and also a shaped
+    // but foreign path, so a tampered record converges on the derived path
+    // instead of quietly sourcing evidence from somewhere else.
+    if !is_external_record(&record) || recorded_liveness_path_is_derived(context, &record) {
         return Ok(record);
     }
     let expected = json!(crate::display_path(&liveness_path(context, &record.id)));
@@ -190,15 +193,73 @@ pub(crate) fn liveness_path(context: &CliContext, session_id: &str) -> PathBuf {
 /// directory: a record-supplied path pointing anywhere else is not evidence
 /// about this lane.
 fn recorded_liveness_path(record: &SessionRecord) -> Option<PathBuf> {
-    let path = record.extra.get(LIVENESS_PATH_KEY)?.as_str()?;
-    let path = Path::new(path);
+    let raw = record.extra.get(LIVENESS_PATH_KEY)?.as_str()?;
+    let path = Path::new(raw);
     if !path.is_absolute() || path.file_name()? != LIVENESS_FILE {
         return None;
     }
     if path.parent()?.file_name()? != record.id.as_str() {
         return None;
     }
+    // Reject traversal outright: a normalizing comparison would accept
+    // `.../sessions/<id>/../../elsewhere/<id>/<file>` because both sides
+    // normalize the same way, so the recorded path must already be canonical.
+    if crate::display_path(path) != raw {
+        return None;
+    }
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return None;
+    }
     Some(path.to_path_buf())
+}
+
+/// Whether the record's sidecar path is the exact path this CLI derives for it.
+/// Only a context-bearing caller can check this; the context-free reader keeps
+/// the shape checks above.
+fn recorded_liveness_path_is_derived(context: &CliContext, record: &SessionRecord) -> bool {
+    recorded_liveness_path(record)
+        .is_some_and(|recorded| recorded == liveness_path(context, &record.id))
+}
+
+/// The stop proof a destructive operation requires, which is deliberately
+/// stronger than the status projection.
+///
+/// The sidecar lives in the same-uid state directory a lane's own worker can
+/// reach, so sidecar evidence alone is forgeable: a live worker could name a
+/// dead pid and have its own lane terminalized. Requiring the lane's broker
+/// heartbeat — a separate file maintained by a separate process the plugin
+/// owns — to be absent or stale means a forged stop must also stop the real
+/// coordination heartbeat, which is itself an observable loss of authority.
+/// This raises the bar; it is not an OS boundary, and the same-uid caveat in
+/// the spec still stands.
+///
+/// It holds when either the plugin never attached to this launch, or its
+/// published termination is corroborated. Both additionally require the lane's
+/// coordination heartbeat to be gone, so a lane that is live enough to hold
+/// coordination authority can never be terminalized through an absent or forged
+/// sidecar.
+///
+/// `NeverAttached` is included deliberately: without it a lane whose plugin
+/// never took the launch has no terminal disposition at all, and its assignment
+/// can be neither cancelled nor reassigned.
+pub(crate) fn external_lane_terminal_is_proven(
+    context: &CliContext,
+    record: &SessionRecord,
+    incarnation: &str,
+) -> bool {
+    if !recorded_liveness_path_is_derived(context, record) {
+        return false;
+    }
+    if !matches!(
+        external_lane_disposition(record),
+        ExternalLaneDisposition::NeverAttached | ExternalLaneDisposition::ProvenStopped
+    ) {
+        return false;
+    }
+    !coordination::broker::heartbeat_fresh(context, &record.id, incarnation, 0)
 }
 
 /// Typed outcome of reading the sidecar against a specific session record.
@@ -466,10 +527,14 @@ pub(crate) fn external_runtime_evidence(
             ));
         }
     };
+    // `lane.state` is part of the identity: without it a plugin-asserted
+    // termination flip leaves the digest unchanged, so a consumer comparing
+    // digests could not see that the evidence changed at all.
     let identity = json!({
         "kind": DSH_RUNTIME_KIND,
         "launch_id": liveness.launch_id,
         "harness": liveness.harness,
+        "lane_state": liveness.lane.state,
     });
     let bytes = serde_json::to_vec(&identity).map_err(|_| {
         CliError::runtime(
@@ -478,10 +543,15 @@ pub(crate) fn external_runtime_evidence(
             None,
         )
     })?;
-    let status = if liveness.lane.state == "terminated" {
-        CoordinationRuntimeStatus::Stopped
-    } else {
-        harness_process_status(&liveness.harness)
+    // One function owns the corroboration rule. Deriving the status here from
+    // the disposition keeps this evidence and the destructive-operation gate
+    // from disagreeing about what a plugin-asserted termination proves.
+    let status = match external_lane_disposition(record) {
+        ExternalLaneDisposition::Running => CoordinationRuntimeStatus::Running,
+        ExternalLaneDisposition::ProvenStopped => CoordinationRuntimeStatus::Stopped,
+        ExternalLaneDisposition::NeverAttached | ExternalLaneDisposition::Unproven(_) => {
+            CoordinationRuntimeStatus::Unknown
+        }
     };
     Ok(CoordinationRuntimeEvidence {
         identity_digest: coordination::digest_bytes(&bytes),

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -1,0 +1,449 @@
+//! External-runtime support for `dsh` worker sessions.
+//!
+//! DSH workers are never tmux-launched: the dsh-runtime-kit bundle owns the
+//! worker agent's lifecycle and maintains a liveness sidecar under the session
+//! state directory. This module owns the sidecar contract and the dsh arms of
+//! `session_status` / `coordination_runtime_evidence`.
+//!
+//! Contract: `docs/specs/main-agent-dsh-external-runtime-v1.md`.
+
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::{
+    CliContext, CliError, CoordinationRuntimeEvidence, CoordinationRuntimeStatus, SessionRecord,
+    coordination,
+};
+
+/// `SessionRecord.runtime.kind` for external dsh worker sessions.
+pub(crate) const DSH_RUNTIME_KIND: &str = "dsh_external";
+
+/// Versioned schema of the plugin-maintained liveness sidecar.
+pub(crate) const LIVENESS_SCHEMA: &str = "main-agent.dsh-runtime-liveness.v1";
+
+/// Sidecar file name inside the session state directory.
+pub(crate) const LIVENESS_FILE: &str = "dsh-runtime-liveness.json";
+
+/// `SessionRecord.extra` key naming the absolute sidecar path. Written once at
+/// external record creation, trusted exactly like the persisted tmux runtime
+/// identity that lives beside it in `extra`.
+pub(crate) const LIVENESS_PATH_KEY: &str = "dsh_liveness_file";
+
+/// Bounded sidecar read: the file is a small JSON document; anything larger
+/// is treated as invalid evidence rather than parsed.
+const MAX_LIVENESS_BYTES: u64 = 64 * 1024;
+
+/// Process identity of the DSH harness process, written by the plugin.
+/// `start_time` is the Linux `/proc/<pid>/stat` starttime (clock ticks); when
+/// present it pins the exact process incarnation, so a recycled pid cannot
+/// masquerade as a live harness.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshHarnessIdentity {
+    pub(crate) pid: i32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) start_time: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshLaneState {
+    /// `open` while the lane may still run turns (idle-but-resumable lanes
+    /// stay open: cold resume is always available while the harness lives);
+    /// `terminated` once the plugin has permanently stopped the lane.
+    pub(crate) state: String,
+}
+
+/// Optional turn evidence for the lane, written by the plugin from the
+/// harness's own agent status and lifecycle events. When absent, activity
+/// evidence stays unknown and diagnosis degrades conservatively.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshTurnEvidence {
+    /// `working` while a turn is running; `waiting` while the lane is idle
+    /// but resumable.
+    pub(crate) phase: String,
+    pub(crate) phase_changed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) current_turn: Option<DshCurrentTurn>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) last_turn: Option<DshLastTurn>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshCurrentTurn {
+    pub(crate) started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) last_progress_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshLastTurn {
+    pub(crate) completed_at: String,
+    /// `completed`, `failed`, or `interrupted`.
+    pub(crate) outcome: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DshRuntimeLiveness {
+    pub(crate) schema_version: String,
+    /// Must equal the session record's `runtime.launch_id`.
+    pub(crate) launch_id: String,
+    pub(crate) harness: DshHarnessIdentity,
+    pub(crate) lane: DshLaneState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) turn: Option<DshTurnEvidence>,
+    /// Informational refresh marker; not used as a liveness proof.
+    #[serde(default)]
+    pub(crate) updated_at: Option<Value>,
+}
+
+/// Create the durable session record for an external dsh worker. No process
+/// is spawned and no prompt is delivered: the dsh-runtime-kit plugin owns the
+/// worker agent's lifecycle. The record carries `runtime.kind = "dsh_external"`
+/// (derived from the agent kind at creation) and the absolute liveness sidecar
+/// path, so later status and evidence probes need no CLI context.
+pub(crate) fn create_external_worker_record(
+    context: &CliContext,
+    cwd: &std::path::Path,
+    worker_session_id: &str,
+    prompt: &str,
+    coordination_mode: crate::cli::CoordinationMode,
+    title: Option<&str>,
+    create_guard: Option<&mut dyn FnMut() -> Result<(), CliError>>,
+) -> Result<SessionRecord, CliError> {
+    let mut created = crate::create_record_with_guard(
+        crate::RecordRequest {
+            context,
+            agent: crate::cli::AgentKind::Dsh,
+            // Not "interactive": external records own no startup projection
+            // and are never CLI-resumable.
+            mode: "external",
+            coordination_mode,
+            title,
+            title_state: None,
+            explicit_id: Some(worker_session_id),
+            cwd,
+            prompt: Some(prompt),
+            log_file_name: None,
+            provider_resume: None,
+            agent_args: Vec::new(),
+            agent_bin: None,
+        },
+        create_guard,
+    )?;
+    created.record.extra.insert(
+        LIVENESS_PATH_KEY.to_string(),
+        json!(crate::display_path(&liveness_path(
+            context,
+            worker_session_id
+        ))),
+    );
+    if let Err(error) = crate::write_session_record(context, &created.record) {
+        crate::cleanup_created_record(context, &created);
+        return Err(error);
+    }
+    Ok(created.record.clone())
+}
+
+pub(crate) fn is_external_record(record: &SessionRecord) -> bool {
+    record
+        .runtime
+        .as_ref()
+        .is_some_and(|runtime| runtime.kind == DSH_RUNTIME_KIND)
+}
+
+pub(crate) fn liveness_path(context: &CliContext, session_id: &str) -> PathBuf {
+    crate::session_dir(context, session_id).join(LIVENESS_FILE)
+}
+
+/// The record-declared sidecar path, or `None` when the record does not carry
+/// a usable absolute path (treated as invalid evidence by callers).
+fn recorded_liveness_path(record: &SessionRecord) -> Option<PathBuf> {
+    let path = record.extra.get(LIVENESS_PATH_KEY)?.as_str()?;
+    let path = Path::new(path);
+    path.is_absolute().then(|| path.to_path_buf())
+}
+
+/// Typed outcome of reading the sidecar against a specific session record.
+pub(crate) enum LivenessEvidence {
+    /// No sidecar exists: the external runtime has not attached (or evidence
+    /// was cleaned); nothing is proven.
+    Missing,
+    /// A sidecar exists but is unreadable, malformed, oversized, schema- or
+    /// launch-mismatched; nothing is proven for this launch.
+    Invalid,
+    /// A structurally valid sidecar for this exact launch.
+    Present(Box<DshRuntimeLiveness>),
+}
+
+pub(crate) fn read_liveness(record: &SessionRecord) -> LivenessEvidence {
+    let Some(path) = recorded_liveness_path(record) else {
+        return LivenessEvidence::Invalid;
+    };
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return LivenessEvidence::Missing;
+        }
+        Err(_) => return LivenessEvidence::Invalid,
+    };
+    let mut bytes = Vec::new();
+    if file
+        .take(MAX_LIVENESS_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .is_err()
+        || bytes.len() as u64 > MAX_LIVENESS_BYTES
+    {
+        return LivenessEvidence::Invalid;
+    }
+    let Ok(liveness) = serde_json::from_slice::<DshRuntimeLiveness>(&bytes) else {
+        return LivenessEvidence::Invalid;
+    };
+    let current_launch_id = record
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .filter(|value| !value.is_empty());
+    if liveness.schema_version != LIVENESS_SCHEMA
+        || liveness.harness.pid <= 1
+        || liveness.harness.start_time == Some(0)
+        || !matches!(liveness.lane.state.as_str(), "open" | "terminated")
+        || current_launch_id != Some(liveness.launch_id.as_str())
+    {
+        return LivenessEvidence::Invalid;
+    }
+    LivenessEvidence::Present(Box::new(liveness))
+}
+
+/// Liveness of the harness process named by the sidecar. `Stopped` requires a
+/// proof (ESRCH, or a start-time mismatch proving pid reuse); permission and
+/// read errors stay `Unknown`, matching the conservative tmux behavior.
+pub(crate) fn harness_process_status(identity: &DshHarnessIdentity) -> CoordinationRuntimeStatus {
+    let alive = unsafe { libc::kill(identity.pid, 0) };
+    if alive != 0 {
+        return match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => CoordinationRuntimeStatus::Stopped,
+            Some(libc::EPERM) => CoordinationRuntimeStatus::Running,
+            _ => CoordinationRuntimeStatus::Unknown,
+        };
+    }
+    match (identity.start_time, linux_process_start_time(identity.pid)) {
+        (Some(expected), Some(actual)) if expected != actual => CoordinationRuntimeStatus::Stopped,
+        (Some(_), None) => CoordinationRuntimeStatus::Unknown,
+        _ => CoordinationRuntimeStatus::Running,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_process_start_time(pid: i32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    // Field 22 (starttime) counted after the parenthesized comm field, which
+    // may itself contain spaces and parentheses.
+    let after_comm = stat.rsplit_once(')')?.1;
+    after_comm.split_whitespace().nth(19)?.parse().ok()
+}
+
+#[cfg(not(target_os = "linux"))]
+fn linux_process_start_time(_pid: i32) -> Option<u64> {
+    None
+}
+
+/// `session_status` for external dsh records: `missing` when nothing is
+/// proven for this launch, `stopped` when the lane is terminated or the
+/// harness process is proven gone, `running` while the lane is open under a
+/// live harness (idle lanes stay `running`; cold resume is always available).
+pub(crate) fn external_session_status(record: &SessionRecord) -> String {
+    match read_liveness(record) {
+        LivenessEvidence::Missing | LivenessEvidence::Invalid => "missing".to_string(),
+        LivenessEvidence::Present(liveness) => {
+            if liveness.lane.state == "terminated" {
+                return "stopped".to_string();
+            }
+            match harness_process_status(&liveness.harness) {
+                CoordinationRuntimeStatus::Running => "running".to_string(),
+                CoordinationRuntimeStatus::Stopped => "stopped".to_string(),
+                CoordinationRuntimeStatus::Unknown => "missing".to_string(),
+            }
+        }
+    }
+}
+
+/// Synthesized activity evidence for an external dsh lane. `Some` only when
+/// the sidecar is valid for this launch, the lane is open, the harness is
+/// proven live, and the plugin supplied turn evidence with a known phase;
+/// everything else stays `None` so diagnosis degrades conservatively.
+pub(crate) fn external_turn_state(record: &SessionRecord) -> Option<crate::activity::TurnState> {
+    let LivenessEvidence::Present(liveness) = read_liveness(record) else {
+        return None;
+    };
+    if liveness.lane.state != "open"
+        || harness_process_status(&liveness.harness) != CoordinationRuntimeStatus::Running
+    {
+        return None;
+    }
+    let turn = liveness.turn.as_ref()?;
+    if !matches!(turn.phase.as_str(), "working" | "waiting") {
+        return None;
+    }
+    serde_json::from_value(json!({
+        "schema_version": crate::activity::TURN_STATE_VERSION,
+        "phase": turn.phase,
+        "phase_changed_at": turn.phase_changed_at,
+        "revision": 0,
+        "source": {
+            "kind": "runtime",
+            "provider": "dsh",
+            "confidence": "authoritative"
+        },
+        "current_turn": turn.current_turn.as_ref().map(|current| json!({
+            "started_at": current.started_at,
+            "last_progress_at": current.last_progress_at
+        })),
+        "last_turn": turn.last_turn.as_ref().map(|last| json!({
+            "completed_at": last.completed_at,
+            "outcome": last.outcome
+        }))
+    }))
+    .ok()
+}
+
+/// `coordination_runtime_evidence` for external dsh records. The identity is
+/// the sidecar's launch-bound harness identity; missing or invalid sidecars
+/// fail with the same typed error as an unavailable tmux runtime identity.
+pub(crate) fn external_runtime_evidence(
+    record: &SessionRecord,
+) -> Result<CoordinationRuntimeEvidence, CliError> {
+    let liveness = match read_liveness(record) {
+        LivenessEvidence::Present(liveness) => liveness,
+        LivenessEvidence::Missing => {
+            return Err(CliError::runtime(
+                "coordination-runtime-unverified",
+                "external dsh runtime liveness evidence is unavailable",
+                None,
+            ));
+        }
+        LivenessEvidence::Invalid => {
+            return Err(CliError::runtime(
+                "coordination-runtime-unverified",
+                "external dsh runtime liveness evidence is invalid",
+                None,
+            ));
+        }
+    };
+    let identity = json!({
+        "kind": DSH_RUNTIME_KIND,
+        "launch_id": liveness.launch_id,
+        "harness": liveness.harness,
+    });
+    let bytes = serde_json::to_vec(&identity).map_err(|_| {
+        CliError::runtime(
+            "coordination-runtime-unverified",
+            "external dsh runtime identity could not be canonicalized",
+            None,
+        )
+    })?;
+    let status = if liveness.lane.state == "terminated" {
+        CoordinationRuntimeStatus::Stopped
+    } else {
+        harness_process_status(&liveness.harness)
+    };
+    Ok(CoordinationRuntimeEvidence {
+        identity_digest: coordination::digest_bytes(&bytes),
+        identity,
+        status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn liveness_json(launch_id: &str, pid: i32, lane: &str) -> String {
+        json!({
+            "schema_version": LIVENESS_SCHEMA,
+            "launch_id": launch_id,
+            "harness": { "pid": pid },
+            "lane": { "state": lane },
+            "updated_at": "0"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn liveness_parses_only_the_exact_versioned_shape() {
+        let valid: DshRuntimeLiveness =
+            serde_json::from_str(&liveness_json("launch-1", 4242, "open")).expect("valid sidecar");
+        assert_eq!(valid.schema_version, LIVENESS_SCHEMA);
+        assert_eq!(valid.launch_id, "launch-1");
+        assert_eq!(valid.harness.pid, 4242);
+        assert_eq!(valid.lane.state, "open");
+
+        let unknown_field = serde_json::from_str::<DshRuntimeLiveness>(
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": { "pid": 4242 },
+                "lane": { "state": "open" },
+                "surprise": true
+            })
+            .to_string(),
+        );
+        assert!(unknown_field.is_err(), "unknown fields are rejected");
+
+        let unknown_harness_field = serde_json::from_str::<DshRuntimeLiveness>(
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": { "pid": 4242, "argv": ["node"] },
+                "lane": { "state": "open" }
+            })
+            .to_string(),
+        );
+        assert!(
+            unknown_harness_field.is_err(),
+            "nested unknown fields are rejected"
+        );
+    }
+
+    #[test]
+    fn harness_status_distinguishes_live_dead_and_recycled_processes() {
+        let live = DshHarnessIdentity {
+            pid: std::process::id() as i32,
+            start_time: None,
+        };
+        assert_eq!(
+            harness_process_status(&live),
+            CoordinationRuntimeStatus::Running
+        );
+
+        #[cfg(target_os = "linux")]
+        {
+            let pinned = DshHarnessIdentity {
+                pid: std::process::id() as i32,
+                start_time: linux_process_start_time(std::process::id() as i32),
+            };
+            assert!(pinned.start_time.is_some(), "own start time is readable");
+            assert_eq!(
+                harness_process_status(&pinned),
+                CoordinationRuntimeStatus::Running
+            );
+            let recycled = DshHarnessIdentity {
+                pid: std::process::id() as i32,
+                start_time: Some(pinned.start_time.expect("pinned start time") + 1),
+            };
+            assert_eq!(
+                harness_process_status(&recycled),
+                CoordinationRuntimeStatus::Stopped,
+                "a start-time mismatch proves pid reuse"
+            );
+        }
+    }
+}

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -289,12 +289,26 @@ pub(crate) fn harness_process_status(identity: &DshHarnessIdentity) -> Coordinat
         // is gone and the pid was recycled.
         (Some(expected), Some(actual)) if expected != actual => CoordinationRuntimeStatus::Stopped,
         (Some(_), Some(_)) => CoordinationRuntimeStatus::Running,
-        // Pinned but unreadable, or never pinned: a live pid alone cannot prove
-        // this incarnation, so liveness stays undecided rather than vouching
-        // for a possibly recycled pid.
-        _ => CoordinationRuntimeStatus::Unknown,
+        // Where a starttime source exists, a live pid without a verified pin
+        // cannot prove this incarnation, so liveness stays undecided rather
+        // than vouching for a possibly recycled pid.
+        _ if INCARNATION_PIN_AVAILABLE => CoordinationRuntimeStatus::Unknown,
+        // On platforms with no starttime source the pid signal is the only
+        // liveness evidence that exists; treating it as undecided would make
+        // every lane permanently unterminalizable. Pid reuse therefore remains
+        // an accepted residual risk there, exactly as it is for the tmux
+        // process-group probe on the same platforms.
+        _ => CoordinationRuntimeStatus::Running,
     }
 }
+
+/// Whether this platform can pin a process incarnation by starttime. When it
+/// can, a liveness claim without a verified pin is undecided rather than live.
+#[cfg(target_os = "linux")]
+const INCARNATION_PIN_AVAILABLE: bool = true;
+
+#[cfg(not(target_os = "linux"))]
+const INCARNATION_PIN_AVAILABLE: bool = false;
 
 #[cfg(target_os = "linux")]
 fn linux_process_start_time(pid: i32) -> Option<u64> {
@@ -360,10 +374,10 @@ pub(crate) fn external_lane_disposition(record: &SessionRecord) -> ExternalLaneD
                 // the pinned harness identity — a still-running harness means
                 // the assertion is unproven, not proven.
                 return match harness {
-                    CoordinationRuntimeStatus::Running => {
-                        ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
-                    }
-                    _ => ExternalLaneDisposition::ProvenStopped,
+                    // Only a harness proven gone corroborates the assertion;
+                    // a live or undecidable harness leaves it unproven.
+                    CoordinationRuntimeStatus::Stopped => ExternalLaneDisposition::ProvenStopped,
+                    _ => ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness),
                 };
             }
             match harness {
@@ -537,8 +551,12 @@ mod tests {
         };
         assert_eq!(
             harness_process_status(&unpinned),
-            CoordinationRuntimeStatus::Unknown,
-            "an unpinned pid never vouches for a live harness"
+            if INCARNATION_PIN_AVAILABLE {
+                CoordinationRuntimeStatus::Unknown
+            } else {
+                CoordinationRuntimeStatus::Running
+            },
+            "an unpinned pid is undecided wherever a starttime pin exists"
         );
 
         #[cfg(target_os = "linux")]
@@ -701,17 +719,10 @@ mod tests {
             .to_string(),
             0o600,
         );
-        let terminated = external_lane_disposition(&record);
-        #[cfg(target_os = "linux")]
         assert_eq!(
-            terminated,
+            external_lane_disposition(&record),
             ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness),
-            "a live harness leaves plugin-asserted termination unproven"
-        );
-        #[cfg(not(target_os = "linux"))]
-        assert_eq!(
-            terminated,
-            ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
+            "only a harness proven gone corroborates plugin-asserted termination"
         );
     }
 

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -9,6 +9,7 @@
 
 use std::fs;
 use std::io::Read;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -153,6 +154,25 @@ pub(crate) fn create_external_worker_record(
     Ok(created.record.clone())
 }
 
+/// Converge a record whose liveness-path key was lost between the record write
+/// and the extra-key write (a crash in that window). The path is derivable, so
+/// a replay repairs it instead of failing permanently.
+pub(crate) fn ensure_recorded_liveness_path(
+    context: &CliContext,
+    record: SessionRecord,
+) -> Result<SessionRecord, CliError> {
+    if !is_external_record(&record) || recorded_liveness_path(&record).is_some() {
+        return Ok(record);
+    }
+    let expected = json!(crate::display_path(&liveness_path(context, &record.id)));
+    crate::mutate_session_record(context, &record.id, |current| {
+        current
+            .extra
+            .insert(LIVENESS_PATH_KEY.to_string(), expected.clone());
+        Ok(current.clone())
+    })
+}
+
 pub(crate) fn is_external_record(record: &SessionRecord) -> bool {
     record
         .runtime
@@ -165,11 +185,20 @@ pub(crate) fn liveness_path(context: &CliContext, session_id: &str) -> PathBuf {
 }
 
 /// The record-declared sidecar path, or `None` when the record does not carry
-/// a usable absolute path (treated as invalid evidence by callers).
+/// a usable absolute path (treated as invalid evidence by callers). The path
+/// must also be the exact conventional file inside the record's own session
+/// directory: a record-supplied path pointing anywhere else is not evidence
+/// about this lane.
 fn recorded_liveness_path(record: &SessionRecord) -> Option<PathBuf> {
     let path = record.extra.get(LIVENESS_PATH_KEY)?.as_str()?;
     let path = Path::new(path);
-    path.is_absolute().then(|| path.to_path_buf())
+    if !path.is_absolute() || path.file_name()? != LIVENESS_FILE {
+        return None;
+    }
+    if path.parent()?.file_name()? != record.id.as_str() {
+        return None;
+    }
+    Some(path.to_path_buf())
 }
 
 /// Typed outcome of reading the sidecar against a specific session record.
@@ -188,13 +217,31 @@ pub(crate) fn read_liveness(record: &SessionRecord) -> LivenessEvidence {
     let Some(path) = recorded_liveness_path(record) else {
         return LivenessEvidence::Invalid;
     };
-    let file = match fs::File::open(&path) {
+    // Evidence that gates destructive operations is opened with the same trust
+    // bar as the coordination files beside it: never follow a symlink, and
+    // accept only an owner-only, single-link regular file.
+    let file = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(&path)
+    {
         Ok(file) => file,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return LivenessEvidence::Missing;
         }
         Err(_) => return LivenessEvidence::Invalid,
     };
+    let Ok(metadata) = file.metadata() else {
+        return LivenessEvidence::Invalid;
+    };
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.nlink() != 1
+        || metadata.permissions().mode() & 0o077 != 0
+        || metadata.len() > MAX_LIVENESS_BYTES
+    {
+        return LivenessEvidence::Invalid;
+    }
     let mut bytes = Vec::new();
     if file
         .take(MAX_LIVENESS_BYTES + 1)
@@ -229,16 +276,23 @@ pub(crate) fn read_liveness(record: &SessionRecord) -> LivenessEvidence {
 pub(crate) fn harness_process_status(identity: &DshHarnessIdentity) -> CoordinationRuntimeStatus {
     let alive = unsafe { libc::kill(identity.pid, 0) };
     if alive != 0 {
-        return match std::io::Error::last_os_error().raw_os_error() {
-            Some(libc::ESRCH) => CoordinationRuntimeStatus::Stopped,
-            Some(libc::EPERM) => CoordinationRuntimeStatus::Running,
-            _ => CoordinationRuntimeStatus::Unknown,
-        };
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => return CoordinationRuntimeStatus::Stopped,
+            // EPERM proves some process holds the pid but says nothing about
+            // which incarnation, so it still needs the starttime pin below.
+            Some(libc::EPERM) => {}
+            _ => return CoordinationRuntimeStatus::Unknown,
+        }
     }
     match (identity.start_time, linux_process_start_time(identity.pid)) {
+        // A different starttime on the same pid proves the pinned incarnation
+        // is gone and the pid was recycled.
         (Some(expected), Some(actual)) if expected != actual => CoordinationRuntimeStatus::Stopped,
-        (Some(_), None) => CoordinationRuntimeStatus::Unknown,
-        _ => CoordinationRuntimeStatus::Running,
+        (Some(_), Some(_)) => CoordinationRuntimeStatus::Running,
+        // Pinned but unreadable, or never pinned: a live pid alone cannot prove
+        // this incarnation, so liveness stays undecided rather than vouching
+        // for a possibly recycled pid.
+        _ => CoordinationRuntimeStatus::Unknown,
     }
 }
 
@@ -256,23 +310,83 @@ fn linux_process_start_time(_pid: i32) -> Option<u64> {
     None
 }
 
-/// `session_status` for external dsh records: `missing` when nothing is
-/// proven for this launch, `stopped` when the lane is terminated or the
-/// harness process is proven gone, `running` while the lane is open under a
-/// live harness (idle lanes stay `running`; cold resume is always available).
-pub(crate) fn external_session_status(record: &SessionRecord) -> String {
-    match read_liveness(record) {
-        LivenessEvidence::Missing | LivenessEvidence::Invalid => "missing".to_string(),
-        LivenessEvidence::Present(liveness) => {
-            if liveness.lane.state == "terminated" {
-                return "stopped".to_string();
-            }
-            match harness_process_status(&liveness.harness) {
-                CoordinationRuntimeStatus::Running => "running".to_string(),
-                CoordinationRuntimeStatus::Stopped => "stopped".to_string(),
-                CoordinationRuntimeStatus::Unknown => "missing".to_string(),
+/// Why a lane's liveness could not be proven. Destructive callers report the
+/// reason instead of treating unproven liveness as absence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum UnprovenReason {
+    /// A sidecar exists but is unreadable, malformed, oversized, or bound to a
+    /// different launch than this record's.
+    InvalidEvidence,
+    /// The sidecar is valid but the pinned harness process state cannot be
+    /// decided (permission, unreadable `/proc`, or a missing starttime pin).
+    UndecidableHarness,
+}
+
+impl UnprovenReason {
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            Self::InvalidEvidence => "external dsh runtime liveness evidence is invalid",
+            Self::UndecidableHarness => {
+                "external dsh runtime liveness could not be decided for the pinned harness"
             }
         }
+    }
+}
+
+/// The four lane states a destructive or diagnostic caller must distinguish.
+/// Collapsing `Unproven` into "absent" would let a corrupted sidecar authorize
+/// destroying the record of a running lane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ExternalLaneDisposition {
+    /// No sidecar exists: the external runtime never attached to this launch.
+    NeverAttached,
+    Running,
+    ProvenStopped,
+    Unproven(UnprovenReason),
+}
+
+pub(crate) fn external_lane_disposition(record: &SessionRecord) -> ExternalLaneDisposition {
+    match read_liveness(record) {
+        LivenessEvidence::Missing => ExternalLaneDisposition::NeverAttached,
+        LivenessEvidence::Invalid => {
+            ExternalLaneDisposition::Unproven(UnprovenReason::InvalidEvidence)
+        }
+        LivenessEvidence::Present(liveness) => {
+            let harness = harness_process_status(&liveness.harness);
+            if liveness.lane.state == "terminated" {
+                // Plugin-asserted termination, deliberately weaker than the
+                // tmux kernel-backed proof: the sidecar lives in the same-uid
+                // state dir a lane's own worker can reach. Corroborate it with
+                // the pinned harness identity — a still-running harness means
+                // the assertion is unproven, not proven.
+                return match harness {
+                    CoordinationRuntimeStatus::Running => {
+                        ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
+                    }
+                    _ => ExternalLaneDisposition::ProvenStopped,
+                };
+            }
+            match harness {
+                CoordinationRuntimeStatus::Running => ExternalLaneDisposition::Running,
+                CoordinationRuntimeStatus::Stopped => ExternalLaneDisposition::ProvenStopped,
+                CoordinationRuntimeStatus::Unknown => {
+                    ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
+                }
+            }
+        }
+    }
+}
+
+/// `session_status` for external dsh records: `missing` when the runtime never
+/// attached, `stopped` when termination is proven, `running` while the lane is
+/// open under a live harness (idle lanes stay `running`; cold resume is always
+/// available), and `unknown` when liveness cannot be proven.
+pub(crate) fn external_session_status(record: &SessionRecord) -> String {
+    match external_lane_disposition(record) {
+        ExternalLaneDisposition::NeverAttached => "missing".to_string(),
+        ExternalLaneDisposition::Running => "running".to_string(),
+        ExternalLaneDisposition::ProvenStopped => "stopped".to_string(),
+        ExternalLaneDisposition::Unproven(_) => "unknown".to_string(),
     }
 }
 
@@ -415,13 +529,16 @@ mod tests {
 
     #[test]
     fn harness_status_distinguishes_live_dead_and_recycled_processes() {
-        let live = DshHarnessIdentity {
+        // Unpinned identity: a live pid alone cannot prove which incarnation
+        // holds it, so liveness stays undecided.
+        let unpinned = DshHarnessIdentity {
             pid: std::process::id() as i32,
             start_time: None,
         };
         assert_eq!(
-            harness_process_status(&live),
-            CoordinationRuntimeStatus::Running
+            harness_process_status(&unpinned),
+            CoordinationRuntimeStatus::Unknown,
+            "an unpinned pid never vouches for a live harness"
         );
 
         #[cfg(target_os = "linux")]
@@ -445,5 +562,243 @@ mod tests {
                 "a start-time mismatch proves pid reuse"
             );
         }
+    }
+
+    /// Build an external record whose sidecar path points into a scratch dir.
+    fn external_record(root: &Path, launch_id: &str) -> SessionRecord {
+        let session_dir = root.join("sessions").join("worker-dsh");
+        fs::create_dir_all(&session_dir).expect("session dir");
+        let mut record: SessionRecord = serde_json::from_value(json!({
+            "schema_version": "agent-session.session.v1",
+            "id": "worker-dsh",
+            "agent": "dsh",
+            "mode": "external",
+            "title": null,
+            "cwd": "/lane/worktree",
+            "tmux_session": "",
+            "prompt_file": null,
+            "log_file": null,
+            "created_at": "0",
+            "updated_at": "0",
+            "runtime": {
+                "kind": DSH_RUNTIME_KIND,
+                "tmux_session": "",
+                "generation": 1,
+                "started_at": "0",
+                "launch_id": launch_id
+            }
+        }))
+        .expect("external record");
+        record.extra.insert(
+            LIVENESS_PATH_KEY.to_string(),
+            json!(session_dir.join(LIVENESS_FILE).to_string_lossy()),
+        );
+        record
+    }
+
+    fn write_sidecar(record: &SessionRecord, body: &str, mode: u32) {
+        let path = recorded_liveness_path(record).expect("recorded path");
+        fs::write(&path, body).expect("write sidecar");
+        fs::set_permissions(&path, fs::Permissions::from_mode(mode)).expect("mode");
+    }
+
+    fn pinned_harness() -> serde_json::Value {
+        let pid = std::process::id() as i32;
+        match linux_process_start_time(pid) {
+            Some(start_time) => json!({ "pid": pid, "start_time": start_time }),
+            None => json!({ "pid": pid }),
+        }
+    }
+
+    #[test]
+    fn lane_disposition_requires_positive_evidence() {
+        let scratch = tempfile::TempDir::new().expect("tempdir");
+        let record = external_record(scratch.path(), "launch-1");
+
+        // No sidecar: the runtime never attached.
+        assert_eq!(
+            external_lane_disposition(&record),
+            ExternalLaneDisposition::NeverAttached
+        );
+        assert_eq!(external_session_status(&record), "missing");
+
+        // Malformed, schema-mismatched, and launch-mismatched sidecars are all
+        // unproven, never a quiet absence.
+        for body in [
+            "not json".to_string(),
+            json!({
+                "schema_version": "main-agent.dsh-runtime-liveness.v999",
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "open" }
+            })
+            .to_string(),
+            json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-2",
+                "harness": pinned_harness(),
+                "lane": { "state": "open" }
+            })
+            .to_string(),
+        ] {
+            write_sidecar(&record, &body, 0o600);
+            assert_eq!(
+                external_lane_disposition(&record),
+                ExternalLaneDisposition::Unproven(UnprovenReason::InvalidEvidence),
+                "invalid evidence must stay unproven: {body}"
+            );
+            assert_eq!(external_session_status(&record), "unknown");
+            assert!(external_runtime_evidence(&record).is_err());
+            assert!(external_turn_state(&record).is_none());
+        }
+
+        // A group-readable sidecar fails the owner-only trust bar.
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "open" }
+            })
+            .to_string(),
+            0o644,
+        );
+        assert_eq!(
+            external_lane_disposition(&record),
+            ExternalLaneDisposition::Unproven(UnprovenReason::InvalidEvidence),
+            "a group-readable sidecar is not trusted evidence"
+        );
+
+        // A dead pid proves the lane stopped.
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": { "pid": i32::MAX, "start_time": 1_u64 },
+                "lane": { "state": "open" }
+            })
+            .to_string(),
+            0o600,
+        );
+        assert_eq!(
+            external_lane_disposition(&record),
+            ExternalLaneDisposition::ProvenStopped
+        );
+        assert_eq!(external_session_status(&record), "stopped");
+
+        // A terminated lane whose harness is still live is an uncorroborated
+        // plugin assertion, not a proof.
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "terminated" }
+            })
+            .to_string(),
+            0o600,
+        );
+        let terminated = external_lane_disposition(&record);
+        #[cfg(target_os = "linux")]
+        assert_eq!(
+            terminated,
+            ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness),
+            "a live harness leaves plugin-asserted termination unproven"
+        );
+        #[cfg(not(target_os = "linux"))]
+        assert_eq!(
+            terminated,
+            ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
+        );
+    }
+
+    #[test]
+    fn recorded_liveness_path_is_confined_to_the_record_session_dir() {
+        let scratch = tempfile::TempDir::new().expect("tempdir");
+        let mut record = external_record(scratch.path(), "launch-1");
+        assert!(recorded_liveness_path(&record).is_some());
+
+        for hostile in [
+            scratch.path().join("elsewhere").join(LIVENESS_FILE),
+            scratch
+                .path()
+                .join("sessions")
+                .join("worker-dsh")
+                .join("other.json"),
+            PathBuf::from("relative/dsh-runtime-liveness.json"),
+        ] {
+            record.extra.insert(
+                LIVENESS_PATH_KEY.to_string(),
+                json!(hostile.to_string_lossy()),
+            );
+            assert!(
+                recorded_liveness_path(&record).is_none(),
+                "path outside the record's own session dir is not evidence: {hostile:?}"
+            );
+            assert_eq!(
+                external_lane_disposition(&record),
+                ExternalLaneDisposition::Unproven(UnprovenReason::InvalidEvidence)
+            );
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn turn_evidence_yields_authoritative_runtime_activity() {
+        let scratch = tempfile::TempDir::new().expect("tempdir");
+        let record = external_record(scratch.path(), "launch-1");
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "open" },
+                "turn": {
+                    "phase": "working",
+                    "phase_changed_at": "100",
+                    "current_turn": { "started_at": "100", "last_progress_at": "110" },
+                    "last_turn": { "completed_at": "90", "outcome": "completed" }
+                }
+            })
+            .to_string(),
+            0o600,
+        );
+        let turn = external_turn_state(&record).expect("turn evidence is present");
+        assert_eq!(turn.phase, crate::activity::TurnPhase::Working);
+        assert_eq!(turn.source.kind, crate::activity::SourceKind::Runtime);
+        assert_eq!(turn.source.provider.as_deref(), Some("dsh"));
+        assert_eq!(
+            turn.source.confidence,
+            crate::activity::Confidence::Authoritative
+        );
+        assert_eq!(
+            turn.current_turn
+                .as_ref()
+                .and_then(|current| current.last_progress_at.as_deref()),
+            Some("110")
+        );
+        assert_eq!(
+            turn.last_turn.as_ref().map(|last| last.outcome.as_str()),
+            Some("completed")
+        );
+
+        // An unknown phase is not evidence.
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "open" },
+                "turn": { "phase": "surprised", "phase_changed_at": "100" }
+            })
+            .to_string(),
+            0o600,
+        );
+        assert!(external_turn_state(&record).is_none());
     }
 }

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -8750,6 +8750,21 @@ fn delete_tmux_buffer(tmux_bin: &Path, buffer_name: &str) {
     let _ = run_status_with_timeout(command, "tmux delete-buffer", PANE_INPUT_COMMAND_TIMEOUT);
 }
 
+/// External runtimes own no tmux pane, so input delivery must refuse by
+/// runtime kind rather than relying on the minted tmux name not existing.
+fn ensure_not_external_runtime(record: &SessionRecord, surface: &str) -> Result<(), CliError> {
+    if dsh_external::is_external_record(record) {
+        return Err(CliError::usage(
+            "dsh-runtime-plugin-owned",
+            format!(
+                "{surface} is unavailable for dsh sessions: the external dsh-runtime-kit runtime owns worker input"
+            ),
+            Some(json!({ "id": record.id.clone() })),
+        ));
+    }
+    Ok(())
+}
+
 fn send_to_session(context: &CliContext, args: cli::SendArgs) -> Result<SendResult, CliError> {
     let text = read_send_text(&args.text, args.text_stdin)?;
     if text.is_none() && args.keys.is_empty() {
@@ -8760,6 +8775,7 @@ fn send_to_session(context: &CliContext, args: cli::SendArgs) -> Result<SendResu
         ));
     }
     let observed = load_session_record(context, &args.id)?;
+    ensure_not_external_runtime(&observed, "send")?;
     let tmux_bin = resolve_tmux_bin(args.tmux_bin.as_deref());
     let record_lock = acquire_session_record_lock(context, &observed.id)?;
     let mut manual_input = ManualInputSection::new(record_lock);
@@ -11825,6 +11841,12 @@ fn last_terminal_activity_at(
     if status != "running" {
         return None;
     }
+    // External runtimes own no tmux session, so probing one is guaranteed to
+    // fail — and this probe has no timeout, so a wedged tmux server must never
+    // block a path that by design never touches tmux.
+    if dsh_external::is_external_record(record) {
+        return None;
+    }
     tmux_window_activity_at(tmux_bin, &record.tmux_session)
 }
 
@@ -11849,6 +11871,13 @@ fn session_list_runtime_snapshot(
     tmux_snapshots: Option<&TmuxSessionSnapshots>,
     record: &SessionRecord,
 ) -> (String, Option<String>) {
+    // A batched tmux snapshot can never see an external runtime's lane: the
+    // record's tmux name is minted but never created. Dispatch first so list
+    // projections agree with single-record status instead of reporting every
+    // live dsh lane as stopped.
+    if dsh_external::is_external_record(record) {
+        return (dsh_external::external_session_status(record), None);
+    }
     match tmux_snapshots {
         Some(snapshots) => match snapshots.sessions.get(&record.tmux_session) {
             Some(snapshot) => (
@@ -12130,16 +12159,29 @@ fn delete_session_locked_with_timeouts(
     verify_timeout: Duration,
 ) -> Result<DeleteResult, CliError> {
     if dsh_external::is_external_record(&record) {
-        // There is no tmux runtime to terminate. Deleting the durable record
-        // is admitted only once nothing proves the lane may still be running:
-        // a terminated or proven-stopped lane deletes; a live lane must be
-        // interrupted by the plugin first.
-        if dsh_external::external_session_status(&record) == "running" {
-            return Err(session_termination_error(
-                &record,
-                SessionTerminationFailure::StillRunning,
-                SessionTerminationOperation::Delete,
-            ));
+        // There is no tmux runtime to terminate, so deletion is admitted only
+        // on positive evidence: the external runtime never attached, or the
+        // lane's stop is proven. A running lane must be interrupted by the
+        // plugin first, and unproven liveness fails closed the same way an
+        // unavailable tmux runtime identity does — a corrupted sidecar must
+        // never authorize destroying a live lane's record.
+        match dsh_external::external_lane_disposition(&record) {
+            dsh_external::ExternalLaneDisposition::Running => {
+                return Err(session_termination_error(
+                    &record,
+                    SessionTerminationFailure::StillRunning,
+                    SessionTerminationOperation::Delete,
+                ));
+            }
+            dsh_external::ExternalLaneDisposition::Unproven(reason) => {
+                return Err(CliError::runtime(
+                    "coordination-runtime-unverified",
+                    reason.message(),
+                    Some(json!({ "id": record.id.clone() })),
+                ));
+            }
+            dsh_external::ExternalLaneDisposition::NeverAttached
+            | dsh_external::ExternalLaneDisposition::ProvenStopped => {}
         }
         let registry_fence = SessionRegistryFence::from_record(&record);
         return finish_session_delete(context, record, session_dir, registry_fence);

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -12181,7 +12181,21 @@ fn delete_session_locked_with_timeouts(
                 ));
             }
             dsh_external::ExternalLaneDisposition::NeverAttached
-            | dsh_external::ExternalLaneDisposition::ProvenStopped => {}
+            | dsh_external::ExternalLaneDisposition::ProvenStopped => {
+                // Sidecar evidence alone is forgeable by the lane's own worker,
+                // and an absent sidecar asserts nothing at all, so destroying
+                // durable state additionally requires the lane's broker
+                // heartbeat — maintained by a separate plugin-owned process —
+                // to be gone.
+                let incarnation = coordination::incarnation(&record)?;
+                if !dsh_external::external_lane_terminal_is_proven(context, &record, &incarnation) {
+                    return Err(CliError::runtime(
+                        "coordination-runtime-unverified",
+                        "external dsh lane termination is not corroborated by its coordination broker",
+                        Some(json!({ "id": record.id.clone() })),
+                    ));
+                }
+            }
         }
         let registry_fence = SessionRegistryFence::from_record(&record);
         return finish_session_delete(context, record, session_dir, registry_fence);

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -6,6 +6,7 @@ mod codex_app_server;
 pub mod completion;
 mod coordination;
 mod diagnose;
+mod dsh_external;
 mod main_agent;
 mod maintenance;
 mod orchestration;
@@ -1850,6 +1851,15 @@ fn start_session_with_create_guard(
     create_guard: Option<&mut dyn FnMut() -> Result<(), CliError>>,
     mut lifecycle_guards: StartLifecycleGuards<'_>,
 ) -> Result<StartView, CliError> {
+    if args.agent == AgentKind::Dsh {
+        // Refused before any durable side effect: dsh session records are
+        // created only by `main-agent worker start`'s external-runtime arm.
+        return Err(CliError::usage(
+            "unsupported-start-agent",
+            "dsh sessions are launched by the external dsh-runtime-kit runtime; use main-agent worker start with launch.agent \"dsh\"",
+            None,
+        ));
+    }
     validate_agent_args(args.agent, &args.agent_args)?;
     let cwd = resolve_cwd(args.cwd.as_deref())?;
     let prompt = read_prompt(&args.prompt, args.prompt_file.as_deref(), args.prompt_stdin)?;
@@ -2773,7 +2783,11 @@ fn create_record_with_guard(
         updated_at: iso.clone(),
         provider_resume: request.provider_resume,
         runtime: Some(RuntimeInfo {
-            kind: "tmux".to_string(),
+            kind: if request.agent == AgentKind::Dsh {
+                dsh_external::DSH_RUNTIME_KIND.to_string()
+            } else {
+                "tmux".to_string()
+            },
             tmux_session: tmux_session.clone(),
             generation: 1,
             started_at: now.timestamp().to_string(),
@@ -2927,6 +2941,7 @@ fn initial_provider_resume_plan(agent: AgentKind, _cwd: &Path) -> InitialProvide
         }
         AgentKind::Codex => InitialProviderPlan::default(),
         AgentKind::Hermes => InitialProviderPlan::default(),
+        AgentKind::Dsh => InitialProviderPlan::default(),
     }
 }
 
@@ -3037,6 +3052,13 @@ fn resolve_provider_resume_source(
             return Err(CliError::usage(
                 "unsupported-provider-resume-agent",
                 "hermes sessions cannot be imported by provider resume id",
+                Some(json!({ "agent": agent.as_str() })),
+            ));
+        }
+        AgentKind::Dsh => {
+            return Err(CliError::usage(
+                "unsupported-provider-resume-agent",
+                "dsh sessions are owned by the external dsh-runtime-kit runtime and cannot be imported by provider resume id",
                 Some(json!({ "agent": agent.as_str() })),
             ));
         }
@@ -3162,6 +3184,7 @@ pub(crate) fn resolve_provider_transcript_path_from_roots(
             budget.truncated
         }
         AgentKind::Hermes => return None,
+        AgentKind::Dsh => return None,
     };
     if truncated || matches.len() != 1 {
         return None;
@@ -7953,6 +7976,13 @@ fn start_interactive_tmux(
         AgentKind::Hermes => {
             command.arg("chat");
         }
+        AgentKind::Dsh => {
+            return Err(CliError::usage(
+                "unsupported-start-agent",
+                "dsh sessions are launched by the external dsh-runtime-kit runtime, never by tmux",
+                None,
+            ));
+        }
     }
     command.args(agent_args);
     run_tmux_new_session(command, tmux_bin, record)
@@ -7991,6 +8021,13 @@ fn start_run_tmux(
             return Err(CliError::usage(
                 "unsupported-run-agent",
                 "hermes does not support one-shot run mode; use start --agent hermes",
+                None,
+            ));
+        }
+        AgentKind::Dsh => {
+            return Err(CliError::usage(
+                "unsupported-run-agent",
+                "dsh sessions are launched by the external dsh-runtime-kit runtime, never by tmux",
                 None,
             ));
         }
@@ -8252,7 +8289,7 @@ fn capture_provider_resume_after_launch(
 ) -> Option<ProviderResume> {
     match agent {
         AgentKind::Codex => capture_codex_resume(record, launch_started_at),
-        AgentKind::Claude | AgentKind::Hermes => None,
+        AgentKind::Claude | AgentKind::Hermes | AgentKind::Dsh => None,
     }
 }
 
@@ -10152,6 +10189,7 @@ fn add_runtime_tmux_environment(
             AgentKind::Codex => Some("CODEX_HOME"),
             AgentKind::Claude => Some("CLAUDE_CONFIG_DIR"),
             AgentKind::Hermes => None,
+            AgentKind::Dsh => None,
         };
         if let Some(env_key) = env_key {
             let mut assignment = OsString::from(format!("{env_key}="));
@@ -12091,6 +12129,21 @@ fn delete_session_locked_with_timeouts(
     kill_timeout: Duration,
     verify_timeout: Duration,
 ) -> Result<DeleteResult, CliError> {
+    if dsh_external::is_external_record(&record) {
+        // There is no tmux runtime to terminate. Deleting the durable record
+        // is admitted only once nothing proves the lane may still be running:
+        // a terminated or proven-stopped lane deletes; a live lane must be
+        // interrupted by the plugin first.
+        if dsh_external::external_session_status(&record) == "running" {
+            return Err(session_termination_error(
+                &record,
+                SessionTerminationFailure::StillRunning,
+                SessionTerminationOperation::Delete,
+            ));
+        }
+        let registry_fence = SessionRegistryFence::from_record(&record);
+        return finish_session_delete(context, record, session_dir, registry_fence);
+    }
     let registry_fence = SessionRegistryFence::from_record(&record);
     terminate_tmux_session_with_timeouts(
         context,
@@ -12286,6 +12339,13 @@ pub(crate) fn stop_session_runtime_locked(
     record: &mut SessionRecord,
     tmux_bin: &Path,
 ) -> Result<(), CliError> {
+    if dsh_external::is_external_record(record) {
+        return Err(CliError::usage(
+            "dsh-runtime-plugin-owned",
+            "dsh worker runtimes are owned by the external dsh-runtime-kit plugin; interrupt the lane there, then reconcile once the liveness sidecar proves the lane stopped",
+            Some(json!({ "id": record.id.clone() })),
+        ));
+    }
     terminate_tmux_session_with_timeouts(
         context,
         record,
@@ -13730,6 +13790,9 @@ pub(crate) struct CoordinationRuntimeEvidence {
 pub(crate) fn coordination_runtime_evidence(
     record: &SessionRecord,
 ) -> Result<CoordinationRuntimeEvidence, CliError> {
+    if dsh_external::is_external_record(record) {
+        return dsh_external::external_runtime_evidence(record);
+    }
     let identity = persisted_tmux_runtime_identity(record)
         .map_err(|_| {
             CliError::runtime(
@@ -15715,6 +15778,9 @@ fn managed_tmux_pane_target(tmux_session: &str) -> String {
 }
 
 fn session_status(tmux_bin: &Path, record: &SessionRecord) -> String {
+    if dsh_external::is_external_record(record) {
+        return dsh_external::external_session_status(record);
+    }
     live_status(tmux_bin, &record.tmux_session)
 }
 
@@ -15811,6 +15877,7 @@ pub(crate) fn canonical_provider_resume_args(
         ]),
         AgentKind::Claude => Some(vec!["--resume".to_string(), session_id.to_string()]),
         AgentKind::Hermes => None,
+        AgentKind::Dsh => None,
     }
 }
 
@@ -15825,6 +15892,7 @@ fn validate_stored_agent_args(record: &SessionRecord, agent: AgentKind) -> Resul
             .iter()
             .find_map(|arg| reserved_claude_resume_arg(arg)),
         AgentKind::Hermes => None,
+        AgentKind::Dsh => None,
     };
     if let Some(flag) = flag {
         return Err(CliError::data(
@@ -16280,6 +16348,9 @@ fn resolve_agent_bin(agent: AgentKind, explicit: Option<&Path>) -> PathBuf {
         AgentKind::Codex => "AGENT_SESSION_CODEX_BIN",
         AgentKind::Claude => "AGENT_SESSION_CLAUDE_BIN",
         AgentKind::Hermes => "AGENT_SESSION_HERMES_BIN",
+        // Never launched by this crate; the resolved name is only ever used
+        // in typed-refusal diagnostics.
+        AgentKind::Dsh => "AGENT_SESSION_DSH_BIN",
     };
     non_empty_env(env_key)
         .map(PathBuf::from)

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -173,6 +173,7 @@ enum SelfCommand {
 enum RuntimeHookProduct {
     Codex,
     Claude,
+    Dsh,
 }
 
 impl RuntimeHookProduct {
@@ -180,6 +181,7 @@ impl RuntimeHookProduct {
         match self {
             Self::Codex => "codex",
             Self::Claude => "claude",
+            Self::Dsh => "dsh",
         }
     }
 }
@@ -1038,6 +1040,9 @@ fn run_command(context: &CliContext, command: &MainAgentCommand) -> Result<Value
 }
 
 fn main_agent_capabilities(provider: RuntimeHookProduct) -> Value {
+    if provider == RuntimeHookProduct::Dsh {
+        return dsh_capabilities_envelope(dsh_external_runtime_capability());
+    }
     let runtime_hook_checkpoint_write = runtime_hook_checkpoint_capability(provider);
     json!({
         "schema_version": "main-agent.capabilities.v1",
@@ -1048,6 +1053,59 @@ fn main_agent_capabilities(provider: RuntimeHookProduct) -> Value {
             "runtime_hook_checkpoint_write": runtime_hook_checkpoint_write,
             "run_wide_closeout": "main-agent.run-wide-closeout.v1",
         }
+    })
+}
+
+fn dsh_capabilities_envelope(external_runtime: Option<&'static str>) -> Value {
+    json!({
+        "schema_version": "main-agent.capabilities.v1",
+        "provider": RuntimeHookProduct::Dsh.as_str(),
+        "compatible": external_runtime.is_some(),
+        "capabilities": {
+            "runtime_checkpoint_file": "main-agent.runtime-checkpoint-file.v1",
+            // DSH policy v1 admits only native allow/block decisions; the
+            // store fences every checkpoint, so no hook admission layer
+            // exists or is claimed for this provider.
+            "runtime_hook_checkpoint_write": Value::Null,
+            "run_wide_closeout": "main-agent.run-wide-closeout.v1",
+            "external_runtime": external_runtime,
+        }
+    })
+}
+
+fn dsh_external_runtime_capability() -> Option<&'static str> {
+    let executable = env::current_exe().ok()?;
+    let agent_hook = executable.parent()?.join("agent-hook");
+    let metadata = fs::metadata(&agent_hook).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let mut command = Command::new(&agent_hook);
+    command.args(["doctor", "--product", "dsh", "--format", "json"]);
+    let output =
+        run_output_with_timeout_and_cap(command, Duration::from_secs(2), 64 * 1024).ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let doctor: Value = serde_json::from_slice(&output.stdout).ok()?;
+    if !dsh_doctor_dispatch_supported(&doctor) {
+        return None;
+    }
+    Some("main-agent.external-runtime.v1")
+}
+
+fn dsh_doctor_dispatch_supported(doctor: &Value) -> bool {
+    if doctor["schema_version"] != "cli.agent-hook.doctor.v1" || doctor["ok"] != true {
+        return false;
+    }
+    let Some(records) = doctor["data"].as_array() else {
+        return false;
+    };
+    records.iter().any(|record| {
+        record["schema_version"] == "agent-hook.doctor.v1"
+            && record["product"] == "dsh"
+            && record["dispatch_supported"] == true
+            && record["registration_owner"] == "dsh-runtime-kit"
     })
 }
 
@@ -1094,6 +1152,9 @@ fn runtime_hook_supports_checkpoint(inventory: &Value, provider: RuntimeHookProd
     let matchers = match provider {
         RuntimeHookProduct::Codex => ["Bash", "Write|Edit|NotebookEdit|apply_patch"],
         RuntimeHookProduct::Claude => ["Bash", "Write|Edit|NotebookEdit"],
+        // DSH has no hook checkpoint-write admission; the external-runtime
+        // capability path never consults this predicate.
+        RuntimeHookProduct::Dsh => return false,
     };
     matchers.into_iter().all(|matcher| {
         rules.iter().any(|rule| {
@@ -1150,6 +1211,7 @@ fn runtime_checkpoint_handler_supports_product(provider: RuntimeHookProduct) -> 
     let handler = match provider {
         RuntimeHookProduct::Codex => codex_home.join("hooks/session-coordination-guard.py"),
         RuntimeHookProduct::Claude => home.join(".claude/hooks/session-coordination-guard.py"),
+        RuntimeHookProduct::Dsh => return false,
     };
     runtime_checkpoint_handler_supports_capability(&handler)
 }
@@ -3292,6 +3354,13 @@ fn run_worker_start_single_input(
     validate_idempotency_key(&args.idempotency_key)?;
     let await_ready = parse_await_ready(&args.await_ready)?;
     validate_assignment_input(&input)?;
+    if input.launch.agent == "dsh" && await_ready.is_some() {
+        return Err(CliError::usage(
+            "dsh-await-ready-unsupported",
+            "dsh worker start is launch-only: the external runtime delivers the prompt after this command returns; use --await-ready 0s and observe readiness with worker wait",
+            Some(json!({ "await_ready": args.await_ready })),
+        ));
+    }
     crate::ensure_provider_stop_canary_platform_supported(input.provider_stop_canary.is_some())?;
     let (record, incarnation) = authenticated_self(context)?;
     ensure_active_claim(context, &record)?;
@@ -3730,6 +3799,30 @@ fn run_worker_start_single_input(
             None,
         )
     })?;
+    if agent == AgentKind::Dsh {
+        if pending_prompt_outcome_unknown.is_some() {
+            return Err(CliError::data(
+                "assignment-start-conflict",
+                "dsh worker starts never record ambiguous prompt delivery; the persisted receipt is foreign",
+                Some(json!({ "assignment_id": assignment_id })),
+            ));
+        }
+        return finish_external_worker_start(ExternalWorkerStartRequest {
+            context,
+            args: &args,
+            launch_input: &launch_input,
+            assignment_id: &assignment_id,
+            worker_session_id: &worker_session_id,
+            record: &record,
+            incarnation: &incarnation,
+            request_digest: &request_digest,
+            legacy_request_digest: &legacy_request_digest,
+            expected_packet_digest: &expected_packet_digest,
+            worker_start_fence_key: &worker_start_fence_key,
+            main_agent_bin: &main_agent_bin,
+            batch_lane,
+        });
+    }
     let prompt = worker_start_prompt(&assignment_id, &main_agent_bin);
     let prior_compact_prompt = prior_compact_worker_start_prompt(&assignment_id, &main_agent_bin);
     let legacy_prompt = legacy_worker_start_prompt(&assignment_id, &main_agent_bin);
@@ -4921,6 +5014,321 @@ fn run_worker_start_single_input(
         );
     }
     Ok(outcome)
+}
+
+/// Scoped inputs for the dsh external-runtime worker start arm. The shared
+/// path (validation, claims, digests, replay, assignment record, packet
+/// storage) already ran; this arm replaces only the tmux launch pipeline.
+/// Contract: `docs/specs/main-agent-dsh-external-runtime-v1.md`.
+struct ExternalWorkerStartRequest<'a> {
+    context: &'a CliContext,
+    args: &'a WorkerStartArgs,
+    launch_input: &'a AssignmentInput,
+    assignment_id: &'a str,
+    worker_session_id: &'a str,
+    record: &'a SessionRecord,
+    incarnation: &'a str,
+    request_digest: &'a str,
+    legacy_request_digest: &'a str,
+    expected_packet_digest: &'a str,
+    worker_start_fence_key: &'a str,
+    main_agent_bin: &'a Path,
+    batch_lane: Option<&'a BatchLaneFence<'a>>,
+}
+
+fn finish_external_worker_start(
+    request: ExternalWorkerStartRequest<'_>,
+) -> Result<Value, CliError> {
+    let ExternalWorkerStartRequest {
+        context,
+        args,
+        launch_input,
+        assignment_id,
+        worker_session_id,
+        record,
+        incarnation,
+        request_digest,
+        legacy_request_digest,
+        expected_packet_digest,
+        worker_start_fence_key,
+        main_agent_bin,
+        batch_lane,
+    } = request;
+    let prompt = dsh_worker_start_prompt(assignment_id, main_agent_bin);
+    let replay_prompts = [prompt.as_str()];
+    let existing = match load_session_record(context, worker_session_id) {
+        Ok(worker) => Some(worker),
+        Err(error) if error.code() == "session-not-found" => None,
+        Err(error) => return Err(error),
+    };
+    let mut worker_start_fence = None;
+    let worker_record = match existing {
+        Some(worker) => {
+            ensure_worker_launch_matches(context, &worker, launch_input, &replay_prompts)?;
+            worker
+        }
+        None => {
+            let mut create_guard = || {
+                let fence = crate::coordination::claims::acquire_main_agent_worker_start_fence(
+                    context,
+                    record,
+                    incarnation,
+                    worker_start_fence_key,
+                )?;
+                let validation = (|| {
+                    let mut locked = orchestration::lock_registry(context)?;
+                    if let Some(batch_lane) = batch_lane {
+                        renew_worker_start_batch_lane_locked(&mut locked.registry, batch_lane)?;
+                    }
+                    validate_worker_start_authority_locked(
+                        &locked.registry,
+                        record,
+                        incarnation,
+                        assignment_id,
+                        worker_session_id,
+                        expected_packet_digest,
+                        &args.idempotency_key,
+                        request_digest,
+                        legacy_request_digest,
+                        &launch_input.launch.cwd,
+                        None,
+                        None,
+                        false,
+                    )?;
+                    if batch_lane.is_some() {
+                        locked.save()?;
+                    }
+                    Ok(())
+                })();
+                if let Err(error) = validation {
+                    fence.finish(context, false)?;
+                    return Err(error);
+                }
+                worker_start_fence = Some(fence);
+                Ok(())
+            };
+            let created = crate::dsh_external::create_external_worker_record(
+                context,
+                Path::new(&launch_input.launch.cwd),
+                worker_session_id,
+                &prompt,
+                launch_input.launch.coordination_mode,
+                launch_input.launch.title.as_deref(),
+                Some(&mut create_guard),
+            );
+            match created {
+                Ok(worker) => worker,
+                Err(error) => {
+                    if let Some(fence) = worker_start_fence.take() {
+                        fence.finish(context, false)?;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    };
+    let launch_id = match worker_record
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.clone())
+        .filter(|value| !value.is_empty())
+    {
+        Some(launch_id) => launch_id,
+        None => {
+            if let Some(fence) = worker_start_fence.take() {
+                fence.finish(context, false)?;
+            }
+            return Err(invalid_input("worker session incarnation is unavailable"));
+        }
+    };
+    let expected_worker = session_ref(context, &worker_record, &launch_id);
+    let attachment = (|| {
+        ensure_active_claim(context, record)?;
+        let mut locked = orchestration::lock_registry(context)?;
+        if let Some(batch_lane) = batch_lane {
+            renew_worker_start_batch_lane_after_child_side_effect_locked(
+                &mut locked.registry,
+                batch_lane,
+            )?;
+        }
+        validate_worker_start_authority_locked(
+            &locked.registry,
+            record,
+            incarnation,
+            assignment_id,
+            worker_session_id,
+            expected_packet_digest,
+            &args.idempotency_key,
+            request_digest,
+            legacy_request_digest,
+            &launch_input.launch.cwd,
+            None,
+            Some(&expected_worker),
+            false,
+        )?;
+        let current = locked
+            .registry
+            .assignments
+            .get_mut(assignment_id)
+            .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?;
+        if current.state != "starting"
+            || !((current.revision == 1 && current.worker.is_none())
+                || (current.revision == 2 && current.worker.as_ref() == Some(&expected_worker)))
+        {
+            return Err(CliError::data(
+                "assignment-start-conflict",
+                "assignment changed while the worker was starting",
+                Some(json!({ "assignment_id": assignment_id, "revision": current.revision })),
+            ));
+        }
+        if current.revision == 1 {
+            current.worker = Some(expected_worker.clone());
+            current.revision = 2;
+            current.updated_at = timestamp();
+        }
+        let outcome = json!({
+            "schema_version": "main-agent.worker-start-result.v1",
+            "assignment": public_assignment_view(current),
+            "worker": {
+                "session_id": worker_record.id,
+                "session_incarnation": launch_id,
+                "status": "external"
+            },
+            "acceptance": {
+                "state": "pending-worker-checkpoint",
+                "transport_only": true
+            },
+            "delivery": {
+                "state": "external-launch-pending",
+                "proof": "external-runtime-transfer"
+            },
+            "external_launch": external_launch_payload(
+                context,
+                &worker_record,
+                &launch_id,
+                &prompt,
+            )?,
+            "launch_observation": Value::Null,
+            "polling": worker_start_polling_evidence(None)
+        });
+        store_receipt(
+            &mut locked.registry,
+            record,
+            incarnation,
+            &args.idempotency_key,
+            "worker-start",
+            request_digest,
+            outcome.clone(),
+        )?;
+        locked.save()?;
+        Ok(outcome)
+    })();
+    match attachment {
+        Ok(outcome) => {
+            if let Some(fence) = worker_start_fence.take() {
+                fence.finish(context, true)?;
+            }
+            Ok(outcome)
+        }
+        Err(error) => {
+            if let Some(fence) = worker_start_fence.take() {
+                fence.finish(context, false)?;
+            }
+            Err(error)
+        }
+    }
+}
+
+/// The plugin-facing launch contract for one dsh lane: the byte-stable
+/// bootstrap prompt, the exact worker environment, and the broker heartbeat
+/// argv the plugin must run for the lane's lifetime.
+fn external_launch_payload(
+    context: &CliContext,
+    worker_record: &SessionRecord,
+    launch_id: &str,
+    prompt: &str,
+) -> Result<Value, CliError> {
+    let state_dir = crate::display_path(&context.state_dir);
+    let capability_file = crate::display_path(&crate::coordination::capability_path(
+        context,
+        &worker_record.id,
+        launch_id,
+    ));
+    let checkpoint_file = crate::display_path(&crate::coordination::checkpoint_path_for_state(
+        &context.state_dir,
+        &worker_record.id,
+        launch_id,
+    ));
+    let liveness_file = worker_record
+        .extra
+        .get(crate::dsh_external::LIVENESS_PATH_KEY)
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_input("external worker record has no liveness sidecar path"))?
+        .to_string();
+    let agent_session_bin = env::current_exe()
+        .ok()
+        .and_then(|executable| Some(executable.parent()?.join("agent-session")))
+        .map(|path| crate::display_path(&path))
+        .ok_or_else(|| {
+            CliError::runtime(
+                "main-agent-executable-unavailable",
+                "the sibling agent-session executable could not be resolved for the external launch contract",
+                None,
+            )
+        })?;
+    Ok(json!({
+        "schema_version": "main-agent.external-launch.v1",
+        "launch_id": launch_id,
+        "prompt": prompt,
+        "worker_env": {
+            "AGENT_SESSION_ID": worker_record.id,
+            "AGENT_SESSION_STATE_DIR": state_dir,
+            "AGENT_SESSION_RUNTIME_ID": launch_id,
+            "AGENT_SESSION_CAPABILITY_FILE": capability_file,
+            "AGENT_SESSION_CHECKPOINT_FILE": checkpoint_file
+        },
+        "broker_heartbeat_argv": [
+            agent_session_bin,
+            "--state-dir",
+            state_dir,
+            "broker",
+            "heartbeat",
+            "--session",
+            worker_record.id,
+            "--incarnation",
+            launch_id,
+            "--generation",
+            "1",
+            "--capability-file",
+            capability_file,
+            "--format",
+            "json"
+        ],
+        "broker_stop_argv": [
+            agent_session_bin,
+            "--state-dir",
+            state_dir,
+            "broker",
+            "stop",
+            "--session",
+            worker_record.id,
+            "--capability-file",
+            capability_file,
+            "--format",
+            "json"
+        ],
+        "liveness_file": liveness_file,
+        "liveness_schema": crate::dsh_external::LIVENESS_SCHEMA
+    }))
+}
+
+fn dsh_worker_start_prompt(assignment_id: &str, main_agent_bin: &Path) -> String {
+    let bootstrap_key = worker_bootstrap_idempotency_key(assignment_id);
+    let main_agent_bin = main_agent_bin.to_string_lossy();
+    let main_agent_bin = shell_words::quote(&main_agent_bin);
+    format!(
+        "Main Agent Mode is explicitly active for this managed worker assignment. Your external runtime supplies the exact session environment for main-agent and agent-session commands. Run exactly `{main_agent_bin} bootstrap --idempotency-key {bootstrap_key} --format json` now. Do not perform any other action before it succeeds; then follow the returned `worker_instructions` and private assignment."
+    )
 }
 
 fn worker_start_request_digests(
@@ -8958,6 +9366,12 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         },
     };
     let activity_evidence = match session_evidence.value() {
+        Some(record) if crate::dsh_external::is_external_record(record) => {
+            match crate::dsh_external::external_turn_state(record) {
+                Some(turn_state) => DiagnosticEvidence::Present(turn_state),
+                None => DiagnosticEvidence::Unavailable("worker-activity-unknown".to_string()),
+            }
+        }
         Some(record) => match crate::activity::activity_status(context, &record.id) {
             Ok(result) if result.turn_state.phase != crate::activity::TurnPhase::Unknown => {
                 DiagnosticEvidence::Present(result.turn_state)
@@ -32012,6 +32426,114 @@ mod tests {
         };
         assert_eq!(args.provider, RuntimeHookProduct::Codex);
         assert_eq!(args.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn dsh_worker_start_prompt_is_a_byte_stable_replay_contract() {
+        let bootstrap_key = worker_bootstrap_idempotency_key("assignment-one");
+        let prompt = dsh_worker_start_prompt(
+            "assignment-one",
+            std::path::Path::new("/release path/main-agent"),
+        );
+        assert_eq!(
+            prompt,
+            format!(
+                "Main Agent Mode is explicitly active for this managed worker assignment. Your external runtime supplies the exact session environment for main-agent and agent-session commands. Run exactly `'/release path/main-agent' bootstrap --idempotency-key {bootstrap_key} --format json` now. Do not perform any other action before it succeeds; then follow the returned `worker_instructions` and private assignment."
+            ),
+            "the dsh prompt is a byte-stable replay contract"
+        );
+    }
+
+    #[test]
+    fn capabilities_parse_the_dsh_external_runtime_provider() {
+        let cli = MainAgentCli::try_parse_from([
+            "main-agent",
+            "capabilities",
+            "--provider",
+            "dsh",
+            "--format",
+            "json",
+        ])
+        .expect("capabilities command parses");
+        let MainAgentCommand::Capabilities(args) = cli.command else {
+            panic!("expected capabilities");
+        };
+        assert_eq!(args.provider, RuntimeHookProduct::Dsh);
+        assert_eq!(args.format, OutputFormat::Json);
+    }
+
+    #[test]
+    fn dsh_capabilities_never_claim_hook_checkpoint_write_admission() {
+        let compatible = dsh_capabilities_envelope(Some("main-agent.external-runtime.v1"));
+        assert_eq!(compatible["schema_version"], "main-agent.capabilities.v1");
+        assert_eq!(compatible["provider"], "dsh");
+        assert_eq!(compatible["compatible"], true);
+        assert_eq!(
+            compatible["capabilities"]["runtime_checkpoint_file"],
+            "main-agent.runtime-checkpoint-file.v1"
+        );
+        assert!(compatible["capabilities"]["runtime_hook_checkpoint_write"].is_null());
+        assert_eq!(
+            compatible["capabilities"]["run_wide_closeout"],
+            "main-agent.run-wide-closeout.v1"
+        );
+        assert_eq!(
+            compatible["capabilities"]["external_runtime"],
+            "main-agent.external-runtime.v1"
+        );
+
+        let incompatible = dsh_capabilities_envelope(None);
+        assert_eq!(incompatible["compatible"], false);
+        assert!(incompatible["capabilities"]["external_runtime"].is_null());
+        assert!(incompatible["capabilities"]["runtime_hook_checkpoint_write"].is_null());
+    }
+
+    #[test]
+    fn dsh_doctor_dispatch_support_requires_bundle_owned_registration() {
+        let supported = json!({
+            "schema_version": "cli.agent-hook.doctor.v1",
+            "ok": true,
+            "data": [{
+                "schema_version": "agent-hook.doctor.v1",
+                "product": "dsh",
+                "status": "unsupported",
+                "supported": false,
+                "dispatch_supported": true,
+                "registration_owner": "dsh-runtime-kit"
+            }]
+        });
+        assert!(dsh_doctor_dispatch_supported(&supported));
+
+        let mut foreign_owner = supported.clone();
+        foreign_owner["data"][0]["registration_owner"] = json!("agent-hook");
+        assert!(!dsh_doctor_dispatch_supported(&foreign_owner));
+
+        let mut dispatch_absent = supported.clone();
+        dispatch_absent["data"][0]["dispatch_supported"] = json!(false);
+        assert!(!dsh_doctor_dispatch_supported(&dispatch_absent));
+
+        let mut wrong_product = supported.clone();
+        wrong_product["data"][0]["product"] = json!("codex");
+        assert!(!dsh_doctor_dispatch_supported(&wrong_product));
+
+        let mut failed_envelope = supported;
+        failed_envelope["ok"] = json!(false);
+        assert!(!dsh_doctor_dispatch_supported(&failed_envelope));
+
+        // The checkpoint-write predicate must never claim dsh support even
+        // against an otherwise-complete inventory.
+        assert!(!runtime_hook_supports_checkpoint(
+            &json!({
+                "schema_version": "cli.agent-hook.inventory.v1",
+                "ok": true,
+                "data": {
+                    "schema_version": "agent-hook.inventory.v1",
+                    "bundle_version": "2026.07.28.1",
+                    "rules": []
+                }
+            }),
+            RuntimeHookProduct::Dsh
+        ));
     }
 
     #[test]

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -9371,10 +9371,26 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         },
     };
     let activity_evidence = match session_evidence.value() {
+        // An external lane publishes a turn only while it is open under a live
+        // harness. Once the plugin closed it — or before it ever attached —
+        // there is no turn to report, and that absence is proven rather than
+        // unavailable: treating it as unavailable would fence the very
+        // cancel/reassign routes such a lane needs. `Unproven` stays
+        // unavailable, so a corrupt sidecar still fails closed.
         Some(record) if crate::dsh_external::is_external_record(record) => {
-            match crate::dsh_external::external_turn_state(record) {
-                Some(turn_state) => DiagnosticEvidence::Present(turn_state),
-                None => DiagnosticEvidence::Unavailable("worker-activity-unknown".to_string()),
+            match crate::activity::state_for_view(context, record) {
+                Some(turn_state) if turn_state.phase != crate::activity::TurnPhase::Unknown => {
+                    DiagnosticEvidence::Present(turn_state)
+                }
+                _ => match crate::dsh_external::external_lane_disposition(record) {
+                    crate::dsh_external::ExternalLaneDisposition::NeverAttached => {
+                        DiagnosticEvidence::Absent("worker-lane-never-attached")
+                    }
+                    crate::dsh_external::ExternalLaneDisposition::ProvenStopped => {
+                        DiagnosticEvidence::Absent("worker-lane-stopped")
+                    }
+                    _ => DiagnosticEvidence::Unavailable("worker-activity-unknown".to_string()),
+                },
             }
         }
         Some(record) => match crate::activity::activity_status(context, &record.id) {
@@ -9636,12 +9652,18 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     let preclaim_blocker = assignment_has_preclaim_blocker(&assignment);
     let terminal_recovery_reconciled =
         terminal_recovery_recorded && worker_status == "stopped" && assignment.worker.is_some();
+    let runtime_never_attached = session_evidence.value().is_some_and(|record| {
+        crate::dsh_external::is_external_record(record)
+            && crate::dsh_external::external_lane_disposition(record)
+                == crate::dsh_external::ExternalLaneDisposition::NeverAttached
+    });
     let failed_preclaim = worker_failed_preclaim(PreClaimEvidence {
         assignment_state: &assignment.state,
         claim_active,
         operations_quiescent: active_operations == 0 && uncertain_operations == 0,
         worker_bound: assignment.worker.is_some(),
         worker_status: &worker_status,
+        runtime_never_attached,
         preclaim_blocker,
         provider_terminated,
         terminal_recovery_reconciled,
@@ -10832,6 +10854,11 @@ struct PreClaimEvidence<'a> {
     operations_quiescent: bool,
     worker_bound: bool,
     worker_status: &'a str,
+    /// A plugin-owned external lane whose runtime never attached to this
+    /// launch. Its status projects as `missing`, which for a tmux lane means
+    /// "no session record at all", so the never-attached case is carried as its
+    /// own fact rather than by widening the `worker_status` match.
+    runtime_never_attached: bool,
     preclaim_blocker: bool,
     provider_terminated: bool,
     terminal_recovery_reconciled: bool,
@@ -10860,7 +10887,11 @@ fn worker_failed_preclaim(evidence: PreClaimEvidence<'_>) -> bool {
         || (starting
             && (evidence.provider_terminated
                 || !evidence.worker_bound
-                || evidence.worker_status == "stopped"))
+                || evidence.worker_status == "stopped"
+                // An external runtime that never attached is as gone as one
+                // that died during startup; without this the lane's assignment
+                // could never be cancelled or reassigned.
+                || evidence.runtime_never_attached))
 }
 
 fn worker_claim_renewal_required(
@@ -12075,7 +12106,13 @@ fn run_worker_cancel(context: &CliContext, args: WorkerCancelArgs) -> Result<Val
     let preclaim_runtime_gone = !terminal_recovery_reconciled
         && assignment.state == "starting"
         && assignment.worker.is_some()
-        && diagnosis["worker"]["status"] == "stopped";
+        // A plugin-owned lane that never attached to its launch reports
+        // `missing`, never `stopped`, and opened no broker either. The proof
+        // below is the sidecar disposition plus its absent heartbeat.
+        && matches!(
+            diagnosis["worker"]["status"].as_str(),
+            Some("stopped" | "missing")
+        );
     let broker_evidence_waived = terminal_recovery_reconciled || preclaim_runtime_gone;
     // Reconciliation committed this same stopped-runtime proof under the
     // record -> coordination -> orchestration lock order. Reacquire the
@@ -12103,21 +12140,39 @@ fn run_worker_cancel(context: &CliContext, args: WorkerCancelArgs) -> Result<Val
                 None,
             ));
         }
-        let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
-        let exact_failed_canary_quiescent = preclaim_runtime_gone
-            && crate::provider_stop_canary_failed_startup_runtime_quiescent(
+        if crate::dsh_external::is_external_record(&worker_record) {
+            // A plugin-owned lane has no tmux runtime whose absence could be
+            // proven here, and its runtime evidence is unavailable precisely
+            // when the plugin never attached. Its terminal proof is the sidecar
+            // disposition corroborated by the absent broker heartbeat.
+            if !crate::dsh_external::external_lane_terminal_is_proven(
+                context,
                 &worker_record,
-                &args.assignment_id,
-            );
-        if (runtime_evidence.status != crate::CoordinationRuntimeStatus::Stopped
-            && !exact_failed_canary_quiescent)
-            || session_status(&resolve_tmux_bin(None), &worker_record) != "stopped"
-        {
-            return Err(CliError::data(
-                "worker-runtime-still-live",
-                "cancellation on waived broker evidence requires the exact worker runtime to remain stopped",
-                Some(json!({ "assignment_id": args.assignment_id })),
-            ));
+                worker_incarnation,
+            ) {
+                return Err(CliError::data(
+                    "worker-runtime-still-live",
+                    "cancellation on waived broker evidence requires the plugin-owned lane to be proven never attached or stopped",
+                    Some(json!({ "assignment_id": args.assignment_id })),
+                ));
+            }
+        } else {
+            let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+            let exact_failed_canary_quiescent = preclaim_runtime_gone
+                && crate::provider_stop_canary_failed_startup_runtime_quiescent(
+                    &worker_record,
+                    &args.assignment_id,
+                );
+            if (runtime_evidence.status != crate::CoordinationRuntimeStatus::Stopped
+                && !exact_failed_canary_quiescent)
+                || session_status(&resolve_tmux_bin(None), &worker_record) != "stopped"
+            {
+                return Err(CliError::data(
+                    "worker-runtime-still-live",
+                    "cancellation on waived broker evidence requires the exact worker runtime to remain stopped",
+                    Some(json!({ "assignment_id": args.assignment_id })),
+                ));
+            }
         }
         Some(lifecycle)
     } else {
@@ -15114,6 +15169,14 @@ fn run_worker_stop_claimed_runtime(
                 None,
             ));
         }
+        // Re-check ownership under the lock: the unlocked precheck can be
+        // overtaken, and `stop_session_runtime_locked` refuses a plugin-owned
+        // lane only after the identity, fence, and receipt below are durable.
+        ensure_worker_session_runtime_stop_not_plugin_owned(
+            context,
+            &current.assignment_id,
+            &locked_worker.session_id,
+        )?;
         orchestration::persist_session_claimed_runtime_stop_identity(
             context,
             &current.assignment_id,
@@ -15560,6 +15623,66 @@ struct WorkerRuntimeStopAssignment {
 /// external dsh plugin, before any reservation, receipt, or authority seal is
 /// persisted: a refusal after those side effects would wedge the assignment
 /// behind a retained runtime-stop reservation that no replay can clear.
+/// Refuse deleting the durable record of a plugin-owned lane whose stop is not
+/// proven, before any fence or receipt is persisted. Deletion itself is gated
+/// again at the record boundary; this only moves the refusal ahead of the
+/// side effects.
+fn ensure_external_lane_deletable(
+    context: &CliContext,
+    assignment_id: &str,
+) -> Result<(), CliError> {
+    let Some((record, incarnation)) = external_lane_worker_record(context, assignment_id)? else {
+        return Ok(());
+    };
+    match crate::dsh_external::external_lane_disposition(&record) {
+        crate::dsh_external::ExternalLaneDisposition::NeverAttached
+        | crate::dsh_external::ExternalLaneDisposition::ProvenStopped
+            if crate::dsh_external::external_lane_terminal_is_proven(
+                context,
+                &record,
+                &incarnation,
+            ) =>
+        {
+            Ok(())
+        }
+        _ => Err(CliError::usage(
+            "dsh-runtime-plugin-owned",
+            "the dsh-runtime-kit plugin owns this lane runtime; close the lane there and let its liveness sidecar and broker prove the stop before deleting the record",
+            Some(json!({
+                "assignment_id": assignment_id,
+                "worker_session_id": record.id
+            })),
+        )),
+    }
+}
+
+/// The bound worker's record and incarnation when the assignment names an
+/// external-runtime lane. A store read failure is an error, never an implicit
+/// "not plugin owned": failing open here would restore the fence-then-refuse
+/// wedge these prechecks exist to prevent.
+fn external_lane_worker_record(
+    context: &CliContext,
+    assignment_id: &str,
+) -> Result<Option<(SessionRecord, String)>, CliError> {
+    let registry = orchestration::load_registry_readonly(context)?;
+    let Some(assignment) = registry.assignments.get(assignment_id) else {
+        return Ok(None);
+    };
+    let Some(worker) = assignment.worker.as_ref() else {
+        return Ok(None);
+    };
+    let record = match load_session_record(context, &worker.session_id) {
+        Ok(record) => record,
+        Err(error) if error.code() == "session-not-found" => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if !crate::dsh_external::is_external_record(&record) {
+        return Ok(None);
+    }
+    let incarnation = worker.session_incarnation.clone();
+    Ok(Some((record, incarnation)))
+}
+
 fn ensure_worker_runtime_stop_not_plugin_owned(
     context: &CliContext,
     assignment_id: &str,
@@ -15571,8 +15694,21 @@ fn ensure_worker_runtime_stop_not_plugin_owned(
     let Some(worker) = assignment.worker.as_ref() else {
         return Ok(());
     };
-    let Ok(record) = load_session_record(context, &worker.session_id) else {
-        return Ok(());
+    ensure_worker_session_runtime_stop_not_plugin_owned(context, assignment_id, &worker.session_id)
+}
+
+/// The same refusal for a caller that already resolved the bound worker, so a
+/// check under the registry lock does not have to re-read the registry.
+fn ensure_worker_session_runtime_stop_not_plugin_owned(
+    context: &CliContext,
+    assignment_id: &str,
+    session_id: &str,
+) -> Result<(), CliError> {
+    let record = match load_session_record(context, session_id) {
+        Ok(record) => record,
+        Err(error) if error.code() == "session-not-found" => return Ok(()),
+        // A store read failure must not read as "not plugin owned".
+        Err(error) => return Err(error),
     };
     if crate::dsh_external::is_external_record(&record) {
         return Err(CliError::usage(
@@ -15580,7 +15716,7 @@ fn ensure_worker_runtime_stop_not_plugin_owned(
             "dsh worker runtimes are owned by the external dsh-runtime-kit plugin; interrupt the lane there, then reconcile once the liveness sidecar proves the lane stopped",
             Some(json!({
                 "assignment_id": assignment_id,
-                "worker_session_id": worker.session_id.clone()
+                "worker_session_id": session_id
             })),
         ));
     }
@@ -15854,6 +15990,15 @@ fn run_worker_stop_runtime(
         }
         None => true,
     };
+
+    // Re-check ownership under the lock, ahead of the fence and reservation:
+    // the unlocked precheck can be overtaken, and the refusal inside
+    // `stop_session_runtime_locked` would arrive after both are durable.
+    ensure_worker_session_runtime_stop_not_plugin_owned(
+        context,
+        &current.assignment_id,
+        &worker.session_id,
+    )?;
 
     // Persist the session-owned authority fence before exposing a durable
     // orchestration reservation. Both global registries and the exact worker
@@ -19512,6 +19657,10 @@ fn run_worker_delete(
     args: AssignmentMutationArgs,
 ) -> Result<Value, CliError> {
     validate_idempotency_key(&args.idempotency_key)?;
+    // A refusal after the delete-identity fence is persisted would fence every
+    // assignment mutation behind a delete only an identical replay can clear,
+    // so refuse a plugin-owned live lane before any durable side effect.
+    ensure_external_lane_deletable(context, &args.assignment_id)?;
     let (record, incarnation) = authenticated_self(context)?;
     ensure_active_claim(context, &record)?;
     let request_digest = crate::coordination::request_digest(
@@ -31095,6 +31244,7 @@ mod tests {
             operations_quiescent: true,
             worker_bound: true,
             worker_status: "stopped",
+            runtime_never_attached: false,
             // The provider died before its first turn, so activity-derived
             // termination is not observable.
             provider_terminated: false,
@@ -31255,11 +31405,44 @@ mod tests {
                 operations_quiescent: true,
                 worker_bound: true,
                 worker_status: "stopped",
+                runtime_never_attached: false,
                 preclaim_blocker: false,
                 provider_terminated: false,
                 terminal_recovery_reconciled: false,
             }),
             "a post-claim stopped worker must not be routed through pre_claim_failure"
+        );
+
+        // The never-attached external lane is terminal only before the claim.
+        assert!(
+            worker_failed_preclaim(PreClaimEvidence {
+                assignment_state: "starting",
+                claim_active: false,
+                operations_quiescent: true,
+                worker_bound: true,
+                // A plugin-owned lane that never attached projects as
+                // `missing`, never as `stopped`.
+                worker_status: "missing",
+                runtime_never_attached: true,
+                preclaim_blocker: false,
+                provider_terminated: false,
+                terminal_recovery_reconciled: false,
+            }),
+            "an external lane whose runtime never attached must be reassignable"
+        );
+        assert!(
+            !worker_failed_preclaim(PreClaimEvidence {
+                assignment_state: "working",
+                claim_active: false,
+                operations_quiescent: true,
+                worker_bound: true,
+                worker_status: "missing",
+                runtime_never_attached: true,
+                preclaim_blocker: false,
+                provider_terminated: false,
+                terminal_recovery_reconciled: false,
+            }),
+            "a lane that already recorded the working checkpoint is never a pre-claim failure"
         );
     }
 

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -5057,7 +5057,11 @@ fn finish_external_worker_start(
     let prompt = dsh_worker_start_prompt(assignment_id, main_agent_bin);
     let replay_prompts = [prompt.as_str()];
     let existing = match load_session_record(context, worker_session_id) {
-        Ok(worker) => Some(worker),
+        // Repair a record whose second (extra-key) write was lost to a crash:
+        // the path is derivable, so replay converges instead of wedging.
+        Ok(worker) => Some(crate::dsh_external::ensure_recorded_liveness_path(
+            context, worker,
+        )?),
         Err(error) if error.code() == "session-not-found" => None,
         Err(error) => return Err(error),
     };
@@ -5259,12 +5263,13 @@ fn external_launch_payload(
         &worker_record.id,
         launch_id,
     ));
-    let liveness_file = worker_record
-        .extra
-        .get(crate::dsh_external::LIVENESS_PATH_KEY)
-        .and_then(Value::as_str)
-        .ok_or_else(|| invalid_input("external worker record has no liveness sidecar path"))?
-        .to_string();
+    // Derived, never read back: a crash between the record write and the
+    // extra-key write must not wedge every replay on a missing key. The
+    // persisted key exists only for the context-free sidecar reader.
+    let liveness_file = crate::display_path(&crate::dsh_external::liveness_path(
+        context,
+        &worker_record.id,
+    ));
     let agent_session_bin = env::current_exe()
         .ok()
         .and_then(|executable| Some(executable.parent()?.join("agent-session")))
@@ -14855,6 +14860,7 @@ fn run_worker_stop_claimed_runtime(
     if args.worker_incarnation.trim().is_empty() || args.worker_incarnation.len() > 256 {
         return Err(invalid_input("worker incarnation is invalid"));
     }
+    ensure_worker_runtime_stop_not_plugin_owned(context, &args.assignment_id)?;
     let (main, main_incarnation, controller_claim) =
         crate::coordination::authenticate_any_from_file_with_active_claim_observational(
             context, None,
@@ -15550,6 +15556,37 @@ struct WorkerRuntimeStopAssignment {
     worker: SessionRef,
 }
 
+/// Refuse a CLI-owned runtime stop for a lane whose runtime belongs to the
+/// external dsh plugin, before any reservation, receipt, or authority seal is
+/// persisted: a refusal after those side effects would wedge the assignment
+/// behind a retained runtime-stop reservation that no replay can clear.
+fn ensure_worker_runtime_stop_not_plugin_owned(
+    context: &CliContext,
+    assignment_id: &str,
+) -> Result<(), CliError> {
+    let registry = orchestration::load_registry_readonly(context)?;
+    let Some(assignment) = registry.assignments.get(assignment_id) else {
+        return Ok(());
+    };
+    let Some(worker) = assignment.worker.as_ref() else {
+        return Ok(());
+    };
+    let Ok(record) = load_session_record(context, &worker.session_id) else {
+        return Ok(());
+    };
+    if crate::dsh_external::is_external_record(&record) {
+        return Err(CliError::usage(
+            "dsh-runtime-plugin-owned",
+            "dsh worker runtimes are owned by the external dsh-runtime-kit plugin; interrupt the lane there, then reconcile once the liveness sidecar proves the lane stopped",
+            Some(json!({
+                "assignment_id": assignment_id,
+                "worker_session_id": worker.session_id.clone()
+            })),
+        ));
+    }
+    Ok(())
+}
+
 fn require_worker_runtime_stop_assignment(
     context: &CliContext,
     registry: &orchestration::Registry,
@@ -15629,6 +15666,7 @@ fn run_worker_stop_runtime(
     if args.worker_incarnation.trim().is_empty() || args.worker_incarnation.len() > 256 {
         return Err(invalid_input("worker incarnation is invalid"));
     }
+    ensure_worker_runtime_stop_not_plugin_owned(context, &args.assignment_id)?;
     let (main, main_incarnation, controller_claim) =
         crate::coordination::authenticate_any_from_file_with_active_claim_observational(
             context, None,

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -802,6 +802,30 @@ fn execute_inner(
 
     match request.action {
         MaintenanceActionId::RemoveConsoleRecord => {
+            // An external runtime owns no tmux session, so the tmux-only
+            // assessment that admits record-only removal says nothing about
+            // whether its lane is alive. Route the decision through the same
+            // positive-evidence rule ordinary deletion uses, or this becomes a
+            // second, ungated way to destroy a running lane's durable state.
+            if crate::dsh_external::is_external_record(&record) {
+                let incarnation = crate::coordination::incarnation(&record)?;
+                match crate::dsh_external::external_lane_disposition(&record) {
+                    crate::dsh_external::ExternalLaneDisposition::NeverAttached
+                    | crate::dsh_external::ExternalLaneDisposition::ProvenStopped
+                        if crate::dsh_external::external_lane_terminal_is_proven(
+                            context,
+                            &record,
+                            &incarnation,
+                        ) => {}
+                    _ => {
+                        return Err(CliError::runtime(
+                            "coordination-runtime-unverified",
+                            "external dsh lane liveness is not proven; the dsh-runtime-kit plugin owns this runtime",
+                            Some(json!({ "id": record.id.clone() })),
+                        ));
+                    }
+                }
+            }
             let resolved = resolve_session_record_path(context, &canonical_id)?;
             validate_record_id(&record, &resolved.expected_id, &resolved.record_path)?;
             // Deliberately no signal of any kind. This reuses the same atomic

--- a/crates/agent-session/src/provider_prompt.rs
+++ b/crates/agent-session/src/provider_prompt.rs
@@ -803,6 +803,7 @@ fn resolve_provider_prompt_source_from_roots(
             )?,
         ),
         AgentKind::Hermes => return None,
+        AgentKind::Dsh => return None,
     };
     Some(ProviderPromptSource {
         provider,

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -5412,6 +5412,7 @@ fn terminal_notification_waiting(
                 && turn.current_turn.is_none()
         }),
         AgentKind::Hermes => false,
+        AgentKind::Dsh => false,
     }
 }
 
@@ -7969,7 +7970,7 @@ fn provider_prompt_new_runtime_source_authorized(record: &crate::SessionRecord) 
         Some(AgentKind::Claude) => {
             resume.provider == "claude" && resume.capture_method == "claude-explicit-session-id"
         }
-        Some(AgentKind::Hermes) | None => false,
+        Some(AgentKind::Hermes) | Some(AgentKind::Dsh) | None => false,
     }
 }
 
@@ -7988,7 +7989,7 @@ fn provider_prompt_pending_fresh_runtime(record: &crate::SessionRecord) -> bool 
                 && resume.capture_method == "claude-explicit-session-id"
                 && !resume.session_id.trim().is_empty()
         }),
-        Some(AgentKind::Hermes) | None => false,
+        Some(AgentKind::Hermes) | Some(AgentKind::Dsh) | None => false,
     }
 }
 

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38572,14 +38572,99 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         "replay must not touch tmux either"
     );
 
+    // A CLI-owned runtime stop is refused before any durable side effect: the
+    // external plugin owns the lane runtime.
+    for stop_verb in ["stop-runtime", "stop-claimed-runtime"] {
+        let refused_stop = run_main_agent(
+            &checkout,
+            &[
+                "--state-dir",
+                &state_arg,
+                "worker",
+                stop_verb,
+                "assignment-dsh",
+                "--worker-incarnation",
+                launch_id,
+                "--if-revision",
+                "2",
+                "--idempotency-key",
+                &format!("worker-{stop_verb}-dsh-0001"),
+                "--format",
+                "json",
+            ],
+            envs,
+        );
+        assert_ne!(
+            refused_stop.code,
+            0,
+            "outcome={}",
+            refused_stop.stdout_text()
+        );
+        assert_eq!(
+            refused_stop.stdout_json()["error"]["code"],
+            "dsh-runtime-plugin-owned",
+            "outcome={}",
+            refused_stop.stdout_text()
+        );
+        let after_stop =
+            orchestration_registry(&state_dir)["assignments"]["assignment-dsh"].clone();
+        assert_eq!(
+            after_stop["revision"], 2,
+            "a refused runtime stop must not mutate the assignment"
+        );
+        assert!(
+            after_stop["runtime_stop"].is_null(),
+            "a refused runtime stop must not persist a reservation"
+        );
+    }
+
+    // Unproven liveness fails closed: a corrupted sidecar must never authorize
+    // destroying the record of a lane that may still be running.
+    let write_sidecar = |body: &str| {
+        fs::write(liveness_file, body).expect("sidecar");
+        fs::set_permissions(liveness_file, fs::Permissions::from_mode(0o600))
+            .expect("sidecar mode");
+    };
+    write_sidecar("not json");
+    let delete_options = CmdOptions::new().with_cwd(&checkout).with_envs(&[
+        ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+    ]);
+    let refused_unproven = run_resolved(
+        "agent-session",
+        &[
+            "--state-dir",
+            &state_arg,
+            "delete",
+            "worker-dsh",
+            "--format",
+            "json",
+        ],
+        &delete_options,
+    );
+    assert_ne!(
+        refused_unproven.code,
+        0,
+        "outcome={}",
+        refused_unproven.stdout_text()
+    );
+    assert_eq!(
+        refused_unproven.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified"
+    );
+    assert!(
+        state_dir.join("sessions/worker-dsh").exists(),
+        "unproven liveness preserves the record"
+    );
+
     // A live open lane refuses record deletion; a terminated lane deletes.
     let live_sidecar = json!({
         "schema_version": "main-agent.dsh-runtime-liveness.v1",
         "launch_id": launch_id,
-        "harness": { "pid": std::process::id() },
+        "harness": harness_identity_json(),
         "lane": { "state": "open" }
     });
-    fs::write(liveness_file, live_sidecar.to_string()).expect("live sidecar");
+    write_sidecar(&live_sidecar.to_string());
     let delete_options = CmdOptions::new().with_cwd(&checkout).with_envs(&[
         ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
         ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
@@ -38606,13 +38691,42 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         state_dir.join("sessions/worker-dsh").exists(),
         "refused deletion preserves the record"
     );
+    // A terminated lane whose harness is still live is only a plugin
+    // assertion, so it stays unproven and refuses deletion.
+    let uncorroborated = json!({
+        "schema_version": "main-agent.dsh-runtime-liveness.v1",
+        "launch_id": launch_id,
+        "harness": harness_identity_json(),
+        "lane": { "state": "terminated" }
+    });
+    write_sidecar(&uncorroborated.to_string());
+    let refused_uncorroborated = run_resolved(
+        "agent-session",
+        &[
+            "--state-dir",
+            &state_arg,
+            "delete",
+            "worker-dsh",
+            "--format",
+            "json",
+        ],
+        &delete_options,
+    );
+    assert_ne!(
+        refused_uncorroborated.code,
+        0,
+        "a live harness leaves plugin-asserted termination unproven: {}",
+        refused_uncorroborated.stdout_text()
+    );
+
+    // A terminated lane whose harness is proven gone deletes.
     let terminated_sidecar = json!({
         "schema_version": "main-agent.dsh-runtime-liveness.v1",
         "launch_id": launch_id,
-        "harness": { "pid": std::process::id() },
+        "harness": { "pid": i32::MAX, "start_time": 1 },
         "lane": { "state": "terminated" }
     });
-    fs::write(liveness_file, terminated_sidecar.to_string()).expect("terminated sidecar");
+    write_sidecar(&terminated_sidecar.to_string());
     let deleted = run_resolved(
         "agent-session",
         &[
@@ -38634,4 +38748,25 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         tmux_calls(&tmux_log).is_empty(),
         "dsh record deletion must never touch tmux"
     );
+}
+
+/// The pinned harness identity of this test process, matching what the
+/// dsh-runtime-kit plugin writes: pid plus the Linux starttime pin when it is
+/// readable, so liveness is decidable rather than merely "some process exists".
+fn harness_identity_json() -> serde_json::Value {
+    let pid = std::process::id();
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(stat) = fs::read_to_string(format!("/proc/{pid}/stat")) {
+            let after_comm = &stat[stat.rfind(')').map(|index| index + 1).unwrap_or(0)..];
+            if let Some(start_time) = after_comm
+                .split_whitespace()
+                .nth(19)
+                .and_then(|field| field.parse::<u64>().ok())
+            {
+                return json!({ "pid": pid, "start_time": start_time });
+            }
+        }
+    }
+    json!({ "pid": pid })
 }

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38618,6 +38618,78 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         );
     }
 
+    // No sidecar exists yet, so the plugin never attached to this launch. That
+    // is terminal pre-claim evidence: supervision must route to
+    // reassign/cancel instead of asking a lane that never started to renew a
+    // claim it never held.
+    let diagnosed = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "diagnose",
+            "assignment-dsh",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+    assert_eq!(diagnosed.code, 0, "outcome={}", diagnosed.stdout_text());
+    let diagnosis = diagnosed.stdout_json()["data"].clone();
+    assert_eq!(
+        diagnosis["failed_preclaim"], true,
+        "a never-attached lane is a pre-claim failure: {diagnosis}"
+    );
+    assert_eq!(
+        diagnosis["worker"]["status"], "missing",
+        "a never-attached lane reports missing, never stopped: {diagnosis}"
+    );
+    // The absence of a turn is proven here, not merely unobserved: a lane whose
+    // plugin never attached has no activity to report. Reporting it as
+    // unavailable evidence would be the difference between a recoverable
+    // assignment and a wedged one.
+    assert_eq!(
+        diagnosis["evidence"]["activity"]["state"], "absent",
+        "never-attached activity is proven absent: {diagnosis}"
+    );
+    assert_eq!(
+        diagnosis["evidence"]["activity"]["error_code"], "worker-lane-never-attached",
+        "the absence is typed: {diagnosis}"
+    );
+
+    // Cancellation is the recovery route that diagnosis points at, and it must
+    // not demand the tmux stopped-runtime or broker evidence a lane that never
+    // attached could never produce. Without this the assignment has no
+    // recovery route at all.
+    let cancelled = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "cancel",
+            "assignment-dsh",
+            "--if-revision",
+            "2",
+            "--reason",
+            "the dsh plugin never attached to the launch",
+            "--idempotency-key",
+            "worker-cancel-dsh-0001",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+    assert_eq!(cancelled.code, 0, "outcome={}", cancelled.stdout_text());
+    let cancelled_assignment =
+        orchestration_registry(&state_dir)["assignments"]["assignment-dsh"].clone();
+    assert_eq!(cancelled_assignment["state"], "cancelled");
+    let cancelled_revision = cancelled_assignment["revision"]
+        .as_u64()
+        .expect("cancelled revision")
+        .to_string();
+
     // Unproven liveness fails closed: a corrupted sidecar must never authorize
     // destroying the record of a lane that may still be running.
     let write_sidecar = |body: &str| {
@@ -38691,6 +38763,49 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         state_dir.join("sessions/worker-dsh").exists(),
         "refused deletion preserves the record"
     );
+
+    // The orchestrated `worker delete` must refuse the same live lane *before*
+    // it persists the delete-identity fence. A fence left behind by a refusal
+    // fences every later assignment mutation behind a delete that only an
+    // identical replay could clear.
+    let refused_delete_verb = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "delete",
+            "assignment-dsh",
+            "--if-revision",
+            &cancelled_revision,
+            "--idempotency-key",
+            "worker-delete-dsh-live-0001",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+    assert_ne!(
+        refused_delete_verb.code,
+        0,
+        "outcome={}",
+        refused_delete_verb.stdout_text()
+    );
+    assert_eq!(
+        refused_delete_verb.stdout_json()["error"]["code"],
+        "dsh-runtime-plugin-owned",
+        "outcome={}",
+        refused_delete_verb.stdout_text()
+    );
+    assert_eq!(
+        orchestration_registry(&state_dir)["assignments"]["assignment-dsh"]["revision"]
+            .as_u64()
+            .expect("revision")
+            .to_string(),
+        cancelled_revision,
+        "a refused worker delete must not mutate the assignment"
+    );
+
     // A terminated lane whose harness is still live is only a plugin
     // assertion, so it stays unproven and refuses deletion.
     let uncorroborated = json!({
@@ -38719,7 +38834,10 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         refused_uncorroborated.stdout_text()
     );
 
-    // A terminated lane whose harness is proven gone deletes.
+    // A terminated lane whose harness is proven gone deletes — but only once
+    // its coordination heartbeat is gone too. The sidecar sits in a directory
+    // the lane's own worker can write, so a lane still holding coordination
+    // authority must not be able to terminalize its own record.
     let terminated_sidecar = json!({
         "schema_version": "main-agent.dsh-runtime-liveness.v1",
         "launch_id": launch_id,
@@ -38727,6 +38845,39 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         "lane": { "state": "terminated" }
     });
     write_sidecar(&terminated_sidecar.to_string());
+    let heartbeat_path = state_dir.join("sessions/worker-dsh/coordination/heartbeat");
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    fs::write(&heartbeat_path, format!("{launch_id}:{now_epoch}")).expect("heartbeat");
+    fs::set_permissions(&heartbeat_path, fs::Permissions::from_mode(0o600))
+        .expect("heartbeat mode");
+    let refused_live_heartbeat = run_resolved(
+        "agent-session",
+        &[
+            "--state-dir",
+            &state_arg,
+            "delete",
+            "worker-dsh",
+            "--format",
+            "json",
+        ],
+        &delete_options,
+    );
+    assert_ne!(
+        refused_live_heartbeat.code,
+        0,
+        "a fresh lane heartbeat refutes a plugin-asserted stop: {}",
+        refused_live_heartbeat.stdout_text()
+    );
+    assert_eq!(
+        refused_live_heartbeat.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified",
+        "outcome={}",
+        refused_live_heartbeat.stdout_text()
+    );
+    fs::remove_file(&heartbeat_path).expect("heartbeat removed");
     let deleted = run_resolved(
         "agent-session",
         &[
@@ -38747,6 +38898,46 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
     assert!(
         tmux_calls(&tmux_log).is_empty(),
         "dsh record deletion must never touch tmux"
+    );
+
+    // The refused delete above left no fence: a distinct idempotency key still
+    // admits. A persisted delete identity would refuse every request but its
+    // own exact replay.
+    let deleted_worker = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "delete",
+            "assignment-dsh",
+            "--if-revision",
+            &cancelled_revision,
+            "--idempotency-key",
+            "worker-delete-dsh-terminal-0001",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+    assert_eq!(
+        deleted_worker.code,
+        0,
+        "outcome={}",
+        deleted_worker.stdout_text()
+    );
+    assert_eq!(
+        deleted_worker.stdout_json()["data"]["deleted"],
+        true,
+        "outcome={}",
+        deleted_worker.stdout_text()
+    );
+    assert!(
+        orchestration_registry(&state_dir)["assignments"]["assignment-dsh"]["revision"]
+            .as_u64()
+            .expect("revision")
+            > cancelled_revision.parse::<u64>().expect("revision"),
+        "the admitted delete advances the assignment"
     );
 }
 

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38344,3 +38344,294 @@ fn main_agent_quick_no_longer_requires_an_idempotency_key() {
         "must no longer require --idempotency-key: {error}"
     );
 }
+
+#[test]
+fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    let checkout = tmp.path().join("checkout");
+    fs::create_dir(&state_dir).expect("state");
+    init_checkout(&checkout, "https://example.invalid/example/repository.git");
+    seed_brokers_at(
+        &state_dir,
+        &[(
+            "main-one",
+            "main-incarnation-one",
+            "main-private-capability-material-0000000001",
+            checkout.as_path(),
+            Some("enforce"),
+        )],
+    );
+    let main_capability = init_main_run(tmp.path(), &state_dir, &checkout, "main-one", "run-one");
+    let (tmux_bin, tmux_log) = fake_tmux(tmp.path());
+    let worktree = tmp.path().join("lane-worktree");
+    fs::create_dir(&worktree).expect("lane worktree");
+    let assignment_path = tmp.path().join("assignment-dsh.json");
+    write_private_json(
+        &assignment_path,
+        &json!({
+            "schema_version": "main-agent.assignment-input.v1",
+            "assignment_id": "assignment-dsh",
+            "task_summary": "Exercise the dsh external-runtime launch contract",
+            "task": {},
+            "launch": {
+                "agent": "dsh",
+                "cwd": worktree,
+                "title": null,
+                "session_id": "worker-dsh",
+                "coordination_mode": "enforce",
+                "agent_args": []
+            },
+            "repository": "example/repository",
+            "worktree": worktree,
+            "base_ref": "main",
+            "scopes": ["crates/agent-session"],
+            "durable_refs": []
+        }),
+    );
+    let state_arg = state_dir.to_string_lossy().into_owned();
+    let tmux_arg = tmux_bin.to_string_lossy().into_owned();
+    let tmux_log_arg = tmux_log.to_string_lossy().into_owned();
+    let envs: &[(&str, &str)] = &[
+        ("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str()),
+        ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+    ];
+
+    // A non-zero --await-ready refuses before any durable side effect: the
+    // external runtime cannot deliver the prompt while this command blocks.
+    let refused = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "start",
+            "--assignment-file",
+            assignment_path.to_str().expect("assignment path"),
+            "--await-ready",
+            "5m",
+            "--idempotency-key",
+            "worker-start-dsh-await-0001",
+            "--format",
+            "json",
+        ],
+        envs,
+    );
+    assert_eq!(refused.code, 64, "outcome={}", refused.stdout_text());
+    assert_eq!(
+        refused.stdout_json()["error"]["code"],
+        "dsh-await-ready-unsupported"
+    );
+    assert!(
+        orchestration_registry(&state_dir)["assignments"]
+            .get("assignment-dsh")
+            .is_none(),
+        "await-ready refusal must not persist an assignment"
+    );
+    assert!(
+        !state_dir.join("sessions/worker-dsh").exists(),
+        "await-ready refusal must not create a worker session"
+    );
+
+    // Launch-only start performs the store bookkeeping and returns the
+    // external launch contract instead of pasting a prompt into tmux.
+    let start_args = [
+        "--state-dir",
+        &state_arg,
+        "worker",
+        "start",
+        "--assignment-file",
+        assignment_path.to_str().expect("assignment path"),
+        "--await-ready",
+        "0",
+        "--idempotency-key",
+        "worker-start-dsh-0001",
+        "--format",
+        "json",
+    ];
+    let started = run_main_agent(&checkout, &start_args, envs);
+    assert_eq!(started.code, 0, "outcome={}", started.stdout_text());
+    let envelope = started.stdout_json();
+    let outcome = envelope["data"].clone();
+    assert_eq!(
+        outcome["schema_version"],
+        "main-agent.worker-start-result.v1"
+    );
+    assert_eq!(outcome["delivery"]["state"], "external-launch-pending");
+    assert_eq!(outcome["delivery"]["proof"], "external-runtime-transfer");
+    assert_eq!(outcome["worker"]["session_id"], "worker-dsh");
+    assert_eq!(outcome["worker"]["status"], "external");
+    let external_launch = &outcome["external_launch"];
+    assert_eq!(
+        external_launch["schema_version"],
+        "main-agent.external-launch.v1"
+    );
+    let launch_id = external_launch["launch_id"].as_str().expect("launch id");
+    assert!(!launch_id.is_empty(), "launch id is minted");
+    assert_eq!(
+        outcome["worker"]["session_incarnation"].as_str(),
+        Some(launch_id),
+        "the incarnation is the minted launch id"
+    );
+    let prompt = external_launch["prompt"].as_str().expect("prompt");
+    assert!(
+        prompt.contains("bootstrap --idempotency-key bootstrap-"),
+        "prompt drives the worker bootstrap: {prompt}"
+    );
+    assert!(
+        !prompt.contains("AGENT_SESSION_"),
+        "the prompt is environment-free; env delivery is plugin-owned: {prompt}"
+    );
+    let worker_env = &external_launch["worker_env"];
+    assert_eq!(worker_env["AGENT_SESSION_ID"], "worker-dsh");
+    assert_eq!(
+        worker_env["AGENT_SESSION_RUNTIME_ID"].as_str(),
+        Some(launch_id)
+    );
+    let capability_env = worker_env["AGENT_SESSION_CAPABILITY_FILE"]
+        .as_str()
+        .expect("capability env");
+    assert!(
+        capability_env.contains("sessions/worker-dsh/coordination/capability-"),
+        "capability path is session-scoped: {capability_env}"
+    );
+    let checkpoint_env = worker_env["AGENT_SESSION_CHECKPOINT_FILE"]
+        .as_str()
+        .expect("checkpoint env");
+    assert!(
+        checkpoint_env.contains("sessions/worker-dsh/coordination/main-agent-checkpoint-"),
+        "checkpoint path is session-scoped: {checkpoint_env}"
+    );
+    let heartbeat_argv = external_launch["broker_heartbeat_argv"]
+        .as_array()
+        .expect("heartbeat argv");
+    assert!(
+        heartbeat_argv[0]
+            .as_str()
+            .is_some_and(|bin| bin.ends_with("agent-session")),
+        "heartbeat runs the sibling agent-session binary"
+    );
+    assert!(
+        heartbeat_argv
+            .iter()
+            .any(|value| value.as_str() == Some(launch_id)),
+        "heartbeat argv binds the minted incarnation"
+    );
+    let liveness_file = external_launch["liveness_file"]
+        .as_str()
+        .expect("liveness file");
+    assert!(
+        liveness_file.ends_with("sessions/worker-dsh/dsh-runtime-liveness.json"),
+        "liveness sidecar lives in the session state dir: {liveness_file}"
+    );
+    assert_eq!(
+        external_launch["liveness_schema"],
+        "main-agent.dsh-runtime-liveness.v1"
+    );
+    let registry = orchestration_registry(&state_dir);
+    let assignment = &registry["assignments"]["assignment-dsh"];
+    assert_eq!(assignment["state"], "starting");
+    assert_eq!(assignment["revision"], 2);
+    assert_eq!(assignment["worker"]["session_id"], "worker-dsh");
+    assert_eq!(
+        assignment["worker"]["session_incarnation"].as_str(),
+        Some(launch_id)
+    );
+    let record: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(state_dir.join("sessions/worker-dsh/session.json"))
+            .expect("worker record"),
+    )
+    .expect("worker record json");
+    assert_eq!(record["agent"], "dsh");
+    assert_eq!(record["mode"], "external");
+    assert_eq!(record["runtime"]["kind"], "dsh_external");
+    assert_eq!(record["runtime"]["launch_id"].as_str(), Some(launch_id));
+    assert_eq!(record["dsh_liveness_file"].as_str(), Some(liveness_file));
+    let stored_prompt =
+        fs::read_to_string(state_dir.join("sessions/worker-dsh/prompt.md")).expect("stored prompt");
+    assert_eq!(
+        stored_prompt, prompt,
+        "the stored prompt is the replay contract"
+    );
+    assert!(
+        tmux_calls(&tmux_log).is_empty(),
+        "a dsh worker start must never touch tmux"
+    );
+
+    // The recorded receipt makes the start idempotent.
+    let replayed = run_main_agent(&checkout, &start_args, envs);
+    assert_eq!(replayed.code, 0, "outcome={}", replayed.stdout_text());
+    assert_eq!(
+        replayed.stdout_json()["data"],
+        outcome,
+        "replay returns the receipt"
+    );
+    assert!(
+        tmux_calls(&tmux_log).is_empty(),
+        "replay must not touch tmux either"
+    );
+
+    // A live open lane refuses record deletion; a terminated lane deletes.
+    let live_sidecar = json!({
+        "schema_version": "main-agent.dsh-runtime-liveness.v1",
+        "launch_id": launch_id,
+        "harness": { "pid": std::process::id() },
+        "lane": { "state": "open" }
+    });
+    fs::write(liveness_file, live_sidecar.to_string()).expect("live sidecar");
+    let delete_options = CmdOptions::new().with_cwd(&checkout).with_envs(&[
+        ("AGENT_SESSION_TMUX_BIN", tmux_arg.as_str()),
+        ("AGENT_SESSION_FAKE_TMUX_LOG", tmux_log_arg.as_str()),
+    ]);
+    let refused_delete = run_resolved(
+        "agent-session",
+        &[
+            "--state-dir",
+            &state_arg,
+            "delete",
+            "worker-dsh",
+            "--format",
+            "json",
+        ],
+        &delete_options,
+    );
+    assert_ne!(
+        refused_delete.code,
+        0,
+        "a live open lane must refuse deletion: {}",
+        refused_delete.stdout_text()
+    );
+    assert!(
+        state_dir.join("sessions/worker-dsh").exists(),
+        "refused deletion preserves the record"
+    );
+    let terminated_sidecar = json!({
+        "schema_version": "main-agent.dsh-runtime-liveness.v1",
+        "launch_id": launch_id,
+        "harness": { "pid": std::process::id() },
+        "lane": { "state": "terminated" }
+    });
+    fs::write(liveness_file, terminated_sidecar.to_string()).expect("terminated sidecar");
+    let deleted = run_resolved(
+        "agent-session",
+        &[
+            "--state-dir",
+            &state_arg,
+            "delete",
+            "worker-dsh",
+            "--format",
+            "json",
+        ],
+        &delete_options,
+    );
+    assert_eq!(deleted.code, 0, "outcome={}", deleted.stdout_text());
+    assert!(
+        !state_dir.join("sessions/worker-dsh").exists(),
+        "terminated lane deletion removes the record"
+    );
+    assert!(
+        tmux_calls(&tmux_log).is_empty(),
+        "dsh record deletion must never touch tmux"
+    );
+}


### PR DESCRIPTION
## Summary

Add `dsh` as an external-runtime provider to the `main-agent` orchestration facade. DSH (DeepSeek Harness) workers are never tmux-launched: the dsh-runtime-kit Cordis bundle owns the worker agent's lifecycle, and this change gives it a typed launch contract while the durable store, revision fencing, idempotency receipts, claims, and acceptance protocol stay identical to the managed-CLI providers. Contract spec: `crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md`.

## Issues

Refs sympoies/dsh-runtime-kit#6 (M1: main-agent external-runtime adapter).

## Changes

- `AgentKind::Dsh` with typed refusals on every tmux-launch, provider-resume, one-shot-run, and activity-configuration surface.
- `main-agent capabilities --provider dsh` reports the external-runtime contract: `runtime_hook_checkpoint_write` stays null by design, `external_runtime` follows a sibling `agent-hook doctor --product dsh` probe, and `compatible` is redefined for this provider only.
- `worker start` with `launch.agent:"dsh"` becomes a launch-only external arm: identical store bookkeeping and fences, a `runtime.kind:"dsh_external"` session record, and a `main-agent.external-launch.v1` payload (byte-stable environment-free bootstrap prompt, exact worker environment, broker heartbeat/stop argv, liveness sidecar path). Non-zero `--await-ready` refuses before any durable side effect.
- New `src/dsh_external.rs`: the strict `main-agent.dsh-runtime-liveness.v1` sidecar contract with launch-id binding and harness pid+starttime incarnation pinning; `session_status` and `coordination_runtime_evidence` dispatch on the record kind; diagnose synthesizes turn state from the sidecar.
- `stop-runtime`/`stop-claimed-runtime` refuse with `dsh-runtime-plugin-owned`; record deletion is admitted only for terminated or proven-stopped lanes; `agent-session start --agent dsh` refuses before any durable side effect.
- Regenerated all four completion assets; documented the contract in the new spec, the orchestration spec, and the docs index.

## Test-First Evidence

The new black-box integration test `main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux` was run against clean `origin/main` sources first and failed (baseline rejects `launch.agent:"dsh"` with `assignment-launch-agent-invalid`, exit 65, where the contract expects the typed `dsh-await-ready-unsupported` refusal); the same test passes on this head. The verified evidence record accompanies delivery (`test-first-evidence verify` ok, delivered head bound).

## Test plan

- `cargo test -p nils-agent-session --lib`: zero new failures against the origin/main baseline (14 serve tests fail identically in this environment on both baseline and head).
- `cargo test -p nils-agent-session --test integration`: 293/293 including the new dsh end-to-end test (worker start refusal, external-launch contract, replay idempotency, sidecar-gated deletion); one unrelated fixture flake passes in isolation.
- `cargo test -p nils-agent-session --test cli_contract`: 4/4.
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- Completion scripts regenerated and syntax-checked (`bash -n`, `zsh -n`).
- Local-fast full-workspace test phase stops on 12 pre-existing `nils-agent-workflow-primitives` sandbox tests that fail identically on the clean baseline in this environment; the full matrix is CI-owned.

## Risk / Notes

- Existing codex/claude behavior is unchanged: every new arm is dsh-gated, existing envelopes are byte-identical, and `AssignmentInput` is untouched so no idempotency digest changes.
- The `external_launch` field is additive and emitted only for dsh worker starts.
- The liveness sidecar is trusted like the persisted tmux runtime identity beside it in `record.extra`: strict schema, launch-id binding, and pid+starttime incarnation pinning; unknown states stay conservative.
- Local validation waiver: the full-workspace local gate fails on 12 pre-existing environmental sandbox tests (verified identical on the clean baseline); CI required checks own the authoritative matrix.
