### PR TITLE
fix(agent-session): normalize DSH bridge lifecycle [skip ci]

### DIFF
--- a/crates/agent-session/docs/turn-state-contract.md
+++ b/crates/agent-session/docs/turn-state-contract.md
@@ -73,6 +73,9 @@ the activity document. Provider identifiers use the admitted event provider's
 runtime-scoped projection domain. Native external DSH records continue to take
 turn evidence only from their plugin-owned liveness sidecar and reject this
 turn-event ingress.
+For the matched alias, `activity hook --agent dsh` maps the DSH bridge's
+`pre_llm_call` and `post_llm_call` callbacks to observed start and authoritative
+completion without enabling Hermes approval callbacks for DSH.
 
 The host receive time is canonical. Provider time is accepted only as inert
 metadata in v1 and never advances state ahead of host observation. Runtime id

--- a/crates/agent-session/src/activity/provider.rs
+++ b/crates/agent-session/src/activity/provider.rs
@@ -122,10 +122,10 @@ pub(super) fn normalize_provider_hook(
         (AgentKind::Claude, "Notification", Some("idle_prompt")) => {
             (TurnEventKind::TurnCompleted, None, Confidence::Observed)
         }
-        (AgentKind::Hermes, "pre_llm_call", _) => {
+        (AgentKind::Hermes | AgentKind::Dsh, "pre_llm_call", _) => {
             (TurnEventKind::TurnStarted, None, Confidence::Observed)
         }
-        (AgentKind::Hermes, "post_llm_call", _) => (
+        (AgentKind::Hermes | AgentKind::Dsh, "post_llm_call", _) => (
             TurnEventKind::TurnCompleted,
             None,
             Confidence::Authoritative,

--- a/crates/agent-session/tests/integration/cli.rs
+++ b/crates/agent-session/tests/integration/cli.rs
@@ -1849,6 +1849,76 @@ fn agent_console_dsh_profile_admits_dsh_activity_for_hermes_transport_only() {
     )
     .expect("write session record");
 
+    let hook_env = [
+        ("AGENT_SESSION_ID", id.as_str()),
+        ("AGENT_SESSION_RUNTIME_ID", runtime_id.as_str()),
+        ("AGENT_SESSION_STATE_DIR", state_arg.as_str()),
+    ];
+    let bridge_hook = |event: &str| {
+        run_with_stdin(
+            tmp.path(),
+            &["activity", "hook", "--agent", "dsh", "--event", event],
+            &hook_env,
+            &json!({
+                "session_id": "provider-session",
+                "turn_id": "bridge-turn-1"
+            })
+            .to_string(),
+        )
+    };
+    let activity_status = || {
+        run(
+            tmp.path(),
+            &[
+                "--state-dir",
+                &state_arg,
+                "activity",
+                "status",
+                &id,
+                "--format",
+                "json",
+            ],
+            &[],
+        )
+    };
+
+    let bridge_started = bridge_hook("pre_llm_call");
+    assert_eq!(
+        bridge_started.code,
+        0,
+        "stderr={}",
+        bridge_started.stderr_text()
+    );
+    let bridge_started_status = activity_status().stdout_json();
+    let bridge_started_state = &data(&bridge_started_status)["turn_state"];
+    assert_eq!(bridge_started_state["phase"], "working");
+    assert_eq!(bridge_started_state["source"]["provider"], "dsh");
+    assert_eq!(
+        bridge_started_state["current_turn"]["provider_turn_id"],
+        projected_provider_identifier(&runtime_id, "dsh", "turn", "bridge-turn-1")
+    );
+    let bridge_started_revision = bridge_started_state["revision"]
+        .as_u64()
+        .expect("bridge started revision");
+
+    let bridge_completed = bridge_hook("post_llm_call");
+    assert_eq!(
+        bridge_completed.code,
+        0,
+        "stderr={}",
+        bridge_completed.stderr_text()
+    );
+    let bridge_completed_status = activity_status().stdout_json();
+    let bridge_completed_state = &data(&bridge_completed_status)["turn_state"];
+    assert_eq!(bridge_completed_state["phase"], "waiting");
+    assert_eq!(bridge_completed_state["last_turn"]["outcome"], "completed");
+    assert!(
+        bridge_completed_state["revision"]
+            .as_u64()
+            .expect("bridge completed revision")
+            > bridge_started_revision
+    );
+
     let submit = |provider: &str, event_id: &str, kind: &str| {
         run_with_stdin(
             tmp.path(),


### PR DESCRIPTION
## Summary

Teach the admitted Agent Console DSH compatibility bridge to normalize its pre/post LLM callbacks into the same turn lifecycle that Hermes already projects, without widening the exact alias admission boundary or Hermes-only approval semantics.

## Problem

- Expected: an admitted `--agent dsh --event pre_llm_call` callback advances the projected turn to `working`, and `post_llm_call` completes it and returns the session to `waiting`.
- Actual: both DSH callbacks were ignored by provider normalization, leaving the turn in `starting` and causing the runtime finish-line hook to report unavailable.
- Impact: real Agent Console DSH sessions could obtain runtime context but could not complete a governed turn.

## Reproduction

1. Start an Agent Console alias session admitted as provider `dsh`.
2. Send `activity hook --agent dsh --event pre_llm_call`.
3. Observe the projected phase remains `starting` instead of `working`.
4. Send the corresponding `post_llm_call`; no authoritative completion is recorded.

## Issues Found

Refs serenvia/sympoies-infra#213

## Fix Approach

- Normalize DSH `pre_llm_call` and `post_llm_call` only after the existing exact Agent Console alias admission gate has accepted the provider.
- Preserve Hermes-only approval events and native/external DSH rejection.
- Exercise the full CLI projection from `starting` to `working` to `waiting`, including provider and turn correlation assertions.

## Test-First Evidence

- RED: the exact Agent Console DSH lifecycle integration test failed because the projected phase remained `starting` after `pre_llm_call`.
- GREEN: after the normalization change, the same exact test observed `working`, then authoritative completion and `waiting`.
- The bound v2 evidence record identifies baseline `76a4f2d6195dba28483a4b45283e5e6bfe5fbcbc` and delivery `66291eb605802f1640e260afe5dcde0d325bae9e`.

## Test plan

- `cargo test -p nils-agent-session --test integration cli::agent_console_dsh_profile_admits_dsh_activity_for_hermes_transport_only -- --exact --nocapture` — passed.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — passed; 1169 tests, formatting, clippy, docs, audits, and doctests green.
- `.agents/scripts/pre-pr.sh` — passed against the pushed signed head.
- Focused security review for the exact diff fingerprint — no verified material findings.

## Risk / Notes

- The mapping is intentionally limited to the already-admitted Agent Console DSH alias. Native and external DSH remain rejected, and Hermes approval semantics are unchanged.
- This PR uses `[skip ci]`; validation is local/manual because the parent deployment explicitly forbids GitHub Actions usage.
