### PR TITLE
fix(agent-session): fence DSH replay attachment

### DIFF
--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -116,6 +116,14 @@ The dsh prompt is a fifth byte-stable replay variant alongside the four
 existing prompts; `ensure_worker_launch_matches` accepts it for replay
 matching exactly like the others.
 
+An exact replay that finds the external worker record but not the terminal
+worker-start receipt MUST acquire or join the original worker-start authority
+fence before committing the assignment attachment. The external and managed
+runtime arms share the same revision-1-to-2 attachment helper, so a crash after
+record creation cannot leave an unowned fence while another caller commits the
+attachment outside it. A conflicting replay is rejected by the existing
+request-digest/idempotency contract.
+
 ## Liveness sidecar — `main-agent.dsh-runtime-liveness.v1`
 
 Path: `<session dir>/dsh-runtime-liveness.json`, written and refreshed only by
@@ -238,6 +246,9 @@ lane needs. The classification table itself is not modified.
 - `worker stop-runtime`, `worker stop-claimed-runtime`: `dsh-runtime-plugin-owned`
   — the plugin interrupts the lane; `worker reconcile-stopped` then proceeds
   store-side unchanged once the sidecar proves the lane stopped.
+- `agent-session start`, `run`, provider-resume import, and `activity setup`
+  refuse before provider launch or configuration side effects; dsh sessions
+  and lifecycle configuration are external-runtime owned.
 - `agent-session resume`/provider resume surfaces: dsh sessions are not
   CLI-resumable (same typed-refusal pattern as Hermes).
 - `agent-session delete`, `maintenance` `remove-console-record`: an unproven

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -630,6 +630,13 @@ fn run_activity(context: &CliContext, args: cli::ActivityArgs) -> i32 {
 }
 
 fn forward_activity_setup_to_agent_hook(args: &cli::ActivitySetupArgs) -> Result<Value, CliError> {
+    if args.agent == AgentKind::Dsh {
+        return Err(CliError::usage(
+            "unsupported-activity-agent",
+            "dsh lifecycle state is owned by the external dsh-runtime-kit runtime; there is no provider activity configuration to manage",
+            Some(json!({ "agent": args.agent.as_str() })),
+        ));
+    }
     let explicit_binary = std::env::var_os("AGENT_HOOK_BIN");
     let binary = explicit_binary
         .clone()

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -4901,26 +4901,8 @@ fn run_worker_start_single_input(
             Some(&expected_worker),
             launch_input.provider_stop_canary.is_some(),
         )?;
-        let current = locked
-            .registry
-            .assignments
-            .get_mut(&assignment_id)
-            .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?;
-        if current.state != "starting"
-            || !((current.revision == 1 && current.worker.is_none())
-                || (current.revision == 2 && current.worker.as_ref() == Some(&expected_worker)))
-        {
-            return Err(CliError::data(
-                "assignment-start-conflict",
-                "assignment changed while the worker was starting",
-                Some(json!({ "assignment_id": assignment_id, "revision": current.revision })),
-            ));
-        }
-        if current.revision == 1 {
-            current.worker = Some(expected_worker.clone());
-            current.revision = 2;
-            current.updated_at = timestamp();
-        }
+        let current =
+            attach_starting_worker_locked(&mut locked.registry, &assignment_id, &expected_worker)?;
         let outcome = json!({
             "schema_version": "main-agent.worker-start-result.v1",
             "assignment": public_assignment_view(current),
@@ -5093,6 +5075,42 @@ fn finish_external_worker_start(
     let worker_record = match existing {
         Some(worker) => {
             ensure_worker_launch_matches(context, &worker, launch_input, &replay_prompts)?;
+            let fence = crate::coordination::claims::acquire_main_agent_worker_start_fence(
+                context,
+                record,
+                incarnation,
+                worker_start_fence_key,
+            )?;
+            let validation = (|| {
+                let mut locked = orchestration::lock_registry(context)?;
+                if let Some(batch_lane) = batch_lane {
+                    renew_worker_start_batch_lane_locked(&mut locked.registry, batch_lane)?;
+                }
+                validate_worker_start_authority_locked(
+                    &locked.registry,
+                    record,
+                    incarnation,
+                    assignment_id,
+                    worker_session_id,
+                    expected_packet_digest,
+                    &args.idempotency_key,
+                    request_digest,
+                    legacy_request_digest,
+                    &launch_input.launch.cwd,
+                    None,
+                    None,
+                    false,
+                )?;
+                if batch_lane.is_some() {
+                    locked.save()?;
+                }
+                Ok(())
+            })();
+            if let Err(error) = validation {
+                fence.finish(context, false)?;
+                return Err(error);
+            }
+            worker_start_fence = Some(fence);
             worker
         }
         None => {
@@ -5182,6 +5200,12 @@ fn finish_external_worker_start(
         }
         return Err(error);
     }
+    if let Err(error) = pause_batch_lane_for_test("before_external_worker_attachment") {
+        if let Some(fence) = worker_start_fence.take() {
+            fence.finish(context, false)?;
+        }
+        return Err(error);
+    }
     let expected_worker = session_ref(context, &worker_record, &launch_id);
     let attachment = (|| {
         ensure_active_claim(context, record)?;
@@ -5207,26 +5231,8 @@ fn finish_external_worker_start(
             Some(&expected_worker),
             false,
         )?;
-        let current = locked
-            .registry
-            .assignments
-            .get_mut(assignment_id)
-            .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?;
-        if current.state != "starting"
-            || !((current.revision == 1 && current.worker.is_none())
-                || (current.revision == 2 && current.worker.as_ref() == Some(&expected_worker)))
-        {
-            return Err(CliError::data(
-                "assignment-start-conflict",
-                "assignment changed while the worker was starting",
-                Some(json!({ "assignment_id": assignment_id, "revision": current.revision })),
-            ));
-        }
-        if current.revision == 1 {
-            current.worker = Some(expected_worker.clone());
-            current.revision = 2;
-            current.updated_at = timestamp();
-        }
+        let current =
+            attach_starting_worker_locked(&mut locked.registry, assignment_id, &expected_worker)?;
         let outcome = json!({
             "schema_version": "main-agent.worker-start-result.v1",
             "assignment": public_assignment_view(current),
@@ -5278,6 +5284,33 @@ fn finish_external_worker_start(
             Err(error)
         }
     }
+}
+
+fn attach_starting_worker_locked<'a>(
+    registry: &'a mut orchestration::Registry,
+    assignment_id: &str,
+    expected_worker: &orchestration::SessionRef,
+) -> Result<&'a mut orchestration::AssignmentRecord, CliError> {
+    let current = registry
+        .assignments
+        .get_mut(assignment_id)
+        .ok_or_else(|| not_found("assignment-not-found", "assignment was not found"))?;
+    if current.state != "starting"
+        || !((current.revision == 1 && current.worker.is_none())
+            || (current.revision == 2 && current.worker.as_ref() == Some(expected_worker)))
+    {
+        return Err(CliError::data(
+            "assignment-start-conflict",
+            "assignment changed while the worker was starting",
+            Some(json!({ "assignment_id": assignment_id, "revision": current.revision })),
+        ));
+    }
+    if current.revision == 1 {
+        current.worker = Some(expected_worker.clone());
+        current.revision = 2;
+        current.updated_at = timestamp();
+    }
+    Ok(current)
 }
 
 /// The plugin-facing launch contract for one dsh lane: the byte-stable

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -15641,20 +15641,22 @@ esac
         let tmp = tempfile::TempDir::new().unwrap();
         let st = state(tmp.path(), Some(TOKEN), minimal_tmux(tmp.path()));
 
-        let (status, body) = call(
-            router(st.clone()),
-            post_json(
-                "/sessions",
-                Some(TOKEN),
-                json!({
-                    "agent": "hermes",
-                    "provider_resume_id": "external-id"
-                }),
-            ),
-        )
-        .await;
-        assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert_eq!(body["error"]["code"], "unsupported-provider-resume-agent");
+        for agent in ["hermes", "dsh"] {
+            let (status, body) = call(
+                router(st.clone()),
+                post_json(
+                    "/sessions",
+                    Some(TOKEN),
+                    json!({
+                        "agent": agent,
+                        "provider_resume_id": "external-id"
+                    }),
+                ),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            assert_eq!(body["error"]["code"], "unsupported-provider-resume-agent");
+        }
     }
 
     #[tokio::test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -4081,6 +4081,7 @@ async fn wait_for_codex_control_within(
     }
 }
 
+#[allow(clippy::result_large_err)]
 async fn wait_for_account_binding(
     state: &ServeState,
     id: &str,
@@ -4174,6 +4175,7 @@ pub(crate) fn structured_prompt_incarnation_conflict(
     )
 }
 
+#[allow(clippy::result_large_err)]
 async fn load_structured_prompt_record_locked(
     state: &ServeState,
     id: &str,
@@ -4208,6 +4210,7 @@ async fn load_structured_prompt_record_locked(
     }
 }
 
+#[allow(clippy::result_large_err)]
 async fn wait_for_structured_prompt_control(
     state: &ServeState,
     id: &str,
@@ -4228,6 +4231,7 @@ async fn wait_for_structured_prompt_control(
     ))
 }
 
+#[allow(clippy::result_large_err)]
 async fn submit_structured_prompt_locked(
     state: &ServeState,
     id: &str,

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38406,6 +38406,526 @@ fn main_agent_quick_no_longer_requires_an_idempotency_key() {
 }
 
 #[test]
+fn dsh_tmux_owned_entrypoints_refuse_before_provider_side_effects() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    let checkout = tmp.path().join("checkout");
+    fs::create_dir(&state_dir).expect("state");
+    init_checkout(&checkout, "https://example.invalid/example/repository.git");
+    let state_arg = state_dir.to_string_lossy().into_owned();
+    let checkout_arg = checkout.to_string_lossy().into_owned();
+
+    for (verb, extra, expected_code) in [
+        ("start", Vec::<&str>::new(), "unsupported-start-agent"),
+        (
+            "run",
+            vec!["--prompt", "do not launch"],
+            "unsupported-run-agent",
+        ),
+    ] {
+        let mut args = vec![
+            "--state-dir",
+            state_arg.as_str(),
+            verb,
+            "--agent",
+            "dsh",
+            "--cwd",
+            checkout_arg.as_str(),
+        ];
+        args.extend(extra);
+        args.extend(["--format", "json"]);
+        let refused = run(&checkout, &args);
+        assert_eq!(refused.code, 64, "outcome={}", refused.stdout_text());
+        assert_eq!(refused.stdout_json()["error"]["code"], expected_code);
+    }
+    assert!(
+        !state_dir.join("sessions").exists()
+            || fs::read_dir(state_dir.join("sessions"))
+                .expect("sessions dir")
+                .next()
+                .is_none(),
+        "managed start/run refusals must not create session records"
+    );
+
+    let provider_marker = tmp.path().join("provider-setup-invoked");
+    let fake_agent_hook = tmp.path().join("agent-hook");
+    fs::write(
+        &fake_agent_hook,
+        format!(
+            "#!/bin/sh\nprintf invoked > '{}'\nexit 1\n",
+            provider_marker.display()
+        ),
+    )
+    .expect("fake agent-hook");
+    fs::set_permissions(&fake_agent_hook, fs::Permissions::from_mode(0o700))
+        .expect("fake agent-hook mode");
+    let fake_agent_hook_arg = fake_agent_hook.to_string_lossy().into_owned();
+    let refused_setup = run_with_env(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "activity",
+            "setup",
+            "--agent",
+            "dsh",
+            "--dry-run",
+            "--format",
+            "json",
+        ],
+        &[("AGENT_HOOK_BIN", fake_agent_hook_arg.as_str())],
+    );
+    assert_eq!(
+        refused_setup.code,
+        64,
+        "outcome={}",
+        refused_setup.stdout_text()
+    );
+    assert_eq!(
+        refused_setup.stdout_json()["error"]["code"],
+        "unsupported-activity-agent"
+    );
+    assert!(
+        !provider_marker.exists(),
+        "the unsupported DSH activity setup must refuse before invoking a provider binary"
+    );
+}
+
+#[test]
+fn main_agent_worker_start_dsh_replay_joins_the_pre_attachment_authority_fence() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    let checkout = tmp.path().join("checkout");
+    fs::create_dir(&state_dir).expect("state");
+    init_checkout(&checkout, "https://example.invalid/example/repository.git");
+    seed_brokers_at(
+        &state_dir,
+        &[(
+            "main-one",
+            "main-incarnation-one",
+            "main-private-capability-material-0000000001",
+            checkout.as_path(),
+            Some("enforce"),
+        )],
+    );
+    let main_capability = init_main_run(tmp.path(), &state_dir, &checkout, "main-one", "run-one");
+    let worktree = tmp.path().join("lane-worktree");
+    init_checkout(&worktree, "https://example.invalid/example/repository.git");
+    let assignment_path = tmp.path().join("assignment-dsh-fence-replay.json");
+    write_private_json(
+        &assignment_path,
+        &json!({
+            "schema_version": "main-agent.assignment-input.v1",
+            "assignment_id": "assignment-dsh-fence-replay",
+            "task_summary": "Join the retained external worker start fence",
+            "task": {},
+            "launch": {
+                "agent": "dsh", "cwd": worktree, "title": null,
+                "session_id": "worker-dsh-fence-replay",
+                "coordination_mode": "enforce", "agent_args": []
+            },
+            "repository": "example/repository", "worktree": worktree, "base_ref": "main",
+            "scopes": ["crates/agent-session"], "durable_refs": []
+        }),
+    );
+    let barrier = tmp.path().join("dsh-fence-replay-barrier");
+    fs::create_dir(&barrier).expect("barrier");
+    let contender_ready = tmp.path().join("dsh-fence-contender-ready");
+    let make_command = |pause: bool| {
+        let mut command = Command::new(bin::resolve("main-agent"));
+        command
+            .current_dir(&checkout)
+            .args([
+                "--state-dir",
+                state_dir.to_str().expect("state dir"),
+                "worker",
+                "start",
+                "--assignment-file",
+                assignment_path.to_str().expect("assignment path"),
+                "--await-ready",
+                "0",
+                "--idempotency-key",
+                "worker-start-dsh-fence-replay-0001",
+                "--format",
+                "json",
+            ])
+            .env("AGENT_SESSION_CAPABILITY_FILE", &main_capability)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        if pause {
+            command
+                .env(
+                    "NILS_AGENT_SESSION_TEST_BATCH_LANE_BARRIER_STAGE",
+                    "before_external_worker_attachment",
+                )
+                .env("NILS_AGENT_SESSION_TEST_BATCH_LANE_BARRIER_DIR", &barrier);
+        } else {
+            command.env(
+                "NILS_AGENT_SESSION_TEST_FENCE_CONTENDER_READY",
+                &contender_ready,
+            );
+        }
+        command
+    };
+
+    let mut interrupted = make_command(true).spawn().expect("spawn interrupted start");
+    let barrier_deadline = Instant::now() + Duration::from_secs(10);
+    while !barrier.join("ready").is_file() {
+        assert!(
+            Instant::now() < barrier_deadline,
+            "external start never reached durable pre-attachment state"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        state_dir.join("sessions/worker-dsh-fence-replay").is_dir(),
+        "the worker record is durable before the attachment"
+    );
+    let retained_registry = load_coordination_registry(&state_dir);
+    let retained_fences = retained_registry["operations"]
+        .as_array()
+        .expect("operations")
+        .iter()
+        .filter(|operation| operation["operation"] == "main-agent-worker-start")
+        .collect::<Vec<_>>();
+    assert_eq!(retained_fences.len(), 1);
+    let retained_lease_id = retained_fences[0]["lease_id"]
+        .as_str()
+        .expect("fence lease id")
+        .to_string();
+
+    let mut replay = make_command(false).spawn().expect("spawn exact replay");
+    let contender_deadline = Instant::now() + Duration::from_secs(10);
+    while !contender_ready.is_file() && replay.try_wait().expect("poll exact replay").is_none() {
+        assert!(
+            Instant::now() < contender_deadline,
+            "external replay neither joined the fence nor completed"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(
+        contender_ready.is_file(),
+        "an exact external replay must join the live pre-attachment fence"
+    );
+    assert!(
+        replay.try_wait().expect("poll joined replay").is_none(),
+        "the joined replay must wait for the current fence owner"
+    );
+
+    interrupted.kill().expect("interrupt first external start");
+    let interrupted = interrupted.wait().expect("wait interrupted external start");
+    assert!(!interrupted.success());
+    let output = replay.wait_with_output().expect("wait exact replay");
+    assert!(
+        output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let replayed_outcome: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("replayed outcome");
+    let terminal_replay = make_command(false)
+        .output()
+        .expect("terminal external replay");
+    assert!(terminal_replay.status.success());
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&terminal_replay.stdout)
+            .expect("terminal replay outcome"),
+        replayed_outcome,
+        "a crash-converged external replay returns the identical launch payload"
+    );
+    let completed_registry = load_coordination_registry(&state_dir);
+    let completed_fences = completed_registry["operations"]
+        .as_array()
+        .expect("operations")
+        .iter()
+        .filter(|operation| operation["operation"] == "main-agent-worker-start")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        completed_fences.len(),
+        1,
+        "replay must reuse the retained fence"
+    );
+    assert_eq!(completed_fences[0]["lease_id"], retained_lease_id);
+    assert_eq!(completed_fences[0]["state"], "completed");
+    assert_eq!(
+        orchestration_registry(&state_dir)["assignments"]["assignment-dsh-fence-replay"]["worker"]
+            ["session_id"],
+        "worker-dsh-fence-replay"
+    );
+
+    let launch = &replayed_outcome["data"]["external_launch"];
+    let launch_id = launch["launch_id"].as_str().expect("launch id").to_string();
+    let worker_env = launch["worker_env"].as_object().expect("worker env");
+    let worker_capability = worker_env["AGENT_SESSION_CAPABILITY_FILE"]
+        .as_str()
+        .expect("worker capability")
+        .to_string();
+    let worker_checkpoint = worker_env["AGENT_SESSION_CHECKPOINT_FILE"]
+        .as_str()
+        .expect("worker checkpoint")
+        .to_string();
+    let liveness_file = launch["liveness_file"]
+        .as_str()
+        .expect("liveness file")
+        .to_string();
+    let liveness_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("liveness epoch")
+        .as_secs();
+    write_private_json(
+        Path::new(&liveness_file),
+        &json!({
+            "schema_version": "main-agent.dsh-runtime-liveness.v1",
+            "launch_id": launch_id,
+            "harness": harness_identity_json(),
+            "lane": { "state": "open" },
+            "turn": {
+                "phase": "working",
+                "phase_changed_at": liveness_epoch.to_string(),
+                "current_turn": { "started_at": liveness_epoch.to_string() },
+                "last_turn": null
+            },
+            "updated_at": liveness_epoch
+        }),
+    );
+    let heartbeat_argv = launch["broker_heartbeat_argv"]
+        .as_array()
+        .expect("heartbeat argv")
+        .iter()
+        .map(|value| value.as_str().expect("heartbeat arg").to_string())
+        .collect::<Vec<_>>();
+    let mut heartbeat = Command::new(&heartbeat_argv[0])
+        .args(&heartbeat_argv[1..])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn emitted heartbeat argv");
+    let state_arg = state_dir.to_string_lossy().into_owned();
+    let ready_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let status = run(
+            &checkout,
+            &[
+                "--state-dir",
+                &state_arg,
+                "broker",
+                "status",
+                "--session",
+                "worker-dsh-fence-replay",
+                "--capability-file",
+                &worker_capability,
+                "--format",
+                "json",
+            ],
+        );
+        if status.code == 0 && data(&status)["state"] == "ready" {
+            break;
+        }
+        assert!(
+            Instant::now() < ready_deadline,
+            "the emitted heartbeat never activated the external broker: {}",
+            status.stdout_text()
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        heartbeat.try_wait().expect("poll heartbeat").is_none(),
+        "the emitted heartbeat remains the live lane owner"
+    );
+    rewrite_registry(&state_dir, |registry| {
+        let controller_claim = registry["claims"]
+            .as_array_mut()
+            .expect("claims")
+            .iter_mut()
+            .find(|claim| claim["session_id"] == "main-one" && claim["state"] == "active")
+            .expect("active controller claim");
+        controller_claim["repositories"] = json!([]);
+        controller_claim["scopes"] = json!([]);
+    });
+
+    let worker_envs = [
+        ("AGENT_SESSION_ID", "worker-dsh-fence-replay"),
+        ("AGENT_SESSION_STATE_DIR", state_arg.as_str()),
+        ("AGENT_SESSION_RUNTIME_ID", launch_id.as_str()),
+        ("AGENT_SESSION_CAPABILITY_FILE", worker_capability.as_str()),
+        ("AGENT_SESSION_CHECKPOINT_FILE", worker_checkpoint.as_str()),
+    ];
+    let bootstrap = run_main_agent(
+        &worktree,
+        &[
+            "--state-dir",
+            &state_arg,
+            "bootstrap",
+            "--idempotency-key",
+            "worker-bootstrap-dsh-fence-replay-0001",
+            "--format",
+            "json",
+        ],
+        &worker_envs,
+    );
+    assert_eq!(bootstrap.code, 0, "outcome={}", bootstrap.stdout_text());
+    assert_eq!(data(&bootstrap)["assignment"]["record"]["state"], "working");
+    assert_eq!(data(&bootstrap)["assignment"]["record"]["revision"], 3);
+    write_private_json(
+        Path::new(&worker_checkpoint),
+        &json!({
+            "schema_version": "main-agent.checkpoint-input.v1",
+            "summary": "External worker reached a fenced checkpoint",
+            "next_action": "Continue the bounded lane",
+            "state": "working",
+            "result_summary": null,
+            "blocker_summary": null
+        }),
+    );
+    let checkpoint = run_main_agent(
+        &worktree,
+        &[
+            "--state-dir",
+            &state_arg,
+            "checkpoint",
+            "--file",
+            &worker_checkpoint,
+            "--if-revision",
+            "3",
+            "--idempotency-key",
+            "worker-checkpoint-dsh-fence-replay-0001",
+            "--format",
+            "json",
+        ],
+        &worker_envs,
+    );
+    assert_eq!(checkpoint.code, 0, "outcome={}", checkpoint.stdout_text());
+    assert_eq!(data(&checkpoint)["assignment"]["state"], "working");
+    assert_eq!(data(&checkpoint)["assignment"]["revision"], 4);
+
+    for verb in ["diagnose", "supervise"] {
+        let observed = run_main_agent(
+            &checkout,
+            &[
+                "--state-dir",
+                &state_arg,
+                "worker",
+                verb,
+                "assignment-dsh-fence-replay",
+                "--format",
+                "json",
+            ],
+            &[("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str())],
+        );
+        assert_eq!(
+            observed.code,
+            0,
+            "{verb} must consume the live external evidence: {}",
+            observed.stdout_text()
+        );
+        if verb == "diagnose" {
+            assert_eq!(
+                data(&observed)["worker"]["status"],
+                "running",
+                "diagnosis must project the external runtime: {}",
+                observed.stdout_text()
+            );
+        }
+    }
+
+    let stop_argv = launch["broker_stop_argv"]
+        .as_array()
+        .expect("stop argv")
+        .iter()
+        .map(|value| value.as_str().expect("stop arg").to_string())
+        .collect::<Vec<_>>();
+    let stopped = Command::new(&stop_argv[0])
+        .args(&stop_argv[1..])
+        .output()
+        .expect("run emitted broker stop argv");
+    assert!(
+        stopped.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&stopped.stdout),
+        String::from_utf8_lossy(&stopped.stderr)
+    );
+    let heartbeat_deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if heartbeat
+            .try_wait()
+            .expect("poll stopped heartbeat")
+            .is_some()
+        {
+            break;
+        }
+        if Instant::now() >= heartbeat_deadline {
+            heartbeat.kill().expect("kill stuck heartbeat fixture");
+            panic!("the emitted heartbeat did not stop after its broker was released");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    let heartbeat_file = state_dir.join("sessions/worker-dsh-fence-replay/coordination/heartbeat");
+    if heartbeat_file.exists() {
+        fs::remove_file(&heartbeat_file).expect("release external lane heartbeat witness");
+    }
+    write_private_json(
+        Path::new(&liveness_file),
+        &json!({
+            "schema_version": "main-agent.dsh-runtime-liveness.v1",
+            "launch_id": launch_id,
+            "harness": harness_identity_json(),
+            "lane": { "state": "terminated" },
+            "updated_at": liveness_epoch + 1
+        }),
+    );
+    let reconciled = run_main_agent(
+        &checkout,
+        &[
+            "--state-dir",
+            &state_arg,
+            "worker",
+            "reconcile-stopped",
+            "assignment-dsh-fence-replay",
+            "--if-revision",
+            "4",
+            "--reason",
+            "external lane released its heartbeat",
+            "--idempotency-key",
+            "worker-reconcile-dsh-fence-replay-0001",
+            "--format",
+            "json",
+        ],
+        &[("AGENT_SESSION_CAPABILITY_FILE", main_capability.as_str())],
+    );
+    assert_eq!(reconciled.code, 0, "outcome={}", reconciled.stdout_text());
+    assert_eq!(data(&reconciled)["assignment"]["state"], "cancelled");
+
+    let conflicting_worktree = tmp.path().join("conflicting-lane-worktree");
+    fs::create_dir(&conflicting_worktree).expect("conflicting lane worktree");
+    write_private_json(
+        &assignment_path,
+        &json!({
+            "schema_version": "main-agent.assignment-input.v1",
+            "assignment_id": "assignment-dsh-fence-replay",
+            "task_summary": "Join the retained external worker start fence",
+            "task": {},
+            "launch": {
+                "agent": "dsh", "cwd": conflicting_worktree, "title": null,
+                "session_id": "worker-dsh-fence-replay",
+                "coordination_mode": "enforce", "agent_args": []
+            },
+            "repository": "example/repository", "worktree": conflicting_worktree,
+            "base_ref": "main", "scopes": ["crates/agent-session"], "durable_refs": []
+        }),
+    );
+    let conflict = make_command(false)
+        .output()
+        .expect("conflicting external replay");
+    assert!(!conflict.status.success());
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&conflict.stdout)
+            .expect("conflicting replay error")["error"]["code"],
+        "idempotency-conflict"
+    );
+}
+
+#[test]
 fn main_agent_worker_start_dsh_returns_the_external_launch_contract_without_tmux() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");

--- a/crates/forge-cli/src/ops/review_state.rs
+++ b/crates/forge-cli/src/ops/review_state.rs
@@ -1242,7 +1242,9 @@ fn hex_decode(encoded: &str) -> Result<Vec<u8>, ForgeError> {
     }
     encoded
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).expect("ASCII checked");
             u8::from_str_radix(pair, 16).map_err(|error| {

--- a/crates/git-cli/src/worktree/dirty_checkout_adoption.rs
+++ b/crates/git-cli/src/worktree/dirty_checkout_adoption.rs
@@ -5468,7 +5468,7 @@ fn decode_lower_hex(value: &str) -> Option<Vec<u8>> {
         return None;
     }
     let mut bytes = Vec::with_capacity(value.len() / 2);
-    for pair in value.as_bytes().chunks_exact(2) {
+    for pair in value.as_bytes().as_chunks::<2>().0 {
         let high = (pair[0] as char).to_digit(16)? as u8;
         let low = (pair[1] as char).to_digit(16)? as u8;
         bytes.push((high << 4) | low);

--- a/crates/image-processing/src/svg_validate.rs
+++ b/crates/image-processing/src/svg_validate.rs
@@ -464,7 +464,7 @@ fn write_jpg(path: &Path, width: u32, height: u32, rgba: &[u8], quality: u8) -> 
 
 fn flatten_rgba_to_rgb(rgba: &[u8]) -> Vec<u8> {
     let mut rgb = Vec::with_capacity((rgba.len() / 4) * 3);
-    for pixel in rgba.chunks_exact(4) {
+    for pixel in rgba.as_chunks::<4>().0 {
         let alpha = pixel[3] as u16;
         let blend = |channel: u8| -> u8 {
             (((channel as u16 * alpha) + (255 * (255 - alpha)) + 127) / 255) as u8

--- a/crates/macos-agent/src/backend/mod.rs
+++ b/crates/macos-agent/src/backend/mod.rs
@@ -1544,7 +1544,7 @@ fn plist_string(dictionary: roxmltree::Node<'_, '_>, key: &str) -> Option<String
         .children()
         .filter(roxmltree::Node::is_element)
         .collect::<Vec<_>>();
-    let mut matches = elements.chunks_exact(2).filter_map(|pair| {
+    let mut matches = elements.as_chunks::<2>().0.iter().filter_map(|pair| {
         (pair[0].has_tag_name("key")
             && pair[0].text() == Some(key)
             && pair[1].has_tag_name("string"))

--- a/crates/nils-common/src/fs.rs
+++ b/crates/nils-common/src/fs.rs
@@ -515,7 +515,7 @@ impl Sha256 {
         self.compress(&block);
 
         let mut out = [0u8; 32];
-        for (index, chunk) in out.chunks_exact_mut(4).enumerate() {
+        for (index, chunk) in out.as_chunks_mut::<4>().0.iter_mut().enumerate() {
             chunk.copy_from_slice(&self.state[index].to_be_bytes());
         }
         out

--- a/crates/plan-issue/src/lifecycle_record.rs
+++ b/crates/plan-issue/src/lifecycle_record.rs
@@ -1646,7 +1646,7 @@ fn decode_hex(input: &str) -> Result<Vec<u8>, String> {
     }
     let mut out = Vec::with_capacity(input.len() / 2);
     let bytes = input.as_bytes();
-    for pair in bytes.chunks_exact(2) {
+    for pair in bytes.as_chunks::<2>().0 {
         let hi = hex_value(pair[0])
             .ok_or_else(|| format!("invalid hex digit `{}`", char::from(pair[0])))?;
         let lo = hex_value(pair[1])

--- a/crates/plan-issue/tests/integration/live_record_ops.rs
+++ b/crates/plan-issue/tests/integration/live_record_ops.rs
@@ -1901,7 +1901,9 @@ fn record_close_live_reuses_and_recovers_latest_semantic_closeout_without_repost
     assert_eq!(hex.len() % 2, 0, "payload carrier hex width");
     let payload_bytes = hex
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             u8::from_str_radix(std::str::from_utf8(pair).expect("hex pair"), 16)
                 .expect("payload hex")

--- a/crates/plan-tooling/src/ledger_sync.rs
+++ b/crates/plan-tooling/src/ledger_sync.rs
@@ -393,7 +393,7 @@ fn decode_hex(input: &str) -> Result<Vec<u8>, String> {
     }
     let mut out = Vec::with_capacity(input.len() / 2);
     let bytes = input.as_bytes();
-    for pair in bytes.chunks_exact(2) {
+    for pair in bytes.as_chunks::<2>().0 {
         let hi = hex_value(pair[0])
             .ok_or_else(|| format!("invalid hex digit `{}`", char::from(pair[0])))?;
         let lo = hex_value(pair[1])


### PR DESCRIPTION
## Summary

Close the nils-cli half of the DSH Main Agent Mode follow-up by making exact external worker-start replay join the retained pre-attachment authority fence and by refusing unsupported DSH activity setup before provider invocation.

## Problem

- Expected: an exact DSH worker-start replay waits on the existing authority fence, takes over the retained lease when necessary, and commits one attachment transition.
- Actual: the retained-record replay branch bypassed the live fence, allowing attachment work to race; unsupported DSH activity setup also reached provider tooling before refusing the request.
- Impact: crash recovery could violate single-owner attachment authority, and unsupported runtime operations could execute an unintended provider boundary.

## Reproduction

1. Pause a DSH worker start after its durable record is written but before attachment.
2. Replay the exact request while the original authority fence is still active.
3. Observe that the pre-fix replay does not join the fence.
4. Invoke DSH activity setup with a provider marker and observe that the pre-fix path invokes the provider before returning an invalid-output error.

## Issues Found

Refs sympoies/dsh-runtime-kit#8

## Fix Approach

- Acquire or join the retained worker-start fence on the existing-record replay path and revalidate authority while holding it through attachment.
- Share the revision-one to revision-two attachment helper across tmux and DSH runtime arms.
- Return `unsupported-activity-agent` before invoking provider tooling for DSH activity setup.
- Extend the real emitted-command integration path through broker activation, bootstrap, checkpoint, diagnose, supervise, conflict refusal, crash takeover, and stopped-lane reconciliation.

## Test-First Evidence

- RED: the new exact-replay regression failed because the replay did not join the live pre-attachment fence.
- RED: the DSH activity-setup regression wrote the provider marker and failed later as invalid provider output.
- GREEN: focused replay/refusal tests pass, with durable evidence bound to the delivered commit.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — passed; nextest 1168/1168 plus doctests and package checks.
- Focused DSH replay, activity-setup refusal, and provider-resume refusal tests — passed 3/3.
- DSH runtime-kit real-store main-agent E2E against these exact binaries — passed 3/3: two-lane lifecycle, overlapping-scope refusal, stopped-lane reconciliation.
- GitHub run `32463242808` — Linux, macOS, coverage, cargo-deny, and CodeQL passed on exact head `ead749ac510b292f922e768f9c971d25dbbe40e7`.
- Targeted quick review — pass, no material actionable findings.

## Risk / Notes

- Medium: the change touches crash-replay authority and external-runtime lifecycle transitions. It is bounded by focused race/refusal regressions, the full declared nils-cli gate, and a real DSH consumer E2E.
