### PR TITLE
fix(agent-session): admit sidecar-owned DSH hook activity

### DIFF
--- a/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
+++ b/crates/agent-session/docs/specs/main-agent-dsh-external-runtime-v1.md
@@ -22,6 +22,13 @@ that issue.
 | Worker-side bootstrap/checkpoint | worker agent runs the existing `main-agent bootstrap` / `main-agent checkpoint` verbs |
 | Stop/interrupt of a lane runtime | plugin (`worker stop-runtime` returns a typed refusal for dsh) |
 
+The plugin's ordinary DSH provider hooks may still invoke the shared
+`agent-session.activity.v1` policy capability. For an external lane, an event
+for the exact active runtime generation is a non-mutating success only when the
+sidecar already proves the live turn. The returned state is projected from the
+sidecar; no competing activity document is advanced. A stale generation or
+unproven sidecar remains a closed failure.
+
 ## `capabilities --provider dsh`
 
 `main-agent capabilities --provider dsh --format json` returns

--- a/crates/agent-session/docs/turn-state-contract.md
+++ b/crates/agent-session/docs/turn-state-contract.md
@@ -71,8 +71,11 @@ remain provider mismatches. The matched alias accepts only DSH lifecycle
 events; Hermes remains its terminal transport identity and cannot also mutate
 the activity document. Provider identifiers use the admitted event provider's
 runtime-scoped projection domain. Native external DSH records continue to take
-turn evidence only from their plugin-owned liveness sidecar and reject this
-turn-event ingress.
+turn evidence only from their plugin-owned liveness sidecar. A DSH provider-hook
+event for the exact active runtime generation succeeds only when that sidecar
+already proves a live turn; the result projects the sidecar state and does not
+mutate the activity document. Stale generations, missing or invalid sidecars,
+and every other provider remain fail-closed.
 For the matched alias, `activity hook --agent dsh` maps the DSH bridge's
 `pre_llm_call` and `post_llm_call` callbacks to observed start and authoritative
 completion without enabling Hermes approval callbacks for DSH.

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -2551,6 +2551,46 @@ fn ingest_event_with_lock(
     };
     let record = load_session_record(context, &observed.id)?;
     crate::ensure_same_session_identity(&observed, &record)?;
