### PR TITLE
feat(agent-session): corroborate a dsh lane stop with its broker

### DIFF
--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -151,8 +151,8 @@ Consumption. The reader resolves one of four dispositions:
 | --- | --- | --- |
 | never attached | no sidecar exists | `missing` |
 | running | valid sidecar, lane `open`, pinned harness proven live | `running` |
-| proven stopped | the pinned harness is proven gone (ESRCH, or a starttime mismatch proving pid reuse) — required whether the lane reads `open` or `terminated` | `stopped` |
-| unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; or the harness state is undecidable (see the platform rule below) | `unknown` |
+| proven stopped | the pinned harness is proven gone (ESRCH, or a starttime mismatch proving pid reuse) — for a lane reading `open` this is the only proof; or the lane reads `terminated` and this lane's broker heartbeat is absent or stale | `stopped` |
+| unproven | sidecar unreadable, malformed, oversized, wrongly owned, or launch-mismatched; the harness state is undecidable (see the platform rule below) with no broker witness available; or the lane reads `terminated` while its own broker heartbeat is still fresh | `unknown` |
 
 Platform rule for the incarnation pin: where a starttime source exists (Linux
 `/proc`), a liveness claim without a verified `start_time` match is *undecided*
@@ -184,9 +184,19 @@ process-group probe on the same platforms. Plugins should always write
   while the harness lives and the lane is open.
 - `lane.state == "terminated"` is a **plugin assertion**, deliberately weaker
   than the tmux kernel-backed proof: the sidecar lives in the same-uid state
-  dir a lane's own worker can reach. It is therefore corroborated against the
-  pinned harness identity, and a still-live harness makes the assertion
-  unproven rather than proven.
+  dir a lane's own worker can reach. It is therefore never believed on its own.
+  Either of two witnesses, each owned by a different process, corroborates it:
+  - the pinned harness proven gone, or
+  - this lane's own broker heartbeat absent or stale.
+
+  The plugin releases a lane's heartbeat when it closes that lane, so a closed
+  lane is provable while the harness keeps serving its other lanes. A lane whose
+  heartbeat is still fresh holds the coordination authority a stopped lane gives
+  up, so the assertion stays unproven with
+  `external dsh lane termination is uncorroborated while its coordination
+  heartbeat stays fresh`. A reader with no way to consult the heartbeat (no state
+  context on hand) treats the lane exactly as one that still holds authority, so
+  a reader that cannot check never widens what is provable.
 - `coordination_runtime_evidence` builds the runtime identity from `harness`
   (validated against `launch_id`) and reuses the existing process-liveness
   proof. Unproven stays conservative exactly as for tmux runtimes.
@@ -232,8 +242,11 @@ refusal. In order:
    is a terminal pre-claim disposition, and the assignment can be cancelled or
    reassigned.
 3. If the harness is undecidable because the platform has no starttime source,
-   the lane's own broker heartbeat is the remaining evidence: once it is stale
-   the operator can stop the harness process, after which the pid probe decides.
+   the lane's own broker heartbeat is the remaining evidence: a lane whose
+   sidecar reads `terminated` becomes provable as soon as that heartbeat goes
+   stale, with no need to stop the harness. A lane whose sidecar still reads
+   `open` has no second witness, so there the operator stops the harness process
+   and the pid probe decides.
 
 The CLI intentionally offers no force flag for this path. A force flag would be
 indistinguishable from the forged-stop case the corroboration rule exists to

