### PR TITLE
fix(agent-hook): preserve authenticated recovery ingress

### DIFF
--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -271,7 +271,15 @@ issue #676 transaction.
 
 `agent-session.activity.v1` emits only a normalized metadata event to
 `agent-session activity event`; it never forwards raw provider JSON. Shadow
-evaluation skips every side-effecting capability.
+evaluation skips every side-effecting capability. If that activity update is
+temporarily unavailable, only the finite, shell-uncomposed Main Agent
+rehydration, recovery, status, rebind, and bootstrap shapes may defer the
+activity failure to a selected locked `agent-session.coordination.v1`
+transaction. This deferral is shape evidence, not authority: the fixed
+coordination consumer must still authenticate the exact release, private
+capability, owner/claim state, and command, and any missing or failed consumer
+keeps the request fail-closed. Ordinary shell commands and near-miss recovery
+forms never receive this deferral.
 
 Recovery uses a private challenge/authorize/consume lifecycle. Capability
 files are exact, expiring, state-bound bearers. Each challenge binds a signed

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -1080,29 +1080,72 @@ pub(crate) fn command_text(object: &Map<String, Value>) -> Option<&str> {
 }
 
 pub(crate) fn exact_main_agent_bootstrap_command(input: &[u8]) -> bool {
-    let Some(command) = strict_json::from_slice(input)
-        .ok()
-        .and_then(|value| value.as_object().and_then(command_text).map(str::to_string))
-    else {
+    let Some(words) = exact_main_agent_command_words(input) else {
         return false;
     };
-    if command.len() > MAX_MUTATION_TARGET_BYTES {
-        return false;
-    }
-    let Ok(words) = shell_words::split(&command) else {
-        return false;
-    };
-    if words.len() != 6 || command != shell_words::join(words.iter()) {
-        return false;
-    }
-    let executable = Path::new(&words[0]);
-    let trusted_shape = words[0] == "main-agent"
-        || (executable.is_absolute() && executable.file_name() == Some(OsStr::new("main-agent")));
-    trusted_shape
+    words.len() == 6
         && words[1] == "bootstrap"
         && words[2] == "--idempotency-key"
         && lifecycle_idempotency_key(&words[3])
         && words[4..] == ["--format", "json"]
+}
+
+/// Recognize only the finite Main Agent commands that the runtime-kit policy
+/// admits while ordinary owner capability evaluation is unavailable.
+///
+/// This is shape evidence, not authority. The paired locked coordination
+/// transaction still resolves the exact release sibling, validates the private
+/// capability, and owns the actual admission or recovery mutation.
+pub(crate) fn exact_main_agent_capability_recovery_command(input: &[u8]) -> bool {
+    let Some(words) = exact_main_agent_command_words(input) else {
+        return false;
+    };
+    let words = words.iter().map(String::as_str).collect::<Vec<_>>();
+    match words.as_slice() {
+        [_, version] => *version == "--version",
+        [_, "self", "show", "--format", "json"] => true,
+        [
+            _,
+            "self",
+            "recover",
+            "--idempotency-key",
+            key,
+            "--format",
+            "json",
+        ] => lifecycle_idempotency_key(key),
+        [_, "rehydrate", "--format", format] => matches!(*format, "json" | "markdown"),
+        [_, "status", "--format", "json"] => true,
+        [
+            _,
+            "rebind",
+            "--if-revision",
+            revision,
+            "--idempotency-key",
+            key,
+            "--format",
+            "json",
+        ] => lifecycle_revision(revision) && lifecycle_idempotency_key(key),
+        _ => exact_main_agent_bootstrap_command(input),
+    }
+}
+
+fn exact_main_agent_command_words(input: &[u8]) -> Option<Vec<String>> {
+    let command = strict_json::from_slice(input)
+        .ok()?
+        .as_object()
+        .and_then(command_text)?
+        .to_string();
+    if command.len() > MAX_MUTATION_TARGET_BYTES {
+        return None;
+    }
+    let words = shell_words::split(&command).ok()?;
+    if command != shell_words::join(words.iter()) {
+        return None;
+    }
+    let executable = Path::new(words.first()?);
+    let trusted_shape = words[0] == "main-agent"
+        || (executable.is_absolute() && executable.file_name() == Some(OsStr::new("main-agent")));
+    trusted_shape.then_some(words)
 }
 
 fn lifecycle_idempotency_key(value: &str) -> bool {
@@ -1110,6 +1153,13 @@ fn lifecycle_idempotency_key(value: &str) -> bool {
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || b"._:-".contains(&byte))
+}
+
+fn lifecycle_revision(value: &str) -> bool {
+    value == "0"
+        || (value.bytes().all(|byte| byte.is_ascii_digit())
+            && !value.starts_with('0')
+            && value.parse::<u64>().is_ok())
 }
 
 fn optional_provider_id<'a>(
@@ -1205,6 +1255,54 @@ fn parse_provider_json(input: &[u8]) -> Result<Value, HookError> {
 mod tests {
     use super::*;
     use crate::model::{DecisionReason, ShadowObservation};
+
+    fn bash_payload(command: &str) -> Vec<u8> {
+        serde_json::to_vec(&json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command}
+        }))
+        .expect("provider request")
+    }
+
+    #[test]
+    fn main_agent_capability_recovery_is_a_finite_exact_allowlist() {
+        for command in [
+            "main-agent --version",
+            "main-agent self show --format json",
+            "main-agent self recover --idempotency-key recover-12345678 --format json",
+            "main-agent rehydrate --format json",
+            "main-agent rehydrate --format markdown",
+            "main-agent status --format json",
+            "main-agent rebind --if-revision 0 --idempotency-key rebind-12345678 --format json",
+            "main-agent rebind --if-revision 42 --idempotency-key rebind-12345678 --format json",
+            "'/trusted release/main-agent' bootstrap --idempotency-key bootstrap-12345678 --format json",
+        ] {
+            assert!(
+                exact_main_agent_capability_recovery_command(&bash_payload(command)),
+                "exact recovery shape rejected: {command}"
+            );
+        }
+
+        for command in [
+            "./main-agent --version",
+            "main-agent self show --format markdown",
+            "main-agent self recover --idempotency-key short --format json",
+            "main-agent self recover --format json --idempotency-key recover-12345678",
+            "main-agent rehydrate --format text",
+            "main-agent status --format json extra",
+            "main-agent rebind --if-revision 01 --idempotency-key rebind-12345678 --format json",
+            "main-agent rebind --if-revision -1 --idempotency-key rebind-12345678 --format json",
+            "main-agent worker list --format json",
+            "main-agent self recover --idempotency-key recover-12345678 --format json; pwd",
+            "main-agent self recover --idempotency-key recover-12345678 --format json > /tmp/result",
+        ] {
+            assert!(
+                !exact_main_agent_capability_recovery_command(&bash_payload(command)),
+                "near-miss recovery shape admitted: {command}"
+            );
+        }
+    }
 
     #[test]
     fn provider_render_uses_the_full_aggregated_context() {

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -383,6 +383,11 @@ fn evaluate_with_io(
     let mut shadow = Vec::new();
     let mut recovery_applied = false;
     let mut execution_budgets = ExecutionBudgets::new();
+    let activity_recovery_candidate = exact_capability_recovery_candidate_for_session_coordination(
+        request,
+        raw,
+        prepared.session_coordination.is_some(),
+    );
     let operation_effect = if prepared.rules.iter().any(|prepared_rule| {
         prepared_rule.mode == RuleMode::Enforce
             && (prepared_rule.rule.timeout_posture == TimeoutPosture::EffectGated
@@ -500,6 +505,16 @@ fn evaluate_with_io(
             liveness.as_ref(),
         ) {
             Ok(outcome) => outcome,
+            Err(error)
+                if activity_recovery_candidate
+                    && matches!(rule.capability, Capability::SessionActivity { .. })
+                    && activity_recovery_failure_is_deferrable(&error) =>
+            {
+                simple(
+                    DecisionAction::Allow,
+                    "activity-recovery-deferred-to-coordination",
+                )
+            }
             Err(error) if error.code == "capability-timeout" => timeout_outcome(
                 loaded,
                 request,
@@ -525,6 +540,29 @@ fn evaluate_with_io(
         raw,
         prepared.session_coordination,
         CoordinationExecution::new(coordination_mode, operation_effect, coordination.unmanaged),
+    )
+}
+
+fn exact_capability_recovery_candidate_for_session_coordination(
+    request: &NormalizedRequest,
+    raw: &[u8],
+    has_session_coordination: bool,
+) -> bool {
+    has_session_coordination
+        && request.event == "PreToolUse"
+        && request.matcher.as_deref() == Some("Bash")
+        && crate::adapter::exact_main_agent_capability_recovery_command(raw)
+}
+
+fn activity_recovery_failure_is_deferrable(error: &HookError) -> bool {
+    matches!(
+        error.code.as_str(),
+        "session-activity-failed"
+            | "capability-unavailable"
+            | "capability-timeout"
+            | "capability-wait-failed"
+            | "capability-input-failed"
+            | "capability-output-failed"
     )
 }
 

--- a/crates/agent-hook/tests/coordination_ingress.rs
+++ b/crates/agent-hook/tests/coordination_ingress.rs
@@ -118,6 +118,222 @@ capability = {{ id = "agent-session.coordination.v1", reason_code = "coordinatio
     )
 }
 
+fn activity_recovery_policy(include_coordination: bool) -> String {
+    format!(
+        r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "runtime-kit"
+version = "2026.08.22.1"
+
+[[rules]]
+id = "runtime.activity"
+products = ["codex"]
+events = ["PreToolUse"]
+matcher = "Bash"
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = {{ id = "agent-session.activity.v1", reason_code = "activity-recorded" }}
+
+{coordination}
+"#,
+        coordination = if include_coordination {
+            r#"[[rules]]
+id = "runtime.coordination"
+products = ["codex"]
+events = ["PreToolUse"]
+matcher = "Bash"
+priority = 900
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "agent-session.coordination.v1", reason_code = "coordination-admitted" }"#
+        } else {
+            ""
+        }
+    )
+}
+
+#[test]
+fn exact_recovery_reaches_authenticated_coordination_when_activity_is_stale() {
+    let fixture = Fixture::new(&activity_recovery_policy(true));
+    let activity = fixture.root.join("agent-session-stale-activity");
+    fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+    fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+        .expect("activity helper mode");
+    install_coordination_handler(&fixture);
+    let capture = fixture.root.join("recovery-coordination.json");
+    let payload = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "recover-after-rehydrate",
+        "cwd": fixture.root,
+        "tool_input": {
+            "command": "main-agent self recover --idempotency-key recover-12345678 --format json"
+        }
+    })
+    .to_string();
+    let recovered = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[
+            (
+                "AGENT_SESSION_BIN",
+                activity.to_str().expect("activity path"),
+            ),
+            ("AGENT_SESSION_ID", "trusted"),
+            ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+            ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+            (
+                "COORDINATION_CAPTURE",
+                capture.to_str().expect("capture path"),
+            ),
+        ],
+    );
+    assert_eq!(
+        recovered.code,
+        0,
+        "exact recovery must reach the later authenticated coordination boundary: stdout={} stderr={}",
+        recovered.stdout_text(),
+        recovered.stderr_text()
+    );
+    assert_eq!(recovered.stdout_json()["data"]["action"], "allow");
+    assert_eq!(
+        recovered.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-recovery-deferred-to-coordination"
+    );
+    assert_eq!(
+        recovered.stdout_json()["data"]["reasons"][1]["code"],
+        "coordination-admitted"
+    );
+    assert_eq!(
+        fs::read_to_string(capture).expect("captured recovery request"),
+        payload
+    );
+}
+
+#[test]
+fn activity_recovery_degradation_requires_exact_shape_and_coordination() {
+    let commands = [
+        "pwd",
+        "main-agent self recover --idempotency-key short --format json",
+        "main-agent self recover --idempotency-key recover-12345678 --format json; pwd",
+    ];
+    for command in commands {
+        let fixture = Fixture::new(&activity_recovery_policy(true));
+        let activity = fixture.root.join("agent-session-stale-activity");
+        fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+        fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+            .expect("activity helper mode");
+        install_coordination_handler(&fixture);
+        let capture = fixture.root.join("rejected-coordination.json");
+        let payload = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "recovery-near-miss",
+            "cwd": fixture.root,
+            "tool_input": {"command": command}
+        })
+        .to_string();
+        let rejected = fixture.run_with_env(
+            &["dispatch", "--product", "codex", "--format", "json"],
+            Some(&payload),
+            &[
+                (
+                    "AGENT_SESSION_BIN",
+                    activity.to_str().expect("activity path"),
+                ),
+                ("AGENT_SESSION_ID", "trusted"),
+                ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+                ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+                (
+                    "COORDINATION_CAPTURE",
+                    capture.to_str().expect("capture path"),
+                ),
+            ],
+        );
+        assert_eq!(rejected.code, 1, "command={command}");
+        assert_eq!(rejected.stdout_json()["data"]["action"], "block");
+        assert_eq!(
+            rejected.stdout_json()["data"]["reasons"][0]["code"],
+            "runtime.activity:capability-failure-closed"
+        );
+        assert!(
+            !capture.exists(),
+            "near miss reached coordination: {command}"
+        );
+    }
+
+    let fixture = Fixture::new(&activity_recovery_policy(false));
+    let activity = fixture.root.join("agent-session-stale-activity");
+    fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+    fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+        .expect("activity helper mode");
+    let payload = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "recovery-without-transaction",
+        "cwd": fixture.root,
+        "tool_input": {
+            "command": "main-agent self recover --idempotency-key recover-12345678 --format json"
+        }
+    })
+    .to_string();
+    let rejected = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[
+            (
+                "AGENT_SESSION_BIN",
+                activity.to_str().expect("activity path"),
+            ),
+            ("AGENT_SESSION_ID", "trusted"),
+            ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+        ],
+    );
+    assert_eq!(rejected.code, 1);
+    assert_eq!(
+        rejected.stdout_json()["data"]["reasons"][0]["code"],
+        "runtime.activity:capability-failure-closed"
+    );
+
+    let fixture = Fixture::new(&activity_recovery_policy(true));
+    let activity = fixture.root.join("agent-session-stale-activity");
+    fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+    fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+        .expect("activity helper mode");
+    install_coordination_handler_with(&fixture, "#!/bin/sh\nexit 70\n");
+    let payload = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "recovery-with-failed-transaction",
+        "cwd": fixture.root,
+        "tool_input": {
+            "command": "main-agent self recover --idempotency-key recover-12345678 --format json"
+        }
+    })
+    .to_string();
+    let rejected = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[
+            (
+                "AGENT_SESSION_BIN",
+                activity.to_str().expect("activity path"),
+            ),
+            ("AGENT_SESSION_ID", "trusted"),
+            ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+            ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+        ],
+    );
+    assert_eq!(rejected.code, 1);
+    assert_eq!(rejected.stdout_json()["data"]["action"], "block");
+    assert_eq!(
+        rejected.stdout_json()["data"]["reasons"][1]["code"],
+        "runtime.coordination:capability-failure-closed"
+    );
+}
+
 fn install_foreign_owner(fixture: &Fixture) {
     install_session_mode(fixture, "enforce");
     let now = now_epoch();


### PR DESCRIPTION
## Summary

Preserve a narrow authenticated recovery ingress when the early activity guard is stale, so exact Main Agent recovery commands can reach the later locked coordination transaction without weakening ordinary shell enforcement.

## Problem

- Expected: exact Main Agent recovery operations reach the authenticated coordination handler, which remains authoritative for allow or block.
- Actual: priority-10 activity failure closed before the priority-900 coordination transaction could run, so recovery itself was blocked with `owner-unclaimed`/capability diagnostics.
- Impact: an Agent Console session could not rehydrate its private capability after runtime/session discontinuity; every subsequent shell operation was denied.

## Reproduction

1. Install the canonical activity and coordination rules.
2. Make the activity handler return its typed stale-capability failure.
3. Invoke exact `main-agent self recover` with a valid session key and revision.
4. Observe the released hook block at the activity rule before the coordination handler receives a payload.

## Issues Found

Refs sympoies/agent-runtime-kit#41

## Fix Approach

- Recognize only the finite exact Main Agent recovery command shapes.
- Defer only deferrable activity failures, and only when a selected locked coordination rule exists.
- Keep the later coordination transaction authoritative and fail closed if it rejects or fails.
- Keep ordinary Bash, malformed recovery shapes, shell composition, redirects, worker operations, and missing coordination blocked.

## Test-First Evidence

- RED: exact recovery was blocked by `coord.codex.pre-tool-use.bash.activity:capability-failure-closed`; the coordination capture was absent.
- GREEN: the exact recovery reaches locked coordination with reason `activity-recovery-deferred-to-coordination`.
- Negative matrix remains fail-closed for non-exact, composed, redirected, malformed, worker, missing-coordination, and rejected-coordination cases.
- Durable evidence is bound to baseline `347b6d94845c5b7824cc862713ca16e645b89a5f` and delivery `04f382468fe7fbfdeab69bbbe30b0440bf152a4b`.

## Test plan

- `cargo test -p nils-agent-hook --test coordination_ingress exact_recovery_reaches_authenticated_coordination_when_activity_is_stale -- --exact --nocapture` — PASS after meaningful RED.
- Focused recovery and fail-closed negative matrices — PASS.
- `cargo test -p nils-agent-hook` — PASS.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — PASS, including formatting, clippy with warnings denied, docs checks, 279 nextest tests, and doctests.
- agent-runtime-kit executable-contract consumer regression with the candidate `agent-hook` — PASS.

## Risk / Notes

- The exception is intentionally narrow and command-shape exact. The main residual risk is accidental recognizer broadening; negative regressions cover shell composition, redirects, malformed arguments, workers, and missing/failed coordination.
- This PR does not release or deploy nils-cli. agent-runtime-kit adoption remains gated on a separately authorized release.
