### PR TITLE
fix(agent-session): witness the broker in dsh runtime evidence

### DIFF
--- a/crates/agent-session/src/coordination/broker.rs
+++ b/crates/agent-session/src/coordination/broker.rs
@@ -140,7 +140,7 @@ pub(crate) fn provision(context: &CliContext, record: &SessionRecord) -> Result<
     crate::orchestration::ensure_session_not_quarantined(context, record)?;
     prepare(context, record)?;
     let incarnation = incarnation(record)?;
-    let runtime = crate::coordination_runtime_evidence(record).ok();
+    let runtime = crate::coordination_runtime_evidence(context, record).ok();
     let generation = record
         .runtime
         .as_ref()
@@ -342,7 +342,7 @@ pub(crate) fn provision(context: &CliContext, record: &SessionRecord) -> Result<
 
 pub(crate) fn activate_ready(context: &CliContext, record: &SessionRecord) -> Result<(), CliError> {
     let incarnation = incarnation(record)?;
-    let _runtime = crate::coordination_runtime_evidence(record)?;
+    let _runtime = crate::coordination_runtime_evidence(context, record)?;
     let started = Instant::now();
     while !heartbeat_fresh(context, &record.id, &incarnation, 0) {
         if started.elapsed() >= Duration::from_secs(2) {
@@ -782,7 +782,7 @@ pub(crate) fn recover(
             ));
         }
     }
