### PR TITLE
fix(agent-hook): preserve DSH activity provider identity [skip ci]

### DIFF
--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -218,6 +218,13 @@ derived only from the normalized DSH subject and canonical event: it sends
 provider/session/turn metadata, event kind, confidence, and digests to
 `agent-session activity event`; prompt and tool arguments are never parsed for
 that event. A managed activity identity requires both session and runtime ID.
+When Main Agent policy replaces the DSH ingress subject with its authenticated
+coordination owner, the runtime transports the original DSH provider session
+only through the private `DSH_RUNTIME_KIT_PROVIDER_SESSION_ID` subprocess
+environment. Activity normalization uses that value for provider correlation
+while every other policy group continues to use the owner subject. The public
+ingress schema is unchanged, and `agent-session` still rejects a value that
+does not match the provider session already bound to the active runtime.
 
 Operation lifecycle is one locked after-policy capability. An unmanaged process
 does not run it. A managed process requires session ID, an absolute capability

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -20,6 +20,7 @@ const DSH_INGRESS_V1: &str = "agent-hook.dsh-ingress.v1";
 const DSH_INGRESS_V2: &str = "agent-hook.dsh-ingress.v2";
 const DSH_INGRESS_V3: &str = "agent-hook.dsh-ingress.v3";
 const DSH_INGRESS_V4: &str = "agent-hook.dsh-ingress.v4";
+const DSH_RUNTIME_KIT_PROVIDER_SESSION_ID_ENV: &str = "DSH_RUNTIME_KIT_PROVIDER_SESSION_ID";
 const MAX_PROVIDER_ID_CHARS: usize = 256;
 const MAX_MUTATION_TARGETS: usize = 256;
 const MAX_MUTATION_TARGET_BYTES: usize = 4096;
@@ -615,6 +616,11 @@ pub fn normalize_activity_event(
                 "DSH activity event is missing its normalized subject",
             )
         })?;
+        let provider_session_id = std::env::var(DSH_RUNTIME_KIT_PROVIDER_SESSION_ID_ENV)
+            .ok()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| subject.session_id.clone());
+        validate_provider_id("provider_session_id", &provider_session_id)?;
         let kind = match request.event.as_str() {
             "UserPromptSubmit" => "turn_started",
             "PreToolUse" | "PostToolUse" | "PostToolUseFailure" => "progress",
@@ -632,7 +638,7 @@ pub fn normalize_activity_event(
             ),
             runtime_id: runtime_id.to_string(),
             provider: "dsh",
-            provider_session_id: Some(subject.session_id.clone()),
+            provider_session_id: Some(provider_session_id),
             provider_turn_id: Some(subject.turn.to_string()),
             kind,
             failure_reason: None,

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -518,6 +518,10 @@ fn dsh_agent_activity_emits_only_metadata_and_partial_identity_fails_closed() {
             ("AGENT_SESSION_ID", "managed-session"),
             ("AGENT_SESSION_RUNTIME_ID", "runtime-1"),
             (
+                "DSH_RUNTIME_KIT_PROVIDER_SESSION_ID",
+                "dsh-provider-session-1",
+            ),
+            (
                 "AGENT_SESSION_BIN",
                 helper.to_str().expect("helper path UTF-8"),
             ),
@@ -532,7 +536,7 @@ fn dsh_agent_activity_emits_only_metadata_and_partial_identity_fails_closed() {
         serde_json::from_slice(&fs::read(&event_log).expect("activity event")).expect("event JSON");
     assert_eq!(event["schema_version"], "agent-session.turn-event.v1");
     assert_eq!(event["provider"], "dsh");
-    assert_eq!(event["provider_session_id"], "dsh-session-1");
+    assert_eq!(event["provider_session_id"], "dsh-provider-session-1");
     assert_eq!(event["provider_turn_id"], "1");
     assert_eq!(event["kind"], "turn_started");
     assert!(!event.to_string().contains(secret_prompt));


### PR DESCRIPTION
## Summary

- Keep the original DSH provider session separate from the authenticated Main Agent coordination owner during activity normalization.
- Preserve the public ingress schema, metadata-only activity payload, validation, and downstream runtime correlation checks.
- Refs https://github.com/serenvia/sympoies-infra/issues/213

## Test plan

- `cargo test -p nils-agent-hook --test dsh_policy` (38 passed)
- `cargo clippy -p nils-agent-hook --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Focused security review: no findings for diff fingerprint `67140b2b809032b9a98f53b36a6c66fb5f8009339dfd35880be62f9efc49d83c`
- Complete test-first evidence is bound to signed head `1ec5f0b4d9a095de237397d68966784b64810b1f`.

GitHub Actions are intentionally not dispatched because private-repository Actions storage is unavailable; validation and deployment are local/manual.
