### PR TITLE
fix(agent-session): avoid external DSH hook lock contention

### DIFF
--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -2534,6 +2534,9 @@ fn ingest_event_with_lock(
 ) -> Result<ActivityResult, CliError> {
     validate_event(&event, admission)?;
     let observed = load_session_record(context, id)?;
+    if let Some(result) = external_dsh_provider_hook_activity(context, &observed, &event)? {
+        return Ok(result);
+    }
     let record_lock = match lock_mode {
         ActivityLockMode::Blocking => crate::acquire_session_record_lock(context, &observed.id)?,
         ActivityLockMode::NonBlocking => {
@@ -2551,46 +2554,6 @@ fn ingest_event_with_lock(
     };
     let record = load_session_record(context, &observed.id)?;
     crate::ensure_same_session_identity(&observed, &record)?;
-    if crate::dsh_external::is_external_record(&record)
-        && event.provider == AgentKind::Dsh.as_str()
-        && event.source_kind == SourceKind::ProviderHook
-    {
-        let active_runtime_id = record
-            .runtime
-            .as_ref()
-            .map(|runtime| runtime.launch_id.as_str())
-            .unwrap_or_default();
-        if active_runtime_id.is_empty() || event.runtime_id != active_runtime_id {
-            return Err(CliError::data(
-                "runtime-id-mismatch",
-                "activity event does not belong to the active runtime generation",
-                Some(json!({ "id": record.id })),
-            ));
-        }
-        let turn_state = crate::dsh_external::external_turn_state(&record).ok_or_else(|| {
-            CliError::runtime(
-                "external-dsh-activity-unavailable",
-                "external DSH activity could not be proven by the plugin liveness sidecar",
-                Some(json!({ "id": record.id })),
-            )
-        })?;
-        if turn_state.phase != TurnPhase::Working || turn_state.current_turn.is_none() {
-            return Err(CliError::runtime(
-                "external-dsh-activity-unavailable",
-                "external DSH activity does not prove a live plugin-owned turn",
-                Some(json!({ "id": record.id })),
-            ));
-        }
-        // The plugin sidecar is the sole activity authority for an external
-        // DSH lane. A provider hook still needs a successful capability result
-        // so policy admission can continue, but it must not create a competing
-        // activity document or advance a second turn-state reducer.
-        return Ok(ActivityResult {
-            id: record.id,
-            turn_state,
-            duplicate: true,
-        });
-    }
     if !session_accepts_activity_provider(&record, &event.provider) {
         return Err(CliError::data(
             "activity-provider-mismatch",
@@ -2841,6 +2804,115 @@ fn ingest_event_with_lock(
         turn_state: state,
         duplicate: false,
     })
+}
+
+fn external_dsh_provider_hook_activity(
+    context: &CliContext,
+    observed: &SessionRecord,
+    event: &TurnEvent,
+) -> Result<Option<ActivityResult>, CliError> {
+    if !crate::dsh_external::is_external_record(observed)
+        || event.provider != AgentKind::Dsh.as_str()
+        || event.source_kind != SourceKind::ProviderHook
+    {
+        return Ok(None);
+    }
+    let active_runtime_id = observed
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .unwrap_or_default();
+    if active_runtime_id.is_empty() || event.runtime_id != active_runtime_id {
+        return Err(CliError::data(
+            "runtime-id-mismatch",
+            "activity event does not belong to the active runtime generation",
+            Some(json!({ "id": observed.id })),
+        ));
+    }
+    let observed_turn = live_external_dsh_turn(observed)?;
+
+    // This path projects the plugin-owned sidecar and never mutates the
+    // activity document, so waiting behind the mutable session-record lock can
+    // only consume the hook admission budget. Re-read after the sidecar read
+    // and require the exact session/runtime identity and validated liveness
+    // binding to remain stable instead.
+    let current = load_session_record(context, &observed.id)?;
+    crate::ensure_same_session_identity(observed, &current)?;
+    if !crate::dsh_external::is_external_record(&current)
+        || !crate::dsh_external::same_liveness_binding(observed, &current)
+    {
+        return Err(CliError::runtime(
+            "session-runtime-changed",
+            "external DSH liveness authority changed during activity admission",
+            Some(json!({ "id": observed.id })),
+        ));
+    }
+    let current_runtime_id = current
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .unwrap_or_default();
+    if event.runtime_id != current_runtime_id {
+        return Err(CliError::data(
+            "runtime-id-mismatch",
+            "activity event does not belong to the active runtime generation",
+            Some(json!({ "id": current.id })),
+        ));
+    }
+    let turn_state = live_external_dsh_turn(&current)?;
+    if turn_state != observed_turn {
+        return Err(CliError::runtime(
+            "external-dsh-activity-unavailable",
+            "external DSH activity changed during sidecar admission",
+            Some(json!({ "id": current.id })),
+        ));
+    }
+    let final_record = load_session_record(context, &current.id)?;
+    crate::ensure_same_session_identity(&current, &final_record)?;
+    if !crate::dsh_external::is_external_record(&final_record)
+        || !crate::dsh_external::same_liveness_binding(&current, &final_record)
+    {
+        return Err(CliError::runtime(
+            "session-runtime-changed",
+            "external DSH liveness authority changed after sidecar admission",
+            Some(json!({ "id": current.id })),
+        ));
+    }
+    let final_runtime_id = final_record
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .unwrap_or_default();
+    if event.runtime_id != final_runtime_id {
+        return Err(CliError::data(
+            "runtime-id-mismatch",
+            "activity event does not belong to the active runtime generation",
+            Some(json!({ "id": final_record.id })),
+        ));
+    }
+    Ok(Some(ActivityResult {
+        id: final_record.id,
+        turn_state,
+        duplicate: true,
+    }))
+}
+
+fn live_external_dsh_turn(record: &SessionRecord) -> Result<TurnState, CliError> {
+    let turn_state = crate::dsh_external::external_turn_state(record).ok_or_else(|| {
+        CliError::runtime(
+            "external-dsh-activity-unavailable",
+            "external DSH activity could not be proven by the plugin liveness sidecar",
+            Some(json!({ "id": record.id })),
+        )
+    })?;
+    if turn_state.phase != TurnPhase::Working || turn_state.current_turn.is_none() {
+        return Err(CliError::runtime(
+            "external-dsh-activity-unavailable",
+            "external DSH activity does not prove a live plugin-owned turn",
+            Some(json!({ "id": record.id })),
+        ));
+    }
+    Ok(turn_state)
 }
 
 fn session_accepts_activity_provider(record: &SessionRecord, provider: &str) -> bool {

--- a/crates/agent-session/src/dsh_external.rs
+++ b/crates/agent-session/src/dsh_external.rs
@@ -216,6 +216,14 @@ fn recorded_liveness_path(record: &SessionRecord) -> Option<PathBuf> {
     Some(path.to_path_buf())
 }
 
+/// Whether two snapshots retain the same validated external-liveness binding.
+/// The activity fast path uses this across its lock-free record re-read so a
+/// concurrent record mutation cannot redirect sidecar authority.
+pub(crate) fn same_liveness_binding(left: &SessionRecord, right: &SessionRecord) -> bool {
+    let left = recorded_liveness_path(left);
+    left.is_some() && left == recorded_liveness_path(right)
+}
+
 /// Whether the record's sidecar path is the exact path this CLI derives for it.
 /// Only a context-bearing caller can check this; the context-free reader keeps
 /// the shape checks above.

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -38781,6 +38781,94 @@ fn main_agent_worker_start_dsh_replay_joins_the_pre_attachment_authority_fence()
         "runtime-id-mismatch",
         "a non-mutating external hook still belongs to exactly one runtime generation"
     );
+    let record_lock_path = state_dir.join("session-locks/worker-dsh-fence-replay.lock");
+    let record_lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&record_lock_path)
+        .expect("external DSH record lock");
+    // SAFETY: the test owns this descriptor and releases it before dropping it.
+    assert_eq!(
+        unsafe { libc::flock(record_lock.as_raw_fd(), libc::LOCK_EX) },
+        0
+    );
+    let mut concurrent_activity = Command::new(bin::resolve("agent-session"));
+    concurrent_activity
+        .current_dir(&checkout)
+        .args([
+            "--state-dir",
+            &state_arg,
+            "activity",
+            "event",
+            "worker-dsh-fence-replay",
+            "--stdin",
+            "--format",
+            "json",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut concurrent_activity = concurrent_activity
+        .spawn()
+        .expect("spawn external DSH activity under record contention");
+    let concurrent_event = json!({
+        "schema_version": "agent-session.turn-event.v1",
+        "event_id": "external-dsh-hook-under-record-contention",
+        "runtime_id": launch_id,
+        "provider": "dsh",
+        "provider_session_id": "provider-session",
+        "provider_turn_id": "1",
+        "kind": "turn_started",
+        "confidence": "observed",
+        "source_kind": "provider_hook"
+    })
+    .to_string();
+    concurrent_activity
+        .stdin
+        .take()
+        .expect("external activity stdin")
+        .write_all(concurrent_event.as_bytes())
+        .expect("write external activity event");
+    let contention_deadline = Instant::now() + Duration::from_millis(250);
+    let completed_under_contention = loop {
+        if concurrent_activity
+            .try_wait()
+            .expect("poll external activity under contention")
+            .is_some()
+        {
+            break true;
+        }
+        if Instant::now() >= contention_deadline {
+            concurrent_activity
+                .kill()
+                .expect("kill activity blocked behind an irrelevant record lock");
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    };
+    // SAFETY: the test owns the locked descriptor.
+    assert_eq!(
+        unsafe { libc::flock(record_lock.as_raw_fd(), libc::LOCK_UN) },
+        0
+    );
+    let concurrent_output = concurrent_activity
+        .wait_with_output()
+        .expect("external activity output under contention");
+    assert!(
+        completed_under_contention,
+        "sidecar-owned external DSH hook activity must not wait on the mutable activity record lock"
+    );
+    assert!(
+        concurrent_output.status.success(),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&concurrent_output.stdout),
+        String::from_utf8_lossy(&concurrent_output.stderr)
+    );
+    assert_eq!(
+        fs::read(&activity_path).expect("activity document after contended hook"),
+        activity_before,
+        "contended external hook activity remains non-mutating"
+    );
     let activity = submit_external_activity("external-dsh-hook-pre-step", &launch_id);
     assert_eq!(
         activity.code,


### PR DESCRIPTION
## Summary

- Admit exact sidecar-owned external DSH provider-hook activity without waiting on the mutable session-record lock.
- Revalidate session identity, runtime generation, liveness binding, and live turn before returning.
- Retain existing fail-closed locking for ordinary reducers and add a real lock-contention regression.

Refs serenvia/sympoies-infra#213

## Test plan

- Focused external DSH record-lock contention integration test: pass.
- Repository local-fast gate: 1169 tests passed, plus clippy, fmt, audits, and doctests.
- Focused security and testing review: no remaining findings.
- Local/manual deployment and fresh m4 acceptance follow merge; GitHub Actions intentionally unused.