+    if crate::dsh_external::is_external_record(&record)
+        && event.provider == AgentKind::Dsh.as_str()
+        && event.source_kind == SourceKind::ProviderHook
+    {
+        let active_runtime_id = record
+            .runtime
+            .as_ref()
+            .map(|runtime| runtime.launch_id.as_str())
+            .unwrap_or_default();
+        if active_runtime_id.is_empty() || event.runtime_id != active_runtime_id {
+            return Err(CliError::data(
+                "runtime-id-mismatch",
+                "activity event does not belong to the active runtime generation",
+                Some(json!({ "id": record.id })),
+            ));
+        }
+        let turn_state = crate::dsh_external::external_turn_state(&record).ok_or_else(|| {
+            CliError::runtime(
+                "external-dsh-activity-unavailable",
+                "external DSH activity could not be proven by the plugin liveness sidecar",
+                Some(json!({ "id": record.id })),
+            )
+        })?;
+        if turn_state.phase != TurnPhase::Working || turn_state.current_turn.is_none() {
+            return Err(CliError::runtime(
+                "external-dsh-activity-unavailable",
+                "external DSH activity does not prove a live plugin-owned turn",
+                Some(json!({ "id": record.id })),
+            ));
+        }
+        // The plugin sidecar is the sole activity authority for an external
+        // DSH lane. A provider hook still needs a successful capability result
+        // so policy admission can continue, but it must not create a competing
+        // activity document or advance a second turn-state reducer.
+        return Ok(ActivityResult {
+            id: record.id,
+            turn_state,
+            duplicate: true,
+        });
+    }
     if !session_accepts_activity_provider(&record, &event.provider) {
         return Err(CliError::data(
             "activity-provider-mismatch",

--- a/crates/agent-session/tests/integration/cli.rs
+++ b/crates/agent-session/tests/integration/cli.rs
@@ -2150,7 +2150,7 @@ capability = { id = "dsh.policy.v1", group = "agent-activity" }
     assert_eq!(
         external_dsh.stdout_json()["error"]["code"],
         "activity-provider-mismatch",
-        "external DSH records take activity only from the plugin liveness sidecar"
+        "changing the provider field cannot turn an ordinary session into an external DSH lane"
     );
 }
 

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38673,6 +38673,87 @@ fn main_agent_worker_start_dsh_replay_joins_the_pre_attachment_authority_fence()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("liveness epoch")
         .as_secs();
+    let state_arg = state_dir.to_string_lossy().into_owned();
+    let submit_external_activity = |event_id: &str, event_runtime_id: &str| {
+        run_resolved(
+            "agent-session",
+            &[
+                "--state-dir",
+                &state_arg,
+                "activity",
+                "event",
+                "worker-dsh-fence-replay",
+                "--stdin",
+                "--format",
+                "json",
+            ],
+            &CmdOptions::new().with_cwd(&checkout).with_stdin_str(
+                &json!({
+                    "schema_version": "agent-session.turn-event.v1",
+                    "event_id": event_id,
+                    "runtime_id": event_runtime_id,
+                    "provider": "dsh",
+                    "provider_session_id": "provider-session",
+                    "provider_turn_id": "1",
+                    "kind": "turn_started",
+                    "confidence": "observed",
+                    "source_kind": "provider_hook"
+                })
+                .to_string(),
+            ),
+        )
+    };
+    let unavailable_activity = submit_external_activity("external-dsh-missing-sidecar", &launch_id);
+    assert_eq!(
+        unavailable_activity.stdout_json()["error"]["code"],
+        "external-dsh-activity-unavailable",
+        "a missing sidecar cannot be converted into successful hook admission"
+    );
+    write_private_json(
+        Path::new(&liveness_file),
+        &json!({
+            "schema_version": "main-agent.dsh-runtime-liveness.v1",
+            "launch_id": launch_id,
+            "harness": harness_identity_json(),
+            "lane": { "state": "open" },
+            "turn": {
+                "phase": "waiting",
+                "phase_changed_at": liveness_epoch.to_string(),
+                "current_turn": null,
+                "last_turn": null
+            },
+            "updated_at": liveness_epoch
+        }),
+    );
+    let waiting_activity = submit_external_activity("external-dsh-waiting", &launch_id);
+    assert_eq!(
+        waiting_activity.stdout_json()["error"]["code"],
+        "external-dsh-activity-unavailable",
+        "an idle lane does not prove the live turn required by a provider hook"
+    );
+    write_private_json(
+        Path::new(&liveness_file),
+        &json!({
+            "schema_version": "main-agent.dsh-runtime-liveness.v1",
+            "launch_id": launch_id,
+            "harness": harness_identity_json(),
+            "lane": { "state": "open" },
+            "turn": {
+                "phase": "working",
+                "phase_changed_at": liveness_epoch.to_string(),
+                "current_turn": null,
+                "last_turn": null
+            },
+            "updated_at": liveness_epoch
+        }),
+    );
+    let incoherent_activity =
+        submit_external_activity("external-dsh-working-without-turn", &launch_id);
+    assert_eq!(
+        incoherent_activity.stdout_json()["error"]["code"],
+        "external-dsh-activity-unavailable",
+        "working without a current turn is not coherent provider-hook evidence"
+    );
     write_private_json(
         Path::new(&liveness_file),
         &json!({
@@ -38689,6 +38770,31 @@ fn main_agent_worker_start_dsh_replay_joins_the_pre_attachment_authority_fence()
             "updated_at": liveness_epoch
         }),
     );
+    let activity_path = state_dir.join("sessions/worker-dsh-fence-replay/activity.json");
+    let activity_before = fs::read(&activity_path).expect("pre-hook activity document");
+    let stale_activity = submit_external_activity(
+        "external-dsh-stale-hook-pre-step",
+        "stale-runtime-generation",
+    );
+    assert_eq!(
+        stale_activity.stdout_json()["error"]["code"],
+        "runtime-id-mismatch",
+        "a non-mutating external hook still belongs to exactly one runtime generation"
+    );
+    let activity = submit_external_activity("external-dsh-hook-pre-step", &launch_id);
+    assert_eq!(
+        activity.code,
+        0,
+        "the external DSH hook is a non-mutating success because the sidecar owns turn evidence: {}",
+        activity.stdout_text()
+    );
+    assert_eq!(data(&activity)["duplicate"], true);
+    assert_eq!(data(&activity)["turn_state"]["phase"], "working");
+    assert_eq!(
+        fs::read(&activity_path).expect("post-hook activity document"),
+        activity_before,
+        "direct hook activity must not create a competing activity document"
+    );
     let heartbeat_argv = launch["broker_heartbeat_argv"]
         .as_array()
         .expect("heartbeat argv")
@@ -38701,7 +38807,6 @@ fn main_agent_worker_start_dsh_replay_joins_the_pre_attachment_authority_fence()
         .stderr(Stdio::piped())
         .spawn()
         .expect("spawn emitted heartbeat argv");
-    let state_arg = state_dir.to_string_lossy().into_owned();
     let ready_deadline = Instant::now() + Duration::from_secs(10);
     loop {
         let status = run(


### PR DESCRIPTION
## Summary

- treat external DSH provider-hook activity as a non-mutating projection of the plugin sidecar
- require an exact runtime generation and a coherent live `working` turn
- keep missing, idle, incoherent, invalid, and stale evidence fail-closed

Refs serenvia/sympoies-infra#213.

## Test plan

- RED: focused external worker integration returned `activity-provider-mismatch` (exit 65)
- GREEN: focused external worker integration, including missing/idle/incoherent/stale cases
- existing Agent Console DSH transport alias integration
- all 868 `nils-agent-session` unit tests
- clippy with warnings denied, rustfmt, and diff hygiene
- focused security/correctness review for fingerprint `ee77b55533b4964c4f515cb033b50426504d019b39f37c79b8597f48ae3890f0`: no findings

Validation and deployment are local/manual; GitHub Actions are intentionally not used because private Actions storage is unavailable.
