### PR TITLE
fix(agent-session): provision the dsh lane coordination broker

### DIFF
--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -79,12 +79,38 @@ launch boundary the arm diverges:
 
 The plugin must deliver `prompt` verbatim as the worker's initial message,
 run `broker_heartbeat_argv` as a supervised background process for the lane's
-lifetime (worker authentication reads the capability file that the heartbeat
-maintains), run `broker_stop_argv` at lane end, and arrange the worker's
+lifetime, run `broker_stop_argv` at lane end, and arrange the worker's
 `main-agent`/`agent-session` invocations to carry `worker_env`. The prompt is
 deliberately environment-free so it stays a byte-stable replay contract; env
 delivery is a plugin responsibility (per-child instruction context or a
 wrapping native tool).
+
+`broker_heartbeat_argv[0]` is the trusted `agent-session` binary, but the verb
+is **not** at a fixed index: global options (`--state-dir`, and `--host` where a
+host label applies) precede it. A consumer validating the argv must walk past
+option/value pairs to find `broker`.
+
+### Coordination-broker lifecycle for a lane
+
+This is the sequence that makes the lane's worker able to authenticate at all,
+and each step belongs to exactly one side:
+
+1. **`worker start` provisions the lane's broker** and mints the capability file
+   that `worker_env.AGENT_SESSION_CAPABILITY_FILE` and the heartbeat argv both
+   name. A tmux worker gets this from its launch path; an external lane has no
+   launch of ours, so the external arm provisions it here. Provisioning is
+   idempotent for replay: an existing capability for the same incarnation is
+   accepted rather than rotated under a running lane.
+2. **The plugin publishes the liveness sidecar**, then starts the heartbeat. The
+   order matters: the heartbeat's first act is to read this lane's runtime
+   evidence, so the sidecar must already exist rather than arrive inside the
+   heartbeat's startup retry window.
+3. **The heartbeat activates the broker** on its first live beat. Readiness
+   cannot be established at step 1 — neither the lane's runtime evidence nor its
+   heartbeat exists yet — so the first beat is the earliest provable moment. A
+   lane's authenticated calls (starting with `main-agent bootstrap`) fail
+   `coordination-unauthorized` until then, which is ordinary startup latency of
+   about one heartbeat interval, not an error state.
 
 The dsh prompt is a fifth byte-stable replay variant alongside the four
 existing prompts; `ensure_worker_launch_matches` accepts it for replay