-    let runtime = crate::coordination_runtime_evidence(&record)?;
+    let runtime = crate::coordination_runtime_evidence(context, &record)?;
     if runtime.status != crate::CoordinationRuntimeStatus::Running {
         return Err(CliError::runtime(
             "coordination-runtime-unverified",
@@ -893,7 +893,7 @@ pub(crate) fn recover(
         }
         thread::sleep(Duration::from_millis(20));
     }
-    let runtime = crate::coordination_runtime_evidence(&record)?;
+    let runtime = crate::coordination_runtime_evidence(context, &record)?;
     if runtime.status != crate::CoordinationRuntimeStatus::Running
         || runtime.identity_digest != broker_snapshot.runtime_identity_digest
     {
@@ -1064,7 +1064,7 @@ pub(crate) fn run_heartbeat_sidecar(
             break;
         }
         established_owner = true;
-        match crate::coordination_runtime_evidence(&record) {
+        match crate::coordination_runtime_evidence(context, &record) {
             Ok(runtime) if runtime.status == crate::CoordinationRuntimeStatus::Running => {}
             Ok(runtime)
                 if runtime.status == crate::CoordinationRuntimeStatus::Stopped

--- a/crates/agent-session/src/coordination/claims.rs
+++ b/crates/agent-session/src/coordination/claims.rs
@@ -1276,7 +1276,7 @@ pub(crate) fn admit(context: &CliContext, args: WorkContextAdmitArgs) -> Result<
             None,
         ));
     }
-    let runtime = crate::coordination_runtime_evidence(&record)?;
+    let runtime = crate::coordination_runtime_evidence(context, &record)?;
     if runtime.status != crate::CoordinationRuntimeStatus::Running {
         return Err(CliError::runtime(
             "coordination-unavailable",
@@ -1653,7 +1653,7 @@ pub(crate) fn reconcile(
     ) {
         return Err(revision_conflict("operation-revision-conflict"));
     }
-    let runtime = crate::coordination_runtime_evidence(&record)?;
+    let runtime = crate::coordination_runtime_evidence(context, &record)?;
     if runtime.identity_digest != lease_snapshot.runtime_identity_digest
         || runtime.status == crate::CoordinationRuntimeStatus::Unknown
     {
@@ -2388,7 +2388,7 @@ pub(crate) fn operator_reconcile_evidence(
     record: &crate::SessionRecord,
     snapshot: &OperationLease,
 ) -> Result<OperatorReconcileEvidence, CliError> {
-    let runtime = crate::coordination_runtime_evidence(record)?;
+    let runtime = crate::coordination_runtime_evidence(context, record)?;
     let activity = crate::activity::state_for_view(context, record);
     Ok(OperatorReconcileEvidence {
         runtime_identity_matches: !snapshot.runtime_identity_digest.is_empty()

--- a/crates/agent-session/src/coordination/mod.rs
+++ b/crates/agent-session/src/coordination/mod.rs
@@ -2577,7 +2577,7 @@ fn lock_registry_with_maintenance(
                 continue;
             };
             let runtime_matches =
-                crate::coordination_runtime_evidence(&record).is_ok_and(|runtime| {
+                crate::coordination_runtime_evidence(context, &record).is_ok_and(|runtime| {
                     runtime.status == crate::CoordinationRuntimeStatus::Running
                         && runtime.identity_digest == lease.runtime_identity_digest
                 });

--- a/crates/agent-session/src/coordination/server.rs
+++ b/crates/agent-session/src/coordination/server.rs
@@ -654,7 +654,7 @@ pub(crate) fn operator_reconcile_provider_turn(
     )? {
         return Ok(replay);
     }
-    let runtime_evidence = crate::coordination_runtime_evidence(&record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &record)?;
     if runtime_evidence.status != crate::CoordinationRuntimeStatus::Running {
         return Err(CliError::data(
             "operator-provider-turn-reconcile-runtime-conflict",

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -579,6 +579,7 @@ pub(crate) fn external_turn_state(record: &SessionRecord) -> Option<crate::activ
 /// the sidecar's launch-bound harness identity; missing or invalid sidecars
 /// fail with the same typed error as an unavailable tmux runtime identity.
 pub(crate) fn external_runtime_evidence(
+    context: &CliContext,
     record: &SessionRecord,
 ) -> Result<CoordinationRuntimeEvidence, CliError> {
     let liveness = match read_liveness(record) {
@@ -616,8 +617,11 @@ pub(crate) fn external_runtime_evidence(
     })?;
     // One function owns the corroboration rule. Deriving the status here from
     // the disposition keeps this evidence and the destructive-operation gate
-    // from disagreeing about what a plugin-asserted termination proves.
-    let status = match external_lane_disposition(record) {
+    // from disagreeing about what a plugin-asserted termination proves — which
+    // is why it must read the *same* disposition, broker witness included. With
+    // the context-free reader here, `worker reconcile-stopped` refused a lane
+    // that `agent-session delete` and `session_status` already called stopped.
+    let status = match external_lane_disposition_with_broker(context, record) {
         ExternalLaneDisposition::Running => CoordinationRuntimeStatus::Running,
         ExternalLaneDisposition::ProvenStopped => CoordinationRuntimeStatus::Stopped,
         ExternalLaneDisposition::NeverAttached | ExternalLaneDisposition::Unproven(_) => {
@@ -813,7 +817,7 @@ mod tests {
                 "invalid evidence must stay unproven: {body}"
             );
             assert_eq!(external_session_status(&context, &record), "unknown");
-            assert!(external_runtime_evidence(&record).is_err());
+            assert!(external_runtime_evidence(&context, &record).is_err());
             assert!(external_turn_state(&record).is_none());
         }
 
@@ -929,6 +933,16 @@ mod tests {
             ExternalLaneDisposition::ProvenStopped
         );
         assert_eq!(external_session_status(&context, &record), "stopped");
+        // Runtime evidence must agree with the projection and the destructive
+        // gate. It is the input `worker reconcile-stopped` reads, and while it
+        // classified from the context-free disposition it reported `Unknown`
+        // here — so a lane `delete` would terminalize refused to reconcile.
+        assert_eq!(
+            external_runtime_evidence(&context, &record)
+                .expect("runtime evidence")
+                .status,
+            CoordinationRuntimeStatus::Stopped
+        );
 
         // A lane still beating holds coordination authority: nothing is proven,
         // the reason names the retained authority rather than the harness, and
@@ -942,6 +956,13 @@ mod tests {
         assert!(
             !external_lane_terminal_is_proven(&context, &record, "launch-1"),
             "a lane that still holds coordination authority is not proven stopped"
+        );
+        assert_eq!(
+            external_runtime_evidence(&context, &record)
+                .expect("runtime evidence")
+                .status,
+            CoordinationRuntimeStatus::Unknown,
+            "reconcile-stopped must refuse a lane that still holds authority"
         );
 
         // A heartbeat for a different incarnation is not this lane's authority.

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -13849,10 +13849,11 @@ pub(crate) struct CoordinationRuntimeEvidence {
 }
 
 pub(crate) fn coordination_runtime_evidence(
+    context: &CliContext,
     record: &SessionRecord,
 ) -> Result<CoordinationRuntimeEvidence, CliError> {
     if dsh_external::is_external_record(record) {
-        return dsh_external::external_runtime_evidence(record);
+        return dsh_external::external_runtime_evidence(context, record);
     }
     let identity = persisted_tmux_runtime_identity(record)
         .map_err(|_| {

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -2200,7 +2200,7 @@ fn run_controller_recover(
             None,
         ));
     }
-    let mut runtime = crate::coordination_runtime_evidence(&record)?;
+    let mut runtime = crate::coordination_runtime_evidence(context, &record)?;
     #[cfg(debug_assertions)]
     match env::var("NILS_AGENT_SESSION_TEST_CONTROLLER_RUNTIME_STATUS").as_deref() {
         Ok("stopped") => runtime.status = crate::CoordinationRuntimeStatus::Stopped,
@@ -2765,7 +2765,7 @@ fn await_worker_start_bootstrap_handshake(
     };
     let runtime_identity_digest = format!(
         "sha256:{}",
-        crate::coordination_runtime_evidence(record)?.identity_digest
+        crate::coordination_runtime_evidence(context, record)?.identity_digest
     );
     let quarantine_matches = orchestration::session_authority_quarantine_matches(
         context,
@@ -3972,7 +3972,7 @@ fn run_worker_start_single_input(
                 let expected_worker = session_ref(context, worker, worker_incarnation);
                 let runtime_identity_digest = format!(
                     "sha256:{}",
-                    crate::coordination_runtime_evidence(worker)?.identity_digest
+                    crate::coordination_runtime_evidence(context, worker)?.identity_digest
                 );
                 orchestration::persist_session_authority_quarantine(
                     context,
@@ -4965,7 +4965,7 @@ fn run_worker_start_single_input(
                 pause_canary_authority_release_for_test()?;
                 let runtime_identity_digest = format!(
                     "sha256:{}",
-                    crate::coordination_runtime_evidence(&worker_record)?.identity_digest
+                    crate::coordination_runtime_evidence(context, &worker_record)?.identity_digest
                 );
                 if let Err(error) = orchestration::clear_matching_session_authority_quarantine(
                     context,
@@ -5472,7 +5472,7 @@ fn finish_retained_worker_start_fence_for_outcome(
         }
         let runtime_identity_digest = format!(
             "sha256:{}",
-            crate::coordination_runtime_evidence(&worker_record)?.identity_digest
+            crate::coordination_runtime_evidence(context, &worker_record)?.identity_digest
         );
         orchestration::clear_matching_session_authority_quarantine(
             context,
@@ -9668,7 +9668,7 @@ fn diagnose_worker(context: &CliContext, assignment_id: &str) -> Result<Value, C
         assignment.worker.is_some() && matches!(&session_evidence, DiagnosticEvidence::Absent(_));
     let durable_runtime_status = session_evidence
         .value()
-        .and_then(|record| crate::coordination_runtime_evidence(record).ok())
+        .and_then(|record| crate::coordination_runtime_evidence(context, record).ok())
         .map(|evidence| evidence.status);
     let stopped_runtime_unverified = !cfg!(target_os = "linux")
         && assignment.worker.is_some()
@@ -12199,7 +12199,7 @@ fn run_worker_cancel(context: &CliContext, args: WorkerCancelArgs) -> Result<Val
                 ));
             }
         } else {
-            let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+            let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
             let exact_failed_canary_quiescent = preclaim_runtime_gone
                 && crate::provider_stop_canary_failed_startup_runtime_quiescent(
                     &worker_record,
@@ -12593,7 +12593,7 @@ fn run_worker_reconcile_stopped(
                 None,
             ));
         }
-        let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+        let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
         match runtime_evidence.status {
             crate::CoordinationRuntimeStatus::Stopped => {}
             crate::CoordinationRuntimeStatus::Running => {
@@ -12788,7 +12788,7 @@ fn run_worker_reconcile_stopped(
             None,
         ));
     }
-    let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     match runtime_evidence.status {
         crate::CoordinationRuntimeStatus::Stopped => {}
         crate::CoordinationRuntimeStatus::Running => {
@@ -13155,7 +13155,7 @@ fn current_authoritative_idle_live_evidence(
             None,
         )
     })?;
-    let runtime_evidence = crate::coordination_runtime_evidence(worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, worker_record)?;
     match runtime_evidence.status {
         crate::CoordinationRuntimeStatus::Running => {
             Ok((activity.revision, runtime_evidence.identity_digest))
@@ -13255,7 +13255,7 @@ fn current_provider_stop_canary_live_evidence(
             None,
         )
     })?;
-    let runtime_evidence = crate::coordination_runtime_evidence(worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, worker_record)?;
     match runtime_evidence.status {
         crate::CoordinationRuntimeStatus::Running => {
             Ok((activity.revision, runtime_evidence.identity_digest))
@@ -14115,7 +14115,7 @@ fn run_worker_provider_stop_canary(
                 && reservation.release_idempotency_key.as_deref()
                     == Some(args.idempotency_key.as_str())
         })
-        && crate::coordination_runtime_evidence(&worker_record)?.status
+        && crate::coordination_runtime_evidence(context, &worker_record)?.status
             == crate::CoordinationRuntimeStatus::Stopped;
     let (activity_revision, runtime_identity_digest) = if release {
         let reservation = assignment_reservation.as_ref().ok_or_else(|| {
@@ -14125,7 +14125,7 @@ fn run_worker_provider_stop_canary(
                 None,
             )
         })?;
-        let evidence = crate::coordination_runtime_evidence(&worker_record)?;
+        let evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
         if !release_replay_stopped && evidence.status != crate::CoordinationRuntimeStatus::Running {
             return Err(CliError::data(
                 "provider-stop-canary-wrapper-not-live",
@@ -14509,7 +14509,7 @@ fn run_worker_provider_stop_canary(
     let deadline = Instant::now() + provider_stop_canary_transition_timeout();
     loop {
         if release {
-            let runtime = crate::coordination_runtime_evidence(&worker_record)?;
+            let runtime = crate::coordination_runtime_evidence(context, &worker_record)?;
             if runtime.status == crate::CoordinationRuntimeStatus::Stopped
                 && session_status(context, &resolve_tmux_bin(None), &worker_record) == "stopped"
             {
@@ -15104,7 +15104,7 @@ fn run_worker_stop_claimed_runtime(
     }
     let _activity_lock =
         crate::activity::acquire_coordination_activity_lock(context, &worker_record.id)?;
-    let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     let tmux_status = session_status(context, &resolve_tmux_bin(None), &worker_record);
     // An interrupted stop can leave a stale tmux wrapper visible after the
     // exact recorded process identity is durably stopped. The receipt plus the
@@ -15358,7 +15358,7 @@ fn run_worker_stop_claimed_runtime(
         }
         crate::stop_session_runtime_locked(context, &mut worker_record, &resolve_tmux_bin(None))?;
     }
-    let stopped_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let stopped_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     if stopped_evidence.status != crate::CoordinationRuntimeStatus::Stopped {
         return Err(CliError::runtime(
             "coordination-runtime-unverified",
@@ -15943,7 +15943,7 @@ fn run_worker_stop_runtime(
             None,
         ));
     }
-    let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     let tmux_status = session_status(context, &resolve_tmux_bin(None), &worker_record);
     let runtime_ready = if resumed {
         matches!(
@@ -16110,7 +16110,7 @@ fn run_worker_stop_runtime(
     pause_worker_runtime_stop_for_test("after_authority_seal")?;
 
     crate::stop_session_runtime_locked(context, &mut worker_record, &resolve_tmux_bin(None))?;
-    let stopped_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let stopped_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     if stopped_evidence.status != crate::CoordinationRuntimeStatus::Stopped {
         return Err(CliError::runtime(
             "coordination-runtime-unverified",
@@ -16634,7 +16634,7 @@ fn run_worker_reconcile_recovery(
             None,
         ));
     }
-    let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     match runtime_evidence.status {
         crate::CoordinationRuntimeStatus::Stopped => {}
         crate::CoordinationRuntimeStatus::Running => {
@@ -20755,7 +20755,7 @@ fn prepare_orphan_provider_stop_canary_adoption(
             None,
         ));
     }
-    let runtime = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime = crate::coordination_runtime_evidence(context, &worker_record)?;
     if runtime.status != crate::CoordinationRuntimeStatus::Stopped
         || session_status(context, &resolve_tmux_bin(None), &worker_record) != "stopped"
     {
@@ -20820,7 +20820,7 @@ fn recover_missing_claim_revocation_quarantine_for_adopt(
             })),
         ));
     }
-    let runtime_evidence = crate::coordination_runtime_evidence(&worker_record)?;
+    let runtime_evidence = crate::coordination_runtime_evidence(context, &worker_record)?;
     if runtime_evidence.status != crate::CoordinationRuntimeStatus::Running
         || runtime_evidence.identity_digest != progress.runtime_identity_digest
     {

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -23855,7 +23855,7 @@ exit 0
             .insert("delete_tmux_identity".to_string(), stopped_runtime);
         crate::write_session_record(&state.context, &alpha).expect("stopped runtime identity");
         let generation = alpha.runtime.as_ref().expect("alpha runtime").generation;
-        let runtime_identity_digest = crate::coordination_runtime_evidence(&alpha)
+        let runtime_identity_digest = crate::coordination_runtime_evidence(&state.context, &alpha)
             .expect("runtime evidence")
             .identity_digest;
         let _session_capability = provision_ready_coordination_fixture(&state.context, &alpha);
@@ -24297,7 +24297,7 @@ exit 0
         assert_eq!(status, StatusCode::CONFLICT, "{rejected}");
         assert_eq!(rejected["error"]["code"], "activity-revision-conflict");
 
-        let runtime_identity_digest = crate::coordination_runtime_evidence(&alpha)
+        let runtime_identity_digest = crate::coordination_runtime_evidence(&state.context, &alpha)
             .expect("runtime evidence")
             .identity_digest;
         let mut registry: Value =
@@ -24977,7 +24977,7 @@ exit 0
         );
         crate::write_session_record(&state.context, &alpha).expect("stopped runtime identity");
         let generation = alpha.runtime.as_ref().expect("alpha runtime").generation;
-        let runtime_identity_digest = crate::coordination_runtime_evidence(&alpha)
+        let runtime_identity_digest = crate::coordination_runtime_evidence(&state.context, &alpha)
             .expect("runtime evidence")
             .identity_digest;
         provision_ready_coordination_fixture(&state.context, &alpha);


### PR DESCRIPTION
## Summary

The lane-stop corroboration rule reached only half its consumers. `agent-session
delete` and `session_status` already called a plugin-closed lane stopped once its
released heartbeat went stale, but `worker reconcile-stopped` still refused it
with `coordination-runtime-unverified` — so the assignment could not be reclaimed
at all, which is the exact dead end the rule was accepted to open. One call was
the cause: dsh runtime evidence classified from the context-free disposition,
which by contract behaves like a lane that still holds authority.

## Problem

- **Expected**: a lane the plugin closed, whose released heartbeat has gone
  stale, reconciles through `worker reconcile-stopped` while the harness keeps
  serving its other lanes.
- **Actual**: `worker reconcile-stopped` fails
  `coordination-runtime-unverified` ("the assignment cannot be terminalized
  without stopped exact-runtime evidence") even though `agent-session list`
  reports that same session as `stopped` and `agent-session delete` would admit
  it.
- **Impact**: the store-side reclaim path stayed closed for exactly the case the
  corroboration rule was added for, and two consumers of one rule disagreed about
  the same lane — the failure mode `external_runtime_evidence`'s own comment says
  it exists to prevent.

## Reproduction

1. Build `main-agent` and `agent-session` from `main` at `3d1124cf`.
2. Run the dsh-runtime-kit acceptance driver against them:
   `NILS_BIN_DIR=<build> node test/main-agent-e2e.mjs`.
3. The `stopped-lane-reconciled` scenario closes a lane, waits for its released
   heartbeat to lapse, observes `agent-session list` reporting `stopped`, and
   then fails: `worker reconcile-stopped` returns
   `coordination-runtime-unverified`.

## Issues Found

Refs sympoies/dsh-runtime-kit#8

## Fix Approach

- `coordination_runtime_evidence` and its dsh arm take the state context and
  classify through `external_lane_disposition_with_broker`, the same witnessed
  disposition the status projection and the destructive gates already use.
- The tmux arm is untouched — it never consulted the lane disposition.
- The corroboration unit test now asserts the evidence consumers read as well as
  the disposition: `Stopped` once the heartbeat is released, `Unknown` while it is
  fresh. The three readers can no longer drift apart without a test failing.

## Test-First Evidence

- Classification `bug-fix`, baseline bound at `3d1124cf`.
- The failing evidence is the end-to-end refusal above, captured against real
  binaries before the fix: exit 1 with `coordination-runtime-unverified` from
  `worker reconcile-stopped`.
- Impact is `update-spec` on the corroboration unit test: it existed but asserted
  only the disposition, the projection, and the destructive gate — never the
  evidence `reconcile-stopped` reads.
- No residual gaps recorded.

## Test plan

- `cargo test -p nils-agent-session` — 868 lib, 294 integration, 4 cli_contract,
  all green.
- `cargo fmt --check`; `cargo clippy --all-targets --all-features -- -D warnings`
  — clean.
- dsh-runtime-kit `node test/main-agent-e2e.mjs` against binaries built from this
  branch — all three scenarios pass, including the previously failing
  `stopped-lane-reconciled`.
- One unrelated flake observed and cleared:
  `activity::tests::claude_notification_waiting_requires_stop_and_no_reactivation`
  asserts inside a one-second window; it failed once under full-suite load, then
  passed alone and on a full rerun, both on this tree and on the unmodified base.

## Risk / Notes

- Signature-only churn across 34 call sites: every one already had the state
  context in scope, and the compiler checked the rest. No tmux behaviour changes.
- The rule itself was reviewed and accepted in #1471, including its same-uid
  residual; this change only stops one consumer from silently disagreeing with it.