--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -197,6 +197,20 @@ process-group probe on the same platforms. Plugins should always write
   heartbeat stays fresh`. A reader with no way to consult the heartbeat (no state
   context on hand) treats the lane exactly as one that still holds authority, so
   a reader that cannot check never widens what is provable.
+
+  **Residual risk, stated exactly.** The heartbeat witness is weaker than the
+  harness witness, and knowing how is the point. Both the sidecar and the
+  heartbeat process are same-uid, so a hostile lane worker can write a
+  `terminated` sidecar and kill its own heartbeat, after which its record is
+  deletable while the lane keeps computing. It cannot do the equivalent to the
+  harness witness: killing the harness kills the lane with it. What the trade
+  costs the attacker is the authority it just surrendered — with a stale broker,
+  every authenticated call it makes, `main-agent checkpoint` included, fails
+  `coordination-unauthorized`, so the lane can no longer touch the run it was
+  hiding from. The exchange is deliberate: it buys a controller the ability to
+  reclaim one lane's assignment while its sibling lanes keep working, instead of
+  waiting for the whole harness to exit. Coordination remains a same-uid
+  boundary, not an OS one, exactly as the caveat above says.
 - `coordination_runtime_evidence` builds the runtime identity from `harness`
   (validated against `launch_id`) and reuses the existing process-liveness
   proof. Unproven stays conservative exactly as for tmux runtimes.

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -870,6 +870,10 @@ mod tests {
 
     /// Write the lane's broker heartbeat with a current epoch, the way the
     /// lane's own heartbeat process does while it holds authority.
+    ///
+    /// Gated with its only caller: proving a *live* harness needs the Linux
+    /// starttime pin, so the corroboration test cannot run anywhere else.
+    #[cfg(target_os = "linux")]
     fn write_lane_heartbeat(context: &CliContext, record: &SessionRecord, incarnation: &str) {
         let path =
             nils_common::coordination_projection::heartbeat_path(&context.state_dir, &record.id);

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -423,6 +423,12 @@ impl UnprovenReason {
 /// different process and observed through a different file. A forged stop has
 /// to stop the real heartbeat too, which is itself a loss of authority the
 /// store can see.
+///
+/// This witness is deliberately weaker than the harness one, and the spec's
+/// "residual risk, stated exactly" paragraph says how: both files are same-uid,
+/// so a hostile lane can kill its own heartbeat and keep running, whereas it
+/// cannot kill the harness without killing itself. What it gives up in exchange
+/// is every authenticated call it could still make.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum LaneBrokerWitness {
     /// The heartbeat is fresh: this lane still holds coordination authority.

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -254,7 +254,7 @@ pub(crate) fn external_lane_terminal_is_proven(
         return false;
     }
     if !matches!(
-        external_lane_disposition(record),
+        external_lane_disposition_with_broker(context, record),
         ExternalLaneDisposition::NeverAttached | ExternalLaneDisposition::ProvenStopped
     ) {
         return false;
@@ -395,6 +395,10 @@ pub(crate) enum UnprovenReason {
     /// The sidecar is valid but the pinned harness process state cannot be
     /// decided (permission, unreadable `/proc`, or a missing starttime pin).
     UndecidableHarness,
+    /// The sidecar claims the lane is terminated, but the lane's coordination
+    /// heartbeat is still fresh: it retains the authority a stopped lane gives
+    /// up, so the claim has no second witness.
+    LaneRetainsCoordinationAuthority,
 }
 
 impl UnprovenReason {
@@ -404,7 +408,41 @@ impl UnprovenReason {
             Self::UndecidableHarness => {
                 "external dsh runtime liveness could not be decided for the pinned harness"
             }
+            Self::LaneRetainsCoordinationAuthority => {
+                "external dsh lane termination is uncorroborated while its coordination \
+                 heartbeat stays fresh"
+            }
         }
+    }
+}
+
+/// What the lane's own coordination heartbeat says about its authority.
+///
+/// The plugin releases a lane's heartbeat when it closes that lane, so the
+/// heartbeat is a second witness to the sidecar's termination claim, owned by a
+/// different process and observed through a different file. A forged stop has
+/// to stop the real heartbeat too, which is itself a loss of authority the
+/// store can see.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LaneBrokerWitness {
+    /// The heartbeat is fresh: this lane still holds coordination authority.
+    Live,
+    /// The heartbeat is absent or stale: the authority is gone.
+    Released,
+    /// The witness could not be read — no context, or no incarnation on the
+    /// record. Treated exactly like a live lane so a reader that cannot check
+    /// never widens what is provable.
+    Unread,
+}
+
+fn lane_broker_witness(context: &CliContext, record: &SessionRecord) -> LaneBrokerWitness {
+    let Ok(incarnation) = coordination::incarnation(record) else {
+        return LaneBrokerWitness::Unread;
+    };
+    if coordination::broker::heartbeat_fresh(context, &record.id, &incarnation, 0) {
+        LaneBrokerWitness::Live
+    } else {
+        LaneBrokerWitness::Released
     }
 }
 
@@ -420,7 +458,22 @@ pub(crate) enum ExternalLaneDisposition {
     Unproven(UnprovenReason),
 }
 
+/// Classify without a broker witness. Every reader that can supply one should
+/// use [`external_lane_disposition_with_broker`]: without it a lane the plugin
+/// closed stays unproven until the whole harness exits.
 pub(crate) fn external_lane_disposition(record: &SessionRecord) -> ExternalLaneDisposition {
+    lane_disposition(record, LaneBrokerWitness::Unread)
+}
+
+/// Classify with the lane's coordination heartbeat as a second witness.
+pub(crate) fn external_lane_disposition_with_broker(
+    context: &CliContext,
+    record: &SessionRecord,
+) -> ExternalLaneDisposition {
+    lane_disposition(record, lane_broker_witness(context, record))
+}
+
+fn lane_disposition(record: &SessionRecord, broker: LaneBrokerWitness) -> ExternalLaneDisposition {
     match read_liveness(record) {
         LivenessEvidence::Missing => ExternalLaneDisposition::NeverAttached,
         LivenessEvidence::Invalid => {
@@ -431,14 +484,26 @@ pub(crate) fn external_lane_disposition(record: &SessionRecord) -> ExternalLaneD
             if liveness.lane.state == "terminated" {
                 // Plugin-asserted termination, deliberately weaker than the
                 // tmux kernel-backed proof: the sidecar lives in the same-uid
-                // state dir a lane's own worker can reach. Corroborate it with
-                // the pinned harness identity — a still-running harness means
-                // the assertion is unproven, not proven.
-                return match harness {
-                    // Only a harness proven gone corroborates the assertion;
-                    // a live or undecidable harness leaves it unproven.
-                    CoordinationRuntimeStatus::Stopped => ExternalLaneDisposition::ProvenStopped,
-                    _ => ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness),
+                // state dir a lane's own worker can reach. It needs a second
+                // witness owned by a different process — either the pinned
+                // harness proven gone, or this lane's coordination heartbeat
+                // released. One of the two is enough; a lane cannot be live
+                // enough to hold coordination authority and terminated at the
+                // same time.
+                return match (harness, broker) {
+                    (CoordinationRuntimeStatus::Stopped, _) => {
+                        ExternalLaneDisposition::ProvenStopped
+                    }
+                    // The plugin releases a lane's heartbeat when it closes the
+                    // lane, so a released heartbeat corroborates the claim even
+                    // while the harness keeps serving its other lanes.
+                    (_, LaneBrokerWitness::Released) => ExternalLaneDisposition::ProvenStopped,
+                    (_, LaneBrokerWitness::Live) => ExternalLaneDisposition::Unproven(
+                        UnprovenReason::LaneRetainsCoordinationAuthority,
+                    ),
+                    (_, LaneBrokerWitness::Unread) => {
+                        ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness)
+                    }
                 };
             }
             match harness {
@@ -456,8 +521,8 @@ pub(crate) fn external_lane_disposition(record: &SessionRecord) -> ExternalLaneD
 /// attached, `stopped` when termination is proven, `running` while the lane is
 /// open under a live harness (idle lanes stay `running`; cold resume is always
 /// available), and `unknown` when liveness cannot be proven.
-pub(crate) fn external_session_status(record: &SessionRecord) -> String {
-    match external_lane_disposition(record) {
+pub(crate) fn external_session_status(context: &CliContext, record: &SessionRecord) -> String {
+    match external_lane_disposition_with_broker(context, record) {
         ExternalLaneDisposition::NeverAttached => "missing".to_string(),
         ExternalLaneDisposition::Running => "running".to_string(),
         ExternalLaneDisposition::ProvenStopped => "stopped".to_string(),
@@ -702,13 +767,19 @@ mod tests {
     fn lane_disposition_requires_positive_evidence() {
         let scratch = tempfile::TempDir::new().expect("tempdir");
         let record = external_record(scratch.path(), "launch-1");
+        // This lane never writes a heartbeat, so the broker witness is
+        // `Released` throughout: every case below turns on sidecar evidence.
+        let context = CliContext {
+            state_dir: scratch.path().to_path_buf(),
+            host: None,
+        };
 
         // No sidecar: the runtime never attached.
         assert_eq!(
             external_lane_disposition(&record),
             ExternalLaneDisposition::NeverAttached
         );
-        assert_eq!(external_session_status(&record), "missing");
+        assert_eq!(external_session_status(&context, &record), "missing");
 
         // Malformed, schema-mismatched, and launch-mismatched sidecars are all
         // unproven, never a quiet absence.
@@ -735,7 +806,7 @@ mod tests {
                 ExternalLaneDisposition::Unproven(UnprovenReason::InvalidEvidence),
                 "invalid evidence must stay unproven: {body}"
             );
-            assert_eq!(external_session_status(&record), "unknown");
+            assert_eq!(external_session_status(&context, &record), "unknown");
             assert!(external_runtime_evidence(&record).is_err());
             assert!(external_turn_state(&record).is_none());
         }
@@ -774,7 +845,7 @@ mod tests {
             external_lane_disposition(&record),
             ExternalLaneDisposition::ProvenStopped
         );
-        assert_eq!(external_session_status(&record), "stopped");
+        assert_eq!(external_session_status(&context, &record), "stopped");
 
         // A terminated lane whose harness is still live is an uncorroborated
         // plugin assertion, not a proof.
@@ -792,7 +863,82 @@ mod tests {
         assert_eq!(
             external_lane_disposition(&record),
             ExternalLaneDisposition::Unproven(UnprovenReason::UndecidableHarness),
-            "only a harness proven gone corroborates plugin-asserted termination"
+            "a context-free reader has no broker witness, so a live harness leaves \
+             plugin-asserted termination unproven"
+        );
+    }
+
+    /// Write the lane's broker heartbeat with a current epoch, the way the
+    /// lane's own heartbeat process does while it holds authority.
+    fn write_lane_heartbeat(context: &CliContext, record: &SessionRecord, incarnation: &str) {
+        let path =
+            nils_common::coordination_projection::heartbeat_path(&context.state_dir, &record.id);
+        fs::create_dir_all(path.parent().expect("coordination parent")).expect("coordination dir");
+        fs::write(
+            &path,
+            format!("{incarnation}:{}", coordination::now_epoch()),
+        )
+        .expect("write heartbeat");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).expect("heartbeat mode");
+    }
+
+    /// The lane's own coordination heartbeat is the second witness to a
+    /// plugin-asserted termination: the plugin releases it when it closes the
+    /// lane, so a forged stop has to give up the lane's coordination authority
+    /// too — which the store observes independently of the sidecar.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_released_lane_heartbeat_corroborates_plugin_asserted_termination() {
+        let scratch = tempfile::TempDir::new().expect("tempdir");
+        let record = external_record(scratch.path(), "launch-1");
+        let context = CliContext {
+            state_dir: scratch.path().to_path_buf(),
+            host: None,
+        };
+        write_sidecar(
+            &record,
+            &json!({
+                "schema_version": LIVENESS_SCHEMA,
+                "launch_id": "launch-1",
+                "harness": pinned_harness(),
+                "lane": { "state": "terminated" }
+            })
+            .to_string(),
+            0o600,
+        );
+
+        // This harness is this test process, so it is provably alive. The lane
+        // heartbeat is gone, so the assertion is corroborated anyway and the
+        // destructive routes open.
+        assert!(
+            external_lane_terminal_is_proven(&context, &record, "launch-1"),
+            "a released lane heartbeat corroborates plugin-asserted termination"
+        );
+        assert_eq!(
+            external_lane_disposition_with_broker(&context, &record),
+            ExternalLaneDisposition::ProvenStopped
+        );
+        assert_eq!(external_session_status(&context, &record), "stopped");
+
+        // A lane still beating holds coordination authority: nothing is proven,
+        // the reason names the retained authority rather than the harness, and
+        // the destructive routes stay closed.
+        write_lane_heartbeat(&context, &record, "launch-1");
+        assert_eq!(
+            external_lane_disposition_with_broker(&context, &record),
+            ExternalLaneDisposition::Unproven(UnprovenReason::LaneRetainsCoordinationAuthority)
+        );
+        assert_eq!(external_session_status(&context, &record), "unknown");
+        assert!(
+            !external_lane_terminal_is_proven(&context, &record, "launch-1"),
+            "a lane that still holds coordination authority is not proven stopped"
+        );
+
+        // A heartbeat for a different incarnation is not this lane's authority.
+        write_lane_heartbeat(&context, &record, "launch-2");
+        assert_eq!(
+            external_lane_disposition_with_broker(&context, &record),
+            ExternalLaneDisposition::ProvenStopped
         );
     }
 

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -2187,7 +2187,7 @@ fn start_session_with_create_guard(
             provider_resume_persistence,
         )?;
     }
-    let status = session_status(&tmux_bin, &created.record);
+    let status = session_status(context, &tmux_bin, &created.record);
     if prompt_delivery_error.is_none() {
         reconcile_owned_startup_projection(context, &mut created.record, &status);
     }
@@ -2494,7 +2494,7 @@ pub(crate) fn start_provider_resume_session(
     }
     advance_owned_startup_stage(context, &mut created.record, "runtime")?;
 
-    let status = session_status(&tmux_bin, &created.record);
+    let status = session_status(context, &tmux_bin, &created.record);
     reconcile_owned_startup_projection(context, &mut created.record, &status);
     let result = session_view(context, &created.record, Some(status), Some(&tmux_bin));
     record_workdir_usage(context, &cwd);
@@ -9282,7 +9282,7 @@ fn read_send_text(text: &Option<String>, text_stdin: bool) -> Result<Option<Stri
 fn glance_session(context: &CliContext, args: cli::GlanceArgs) -> Result<GlanceResult, CliError> {
     let mut record = load_session_record(context, &args.id)?;
     let tmux_bin = resolve_tmux_bin(args.tmux_bin.as_deref());
-    let status = session_status(&tmux_bin, &record);
+    let status = session_status(context, &tmux_bin, &record);
     let (reconciled, status) = reconcile_startup_projection(context, record, status, None);
     record = reconciled;
     if status != "running" {
@@ -9541,7 +9541,7 @@ fn update_session_title_if_revision(
             Ok((record.clone(), previous_title))
         },
     )?;
-    let status = session_status(tmux_bin, &record);
+    let status = session_status(context, tmux_bin, &record);
     // The persisted record above is the source of truth. Claude also carries its
     // own prompt-bar display name, which we set once via `--name` at launch
     // (`start_interactive_tmux`) and which never changes afterwards, so a renamed
@@ -9718,7 +9718,7 @@ fn resume_session_locked(
     tmux_bin: &Path,
 ) -> Result<ResumeSessionOutcome, CliError> {
     orchestration::ensure_session_not_quarantined(context, &record)?;
-    match session_status(tmux_bin, &record).as_str() {
+    match session_status(context, tmux_bin, &record).as_str() {
         "running" => {
             return Ok(ResumeSessionOutcome {
                 session: session_view(
@@ -10889,8 +10889,12 @@ fn list_sessions_with_shadow_sampling(
                 )?;
                 let record = read_session_record(&resolved.record_path)?;
                 validate_record_id(&record, &resolved.expected_id, &resolved.record_path)?;
-                let (status, observed_last_terminal_activity_at) =
-                    session_list_runtime_snapshot(&tmux_bin, tmux_snapshots.as_ref(), &record);
+                let (status, observed_last_terminal_activity_at) = session_list_runtime_snapshot(
+                    context,
+                    &tmux_bin,
+                    tmux_snapshots.as_ref(),
+                    &record,
+                );
                 let observed_status = status.clone();
                 let (record, status) = reconcile_startup_projection(
                     context,
@@ -10939,7 +10943,7 @@ fn load_session_view(
     let tmux_bin = tmux_bin
         .map(Path::to_path_buf)
         .unwrap_or_else(|| resolve_tmux_bin(None));
-    let status = session_status(&tmux_bin, &record);
+    let status = session_status(context, &tmux_bin, &record);
     let (reconciled, status) = reconcile_startup_projection(context, record, status, None);
     record = reconciled;
     if status != "running" {
@@ -11601,7 +11605,7 @@ fn session_view(
             &fallback_tmux
         }
     };
-    let status = forced_status.unwrap_or_else(|| session_status(tmux_bin, record));
+    let status = forced_status.unwrap_or_else(|| session_status(context, tmux_bin, record));
     let last_terminal_activity_at = last_terminal_activity_at(tmux_bin, record, &status);
     session_view_from_parts(
         context,
@@ -11867,6 +11871,7 @@ impl TmuxSessionSnapshots {
 }
 
 fn session_list_runtime_snapshot(
+    context: &CliContext,
     tmux_bin: &Path,
     tmux_snapshots: Option<&TmuxSessionSnapshots>,
     record: &SessionRecord,
@@ -11876,7 +11881,7 @@ fn session_list_runtime_snapshot(
     // projections agree with single-record status instead of reporting every
     // live dsh lane as stopped.
     if dsh_external::is_external_record(record) {
-        return (dsh_external::external_session_status(record), None);
+        return (dsh_external::external_session_status(context, record), None);
     }
     match tmux_snapshots {
         Some(snapshots) => match snapshots.sessions.get(&record.tmux_session) {
@@ -11886,7 +11891,7 @@ fn session_list_runtime_snapshot(
             ),
             None => ("stopped".to_string(), None),
         },
-        None => (session_status(tmux_bin, record), None),
+        None => (session_status(context, tmux_bin, record), None),
     }
 }
 
@@ -12165,7 +12170,7 @@ fn delete_session_locked_with_timeouts(
         // plugin first, and unproven liveness fails closed the same way an
         // unavailable tmux runtime identity does — a corrupted sidecar must
         // never authorize destroying a live lane's record.
-        match dsh_external::external_lane_disposition(&record) {
+        match dsh_external::external_lane_disposition_with_broker(context, &record) {
             dsh_external::ExternalLaneDisposition::Running => {
                 return Err(session_termination_error(
                     &record,
@@ -12223,7 +12228,7 @@ fn delete_session_locked_after_failed_canary_proof(
     tmux_bin: &Path,
     proof: ProviderStopCanaryFailedStartupQuiescenceProof,
 ) -> Result<DeleteResult, CliError> {
-    if !proof.matches(&record) || session_status(tmux_bin, &record) != "stopped" {
+    if !proof.matches(&record) || session_status(context, tmux_bin, &record) != "stopped" {
         return Err(session_termination_error(
             &record,
             SessionTerminationFailure::StillRunning,
@@ -15833,9 +15838,9 @@ fn managed_tmux_pane_target(tmux_session: &str) -> String {
     format!("={tmux_session}:0.0")
 }
 
-fn session_status(tmux_bin: &Path, record: &SessionRecord) -> String {
+fn session_status(context: &CliContext, tmux_bin: &Path, record: &SessionRecord) -> String {
     if dsh_external::is_external_record(record) {
-        return dsh_external::external_session_status(record);
+        return dsh_external::external_session_status(context, record);
     }
     live_status(tmux_bin, &record.tmux_session)
 }

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -3910,7 +3910,7 @@ fn run_worker_start_single_input(
     let (worker_record, mut worker_status, mut launch_observation) = if let Some(worker) = existing
     {
         ensure_worker_launch_matches(context, &worker, &launch_input, &replay_prompts)?;
-        let status = session_status(&resolve_tmux_bin(None), &worker);
+        let status = session_status(context, &resolve_tmux_bin(None), &worker);
         (worker, status, None)
     } else {
         let mut create_guard = || {
@@ -4785,7 +4785,8 @@ fn run_worker_start_single_input(
                         Some(&expected_worker),
                     )?;
                     locked.save()?;
-                    worker_status = session_status(&resolve_tmux_bin(None), &worker_record);
+                    worker_status =
+                        session_status(context, &resolve_tmux_bin(None), &worker_record);
                     Ok(CanaryReplayAction::Continue)
                 }
                 Err(error) if error.code() == "managed-worker-prompt-delivery-outcome-unknown" => {
@@ -9418,7 +9419,9 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
                 Some(turn_state) if turn_state.phase != crate::activity::TurnPhase::Unknown => {
                     DiagnosticEvidence::Present(turn_state)
                 }
-                _ => match crate::dsh_external::external_lane_disposition(record) {
+                _ => match crate::dsh_external::external_lane_disposition_with_broker(
+                    context, record,
+                ) {
                     crate::dsh_external::ExternalLaneDisposition::NeverAttached => {
                         DiagnosticEvidence::Absent("worker-lane-never-attached")
                     }
@@ -9497,7 +9500,7 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     };
     let worker_status = session_evidence
         .value()
-        .map(|record| session_status(&resolve_tmux_bin(None), record))
+        .map(|record| session_status(context, &resolve_tmux_bin(None), record))
         .unwrap_or_else(|| "missing".to_string());
     let claim_active = coordination_evidence
         .value()
@@ -9688,6 +9691,9 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
     let preclaim_blocker = assignment_has_preclaim_blocker(&assignment);
     let terminal_recovery_reconciled =
         terminal_recovery_recorded && worker_status == "stopped" && assignment.worker.is_some();
+    // `NeverAttached` is decided by the absence of a sidecar alone, so the
+    // broker witness cannot change this answer; the context-free reader is the
+    // exact question being asked.
     let runtime_never_attached = session_evidence.value().is_some_and(|record| {
         crate::dsh_external::is_external_record(record)
             && crate::dsh_external::external_lane_disposition(record)
@@ -12201,7 +12207,7 @@ fn run_worker_cancel(context: &CliContext, args: WorkerCancelArgs) -> Result<Val
                 );
             if (runtime_evidence.status != crate::CoordinationRuntimeStatus::Stopped
                 && !exact_failed_canary_quiescent)
-                || session_status(&resolve_tmux_bin(None), &worker_record) != "stopped"
+                || session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped"
             {
                 return Err(CliError::data(
                     "worker-runtime-still-live",
@@ -12605,7 +12611,7 @@ fn run_worker_reconcile_stopped(
                 ));
             }
         }
-        if session_status(&resolve_tmux_bin(None), &worker_record) != "stopped" {
+        if session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped" {
             return Err(CliError::data(
                 "worker-runtime-still-live",
                 "the assignment cannot be terminalized while the exact worker runtime can still act",
@@ -12801,7 +12807,7 @@ fn run_worker_reconcile_stopped(
         }
     }
     if runtime_evidence.identity_digest != progress.runtime_identity_digest
-        || session_status(&resolve_tmux_bin(None), &worker_record) != "stopped"
+        || session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped"
     {
         return Err(CliError::data(
             "worker-runtime-still-live",
@@ -14135,7 +14141,7 @@ fn run_worker_provider_stop_canary(
         current_provider_stop_canary_live_evidence(context, &worker_record, &assignment, &packet)?
     };
     if !release_replay_stopped
-        && session_status(&resolve_tmux_bin(None), &worker_record) != "running"
+        && session_status(context, &resolve_tmux_bin(None), &worker_record) != "running"
     {
         return Err(CliError::data(
             "provider-stop-canary-wrapper-not-live",
@@ -14505,7 +14511,7 @@ fn run_worker_provider_stop_canary(
         if release {
             let runtime = crate::coordination_runtime_evidence(&worker_record)?;
             if runtime.status == crate::CoordinationRuntimeStatus::Stopped
-                && session_status(&resolve_tmux_bin(None), &worker_record) == "stopped"
+                && session_status(context, &resolve_tmux_bin(None), &worker_record) == "stopped"
             {
                 break;
             }
@@ -14516,7 +14522,8 @@ fn run_worker_provider_stop_canary(
             &reservation.idempotency_key,
             reservation.child_pid,
             reservation.child_start_ticks,
-        )? && session_status(&resolve_tmux_bin(None), &worker_record) == "running"
+        )? && session_status(context, &resolve_tmux_bin(None), &worker_record)
+            == "running"
         {
             crate::record_provider_stop_canary_proof(
                 context,
@@ -15098,7 +15105,7 @@ fn run_worker_stop_claimed_runtime(
     let _activity_lock =
         crate::activity::acquire_coordination_activity_lock(context, &worker_record.id)?;
     let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
-    let tmux_status = session_status(&resolve_tmux_bin(None), &worker_record);
+    let tmux_status = session_status(context, &resolve_tmux_bin(None), &worker_record);
     // An interrupted stop can leave a stale tmux wrapper visible after the
     // exact recorded process identity is durably stopped. The receipt plus the
     // session-owned fence makes that state attributable to this operation, so
@@ -15670,7 +15677,7 @@ fn ensure_external_lane_deletable(
     let Some((record, incarnation)) = external_lane_worker_record(context, assignment_id)? else {
         return Ok(());
     };
-    match crate::dsh_external::external_lane_disposition(&record) {
+    match crate::dsh_external::external_lane_disposition_with_broker(context, &record) {
         crate::dsh_external::ExternalLaneDisposition::NeverAttached
         | crate::dsh_external::ExternalLaneDisposition::ProvenStopped
             if crate::dsh_external::external_lane_terminal_is_proven(
@@ -15937,7 +15944,7 @@ fn run_worker_stop_runtime(
         ));
     }
     let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
-    let tmux_status = session_status(&resolve_tmux_bin(None), &worker_record);
+    let tmux_status = session_status(context, &resolve_tmux_bin(None), &worker_record);
     let runtime_ready = if resumed {
         matches!(
             runtime_evidence.status,
@@ -16645,7 +16652,7 @@ fn run_worker_reconcile_recovery(
             ));
         }
     }
-    if session_status(&resolve_tmux_bin(None), &worker_record) != "stopped" {
+    if session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped" {
         return Err(CliError::data(
             "submit-recovery-runtime-still-live",
             "recovery cannot be terminalized while the exact worker runtime can still act",
@@ -19520,7 +19527,7 @@ fn verify_worker_reenter_runtime(
     }
     if worker_record.agent != AgentKind::Codex.as_str()
         || worker_record.coordination_mode == CoordinationMode::Off
-        || session_status(&resolve_tmux_bin(None), &worker_record) != "running"
+        || session_status(context, &resolve_tmux_bin(None), &worker_record) != "running"
     {
         return Err(CliError::data(
             "worker-reentry-runtime-not-ready",
@@ -20750,7 +20757,7 @@ fn prepare_orphan_provider_stop_canary_adoption(
     }
     let runtime = crate::coordination_runtime_evidence(&worker_record)?;
     if runtime.status != crate::CoordinationRuntimeStatus::Stopped
-        || session_status(&resolve_tmux_bin(None), &worker_record) != "stopped"
+        || session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped"
     {
         return Err(CliError::unavailable(
             "provider-stop-canary-orphan-not-quiescent",

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -809,7 +809,7 @@ fn execute_inner(
             // second, ungated way to destroy a running lane's durable state.
             if crate::dsh_external::is_external_record(&record) {
                 let incarnation = crate::coordination::incarnation(&record)?;
-                match crate::dsh_external::external_lane_disposition(&record) {
+                match crate::dsh_external::external_lane_disposition_with_broker(context, &record) {
                     crate::dsh_external::ExternalLaneDisposition::NeverAttached
                     | crate::dsh_external::ExternalLaneDisposition::ProvenStopped
                         if crate::dsh_external::external_lane_terminal_is_proven(

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -6429,7 +6429,7 @@ async fn attach_handler(
         let tmux = tmux.clone();
         move || {
             let record = load_session_record(&context, &id)?;
-            let status = session_status(&tmux, &record);
+            let status = session_status(&context, &tmux, &record);
             Ok::<_, CliError>((record, status))
         }
     })

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38901,8 +38901,12 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         "a refused worker delete must not mutate the assignment"
     );
 
-    // A terminated lane whose harness is still live is only a plugin
-    // assertion, so it stays unproven and refuses deletion.
+    // A terminated lane whose harness is still live needs its second witness.
+    // While the lane's own coordination heartbeat stays fresh it still holds
+    // the authority a stopped lane gives up, so the assertion is uncorroborated
+    // and deletion refuses. The sidecar sits in a directory the lane's own
+    // worker can write, so this is the check that stops a live lane from
+    // terminalizing its own record.
     let uncorroborated = json!({
         "schema_version": "main-agent.dsh-runtime-liveness.v1",
         "launch_id": launch_id,
@@ -38910,6 +38914,17 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         "lane": { "state": "terminated" }
     });
     write_sidecar(&uncorroborated.to_string());
+    let heartbeat_path = state_dir.join("sessions/worker-dsh/coordination/heartbeat");
+    let now_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("epoch")
+        .as_secs();
+    let write_lane_heartbeat = || {
+        fs::write(&heartbeat_path, format!("{launch_id}:{now_epoch}")).expect("heartbeat");
+        fs::set_permissions(&heartbeat_path, fs::Permissions::from_mode(0o600))
+            .expect("heartbeat mode");
+    };
+    write_lane_heartbeat();
     let refused_uncorroborated = run_resolved(
         "agent-session",
         &[
@@ -38925,14 +38940,19 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
     assert_ne!(
         refused_uncorroborated.code,
         0,
-        "a live harness leaves plugin-asserted termination unproven: {}",
+        "a lane that still holds coordination authority is not proven stopped: {}",
+        refused_uncorroborated.stdout_text()
+    );
+    assert_eq!(
+        refused_uncorroborated.stdout_json()["error"]["code"],
+        "coordination-runtime-unverified",
+        "outcome={}",
         refused_uncorroborated.stdout_text()
     );
 
     // A terminated lane whose harness is proven gone deletes — but only once
-    // its coordination heartbeat is gone too. The sidecar sits in a directory
-    // the lane's own worker can write, so a lane still holding coordination
-    // authority must not be able to terminalize its own record.
+    // its coordination heartbeat is gone too, which is the same rule read
+    // through the other witness.
     let terminated_sidecar = json!({
         "schema_version": "main-agent.dsh-runtime-liveness.v1",
         "launch_id": launch_id,
@@ -38940,14 +38960,7 @@ fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux
         "lane": { "state": "terminated" }
     });
     write_sidecar(&terminated_sidecar.to_string());
-    let heartbeat_path = state_dir.join("sessions/worker-dsh/coordination/heartbeat");
-    let now_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("epoch")
-        .as_secs();
-    fs::write(&heartbeat_path, format!("{launch_id}:{now_epoch}")).expect("heartbeat");
-    fs::set_permissions(&heartbeat_path, fs::Permissions::from_mode(0o600))
-        .expect("heartbeat mode");
+    write_lane_heartbeat();
     let refused_live_heartbeat = run_resolved(
         "agent-session",
         &[


### PR DESCRIPTION
## Summary

A dsh lane closed while its harness keeps running had no terminal proof: the
sidecar's `terminated` claim could only be corroborated by the pinned harness
proven gone, so `worker reconcile-stopped` and record deletion stayed refused
until the whole DSH process exited — even while the run's other lanes were still
working. This accepts the lane's own coordination heartbeat as a second witness:
the plugin releases it when it closes that lane, so a released heartbeat proves
the stop while the harness lives, and a lane still beating stays unproven because
it holds the authority a stopped lane gives up.

## Issues

Refs sympoies/dsh-runtime-kit#8

## Changes

- `dsh_external`: the lane classifier now takes an explicit broker witness
  (`Live`, `Released`, `Unread`). A `terminated` sidecar is proven by either
  witness — harness proven gone, or this lane's heartbeat absent or stale — and a
  fresh heartbeat yields the new `LaneRetainsCoordinationAuthority` unproven
  reason instead of an undecidable-harness one.
- `Unread` is the conservative default: a reader with no state context is treated
  exactly like a lane that still holds authority, so a reader that cannot check
  never widens what is provable.
- Every context-bearing reader passes the witness: `agent-session delete`, the
  `remove-console-record` maintenance action, `ensure_external_lane_deletable`,
  diagnose's activity classification, and `session_status`. `session_status` and
  the session-list runtime projection gained the state context that required.
- The never-attached probe keeps the context-free reader deliberately, with a
  comment: an absent sidecar answers that question by itself.
- Spec: the disposition table, the `terminated`-corroboration rule, and the
  unproven-lane closeout now describe both witnesses.

## Test-First Evidence

- Classification `behavior-change`, baseline bound at `695ccb85`.
- Failing baseline first: the new unit test asserts a plugin-closed lane with no
  live heartbeat is proven stopped, and it panics on the pre-change tree
  (`a released lane heartbeat corroborates plugin-asserted termination`).
- The same test pins the other side: a fresh heartbeat for this incarnation
  refuses the stop with the new typed reason, and a heartbeat minted for a
  different incarnation is not this lane's authority.
- The dsh launch-contract integration test previously asserted the old
  harness-only rule; it now writes a live lane heartbeat for that case, so it
  still pins the refusal — and its typed code — for the reason that survives.
- No residual gaps recorded.

## Test plan

- `cargo test -p nils-agent-session` — 868 lib, 294 integration, 4 cli_contract,
  all green.
- `cargo fmt --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `rumdl check` on the updated spec — clean.

## Risk / Notes

- This lowers the bar for destructive routes on one specific shape: a sidecar
  that says `terminated` plus a heartbeat that stopped. A forged stop therefore
  needs the lane's own heartbeat to stop as well, which is a real loss of
  coordination authority the store observes independently — but it is one witness
  rather than two, and coordination remains a same-uid boundary, not an OS one.
- An open lane is unaffected: only the pinned harness can prove that one stopped.
- A lane whose heartbeat dies while the lane keeps running would now read
  `stopped` if its sidecar also said `terminated`. A sidecar that still says
  `open` keeps reading `unknown`, and heartbeat death is already surfaced by
  `worker diagnose` as a stale broker.