--- a/crates/agent-session/src/coordination/broker.rs
+++ b/crates/agent-session/src/coordination/broker.rs
@@ -1042,6 +1042,7 @@ pub(crate) fn run_heartbeat_sidecar(
     let started = Instant::now();
     let mut established_owner = false;
     let mut observed_stopped = false;
+    let mut activated_external_broker = false;
     loop {
         let record = match crate::load_session_record(context, &args.session) {
             Ok(record) => record,
@@ -1093,6 +1094,18 @@ pub(crate) fn run_heartbeat_sidecar(
             SECRET_FILE_MODE,
         )
         .map_err(|_| unavailable())?;
+        // An external-runtime lane has no launcher of ours to activate its
+        // broker. `main-agent worker start` can only provision it: at that
+        // point neither the lane's runtime evidence nor this heartbeat exists,
+        // and `activate_ready` requires both. The first live beat is therefore
+        // the earliest moment readiness is provable, and without activating
+        // here the broker stays `starting` forever — every authenticated worker
+        // call, starting with `main-agent bootstrap`, fails
+        // `coordination-unauthorized`. Tmux launches keep their existing
+        // launcher-driven activation and never reach this branch.
+        if !activated_external_broker && crate::dsh_external::is_external_record(&record) {
+            activated_external_broker = activate_ready(context, &record).is_ok()
+        }
         thread::sleep(Duration::from_secs(2));
     }
     if established_owner

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -5036,6 +5036,29 @@ struct ExternalWorkerStartRequest<'a> {
     batch_lane: Option<&'a BatchLaneFence<'a>>,
 }
 
+/// Establish the coordination broker for one external-runtime lane worker.
+///
+/// Idempotent by design: `worker start` is replayable, and re-provisioning a
+/// live incarnation would rotate the credentials a running lane authenticates
+/// with (or refuse outright once its heartbeat is fresh). An existing
+/// capability for this exact incarnation is therefore accepted as already
+/// established.
+fn ensure_external_worker_broker(
+    context: &CliContext,
+    worker_record: &SessionRecord,
+) -> Result<(), CliError> {
+    let incarnation = crate::coordination::incarnation(worker_record)?;
+    if crate::coordination::capability_path(context, &worker_record.id, &incarnation).exists() {
+        return Ok(());
+    }
+    crate::coordination::provision(context, worker_record).map(|_| ())
+    // Deliberately not `activate_ready`: that step belongs to a launcher that
+    // already has a live runtime and a fresh heartbeat. An external lane has
+    // neither at this point — its runtime evidence and its heartbeat both begin
+    // once the plugin adopts this payload — so readiness is established by the
+    // heartbeat the plugin starts, not by this call.
+}
+
 fn finish_external_worker_start(
     request: ExternalWorkerStartRequest<'_>,
 ) -> Result<Value, CliError> {
@@ -5145,6 +5168,19 @@ fn finish_external_worker_start(
             return Err(invalid_input("worker session incarnation is unavailable"));
         }
     };
+    // Provision the lane's coordination broker before advertising its heartbeat
+    // argv. A tmux worker gets these credentials from `establish_coordination_
+    // broker` during launch; an external lane has no launch of ours to hang that
+    // off, so without this the capability file the payload names is never
+    // created and `agent-session broker heartbeat` refuses the lane with
+    // `coordination-unauthorized` — the worker can then never authenticate
+    // bootstrap or any checkpoint.
+    if let Err(error) = ensure_external_worker_broker(context, &worker_record) {
+        if let Some(fence) = worker_start_fence.take() {
+            fence.finish(context, false)?;
+        }
+        return Err(error);
+    }
     let expected_worker = session_ref(context, &worker_record, &launch_id);
     let attachment = (|| {
         ensure_active_claim(context, record)?;

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38615,6 +38615,15 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         Some(launch_id),
         "the provisioned broker is bound to the minted launch incarnation"
     );
+    // Provisioned, deliberately not activated: readiness needs runtime evidence
+    // and a fresh heartbeat, and an external lane has neither until the plugin
+    // adopts this payload. Activating here would advertise a lane as ready
+    // before anything of the sort exists.
+    assert_eq!(
+        brokers["brokers"]["worker-dsh"]["state"].as_str(),
+        Some("starting"),
+        "worker start provisions the lane broker without activating readiness"
+    );
     let registry = orchestration_registry(&state_dir);
     let assignment = &registry["assignments"]["assignment-dsh"];
     assert_eq!(assignment["state"], "starting");

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -1246,6 +1246,13 @@ fn rewrite_registry(state_dir: &Path, mutate: impl FnOnce(&mut serde_json::Value
     fs::set_permissions(path, fs::Permissions::from_mode(0o600)).expect("registry mode");
 }
 
+fn coordination_registry(state_dir: &Path) -> serde_json::Value {
+    serde_json::from_slice(
+        &fs::read(state_dir.join("coordination/registry.json")).expect("coordination registry"),
+    )
+    .expect("coordination registry json")
+}
+
 fn orchestration_registry(state_dir: &Path) -> serde_json::Value {
     serde_json::from_slice(
         &fs::read(state_dir.join("orchestration/registry.json")).expect("orchestration registry"),
@@ -38581,6 +38588,32 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
     assert_eq!(
         external_launch["liveness_schema"],
         "main-agent.dsh-runtime-liveness.v1"
+    );
+    // The lane's coordination broker is provisioned by this start, so the
+    // capability the heartbeat argv names actually exists. Without it the
+    // emitted heartbeat refuses with `coordination-unauthorized` and the lane
+    // worker can never authenticate `bootstrap` or any checkpoint — the payload
+    // would advertise a runtime contract the store cannot honour.
+    let capability_env = worker_env["AGENT_SESSION_CAPABILITY_FILE"]
+        .as_str()
+        .expect("capability env");
+    assert!(
+        Path::new(capability_env).is_file(),
+        "worker start must provision the lane broker credential: {capability_env}"
+    );
+    let heartbeat_capability = heartbeat_argv
+        .iter()
+        .filter_map(|value| value.as_str())
+        .any(|value| value == capability_env);
+    assert!(
+        heartbeat_capability,
+        "the heartbeat argv must name the provisioned capability"
+    );
+    let brokers = coordination_registry(&state_dir);
+    assert_eq!(
+        brokers["brokers"]["worker-dsh"]["incarnation"].as_str(),
+        Some(launch_id),
+        "the provisioned broker is bound to the minted launch incarnation"
     );
     let registry = orchestration_registry(&state_dir);
     let assignment = &registry["assignments"]["assignment-dsh"];


### PR DESCRIPTION
## Summary

The dsh external-runtime lane feature could not work end to end as merged:
`main-agent worker start` created the lane's coordination directory but never
provisioned its broker, so the capability file that both
`worker_env.AGENT_SESSION_CAPABILITY_FILE` and `broker_heartbeat_argv` name was
never created. The advertised heartbeat refused with `coordination-unauthorized`,
and the lane worker could not authenticate `main-agent bootstrap` or any
checkpoint. Only the four tmux launch paths call `establish_coordination_broker`;
the external arm had no equivalent.

This was found by running the contract end to end against real binaries for the
first time — the gap that
`test-coverage:dsh-worker-start:bootstrap-checkpoint-heartbeat-e2e` (#8) was
opened for. Substring assertions on the payload cannot detect a functional
mismatch between minted paths and the verbs that consume them.

## Problem

A dsh lane worker had no credentials at all. Reproduction against real binaries:
launch a lane through the external arm, then run the exact
`broker_heartbeat_argv` the payload returned. It exits 65 with
`coordination-unauthorized` ("this session is not a verified coordination broker
incarnation"), and the lane's coordination directory contains no
`capability-*` file. Every authenticated worker call fails from there on.

## Reproduction

1. `agent-session start --agent hermes --coordination-mode enforce` for a
   controller identity, then `main-agent init` with its capability.
2. `main-agent worker start --assignment-file <dsh packet> --await-ready 0`.
3. Run the returned `broker_heartbeat_argv` verbatim →
   `coordination-unauthorized`, exit 65.
4. `ls <state>/sessions/<worker>/coordination` → empty; no capability file.
5. `main-agent bootstrap` as the worker → `coordination-unauthorized`.

## Issues Found

Refs sympoies/dsh-runtime-kit#6 (Path B Phase 4 acceptance run).
Refs sympoies/dsh-runtime-kit#8 (deferred review follow-ups).

## Fix Approach

- `finish_external_worker_start` provisions the lane broker before returning the
  payload, through `ensure_external_worker_broker`. Provisioning is idempotent
  for replay: an existing capability for the same incarnation is accepted rather
  than rotated under a running lane, and a failure releases the worker-start
  fence.
- It deliberately does not call `activate_ready`: that step requires runtime
  evidence and a fresh heartbeat, and an external lane has neither at start —
  both begin once the plugin adopts the payload.
- Readiness is therefore established by the lane's own heartbeat: on its first
  live beat, `run_heartbeat_sidecar` activates a `starting` broker for an
  external record. Tmux launches keep their launcher-driven activation and never
  reach that branch. Without it the broker stays `starting` forever.
- The producer spec documents the three-step lifecycle (provision at start →
  publish sidecar, then heartbeat → activate on first beat), the resulting
  authentication window of about one heartbeat interval, and the fact that the
  heartbeat verb is not at a fixed argv index (global options precede it).

## Test-First Evidence

The dsh launch-contract integration test now asserts the capability file exists
after `worker start`, that the heartbeat argv names that exact path, and that the
provisioned broker is bound to the minted launch incarnation.

Failing baseline captured before the fix: with the two production files stashed,
`main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux`
fails at `coordination.rs:38600` (capability file absent). It passes with the fix
applied. Durable evidence record: `test-first-evidence verify` clean.

## Test plan

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p nils-agent-session` — 867 lib, 294 integration, 4 cli_contract,
  all green.
- End-to-end acceptance run against these binaries (in the consuming repo): two
  lanes launch, both bootstrap, one submits through its lane checkpoint tool,
  supervise → request-changes → resubmit → accept → closeout, plus an overlapping
  scope refused at claim acquisition.
- `rumdl` clean on the spec.

## Risk / Notes

- Scoped to the external-runtime arm and to external records: the tmux launch,
  resume, and activation paths are untouched, and the heartbeat's new branch is
  gated on `is_external_record`.
- Provisioning adds one broker registration per lane launch; replay accepts the
  existing credential rather than rotating it, so a live lane is never
  invalidated by a replayed start.
- Residual gap, recorded rather than fixed here: a lane closed while its harness
  is alive stays *unproven*, so `reconcile-stopped` and record deletion remain
  refused until the harness exits. Relaxing that to accept a released broker
  heartbeat as corroboration is a deliberate design decision, tracked in
  sympoies/dsh-runtime-kit#8.
