### PR TITLE
fix(agent-hook): honor advisory checkout coordination

### DIFF
--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -3149,6 +3149,9 @@ fn checkout_lease(
     run_child: &mut dyn FnMut(Command) -> Result<Output, HookError>,
 ) -> Result<Outcome, HookError> {
     let group = DshCapabilityGroup::CheckoutLeaseGuard;
+    if crate::liveness::coordination_failure_mode().is_some() {
+        return Ok(Outcome::allow(group));
+    }
     if effect == OperationEffectClass::ReadOnly {
         return Ok(Outcome::allow(group));
     }

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -2014,6 +2014,77 @@ fn checkout_lease_is_session_bound_and_clean_reclaim_is_not_early() {
 }
 
 #[test]
+fn checkout_lease_does_not_contend_in_authenticated_advisory_mode() {
+    let fixture = Fixture::new(&policy("checkout-lease-guard", "dsh"));
+    git(&fixture, &["init", "--quiet"]);
+    git(&fixture, &["config", "user.email", "test@example.com"]);
+    git(&fixture, &["config", "user.name", "Test"]);
+    fs::write(fixture.root.join("tracked.txt"), "base\n").expect("tracked file");
+    git(&fixture, &["add", "--all"]);
+    git(&fixture, &["commit", "--quiet", "-m", "test: initial"]);
+
+    let owner = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&request_for_session(
+            &fixture,
+            "lease-owner",
+            "bash",
+            json!({"command": "printf ok"}),
+        )),
+    );
+    assert_eq!(owner.code, 0, "envelope={}", owner.stdout_text());
+
+    let lease_root = fixture
+        .state_home
+        .join("dsh-runtime-kit/agent-hook/dsh-checkout-leases");
+    let checkout_lease_dir = fs::read_dir(&lease_root)
+        .expect("lease root")
+        .next()
+        .expect("checkout lease directory")
+        .expect("checkout lease entry")
+        .path();
+    let lease_path = checkout_lease_dir.join("lease.json");
+    let owner_lease = fs::read(&lease_path).expect("owner lease JSON");
+
+    let session_dir = fixture.session_state.join("sessions/lease-advisory");
+    fs::create_dir_all(&session_dir).expect("session directory");
+    let session_record = session_dir.join("session.json");
+    fs::write(
+        &session_record,
+        serde_json::to_vec(&json!({
+            "schema_version": "agent-session.session.v1",
+            "id": "lease-advisory",
+            "coordination_mode": "advisory",
+            "runtime": {"launch_id": "lease-advisory-incarnation"}
+        }))
+        .expect("session JSON"),
+    )
+    .expect("session record");
+    Fixture::set_private(&session_record);
+
+    let advisory = fixture.run_with_env(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&request_for_session(
+            &fixture,
+            "lease-advisory",
+            "bash",
+            json!({"command": "printf ok"}),
+        )),
+        &[
+            ("AGENT_SESSION_ID", "lease-advisory"),
+            ("AGENT_SESSION_RUNTIME_ID", "lease-advisory-incarnation"),
+            ("AGENT_SESSION_COORDINATION_MODE", "advisory"),
+        ],
+    );
+    assert_eq!(advisory.code, 0, "envelope={}", advisory.stdout_text());
+    assert_eq!(advisory.stdout_json()["data"]["action"], "allow");
+    assert_eq!(
+        fs::read(&lease_path).expect("lease JSON after advisory dispatch"),
+        owner_lease,
+    );
+}
+
+#[test]
 fn checkout_lease_applies_to_native_file_tools_without_requiring_a_command() {
     let policy = policy("checkout-lease-guard", "dsh").replace(
         "matcher = \"bash\"",


### PR DESCRIPTION
## Summary

Align the DSH checkout lease guard with the authenticated session-coordination contract so ordinary advisory sessions remain usable while enforced ownership remains fail-closed.

## Problem

- Expected: authenticated `advisory` and `off` sessions never acquire or contend the physical checkout lease.
- Actual: the checkout lease guard ran for every non-read-only DSH shell dispatch, so an advisory session was blocked by an existing clean-checkout lease.
- Impact: a correctly launched Agent Console DSH session could complete `runtime_context` but its first shell operation was blocked.

## Reproduction

1. Acquire a clean-checkout lease with one DSH session.
2. Dispatch a non-read-only-classified shell command from a second authenticated advisory session.
3. Observe `checkout-lease-guard` block the second session.

## Issues Found

- Refs https://github.com/serenvia/sympoies-infra/issues/213

## Fix Approach

- Reuse the trusted coordination-mode resolver at the checkout lease capability boundary.
- Allow only authenticated `advisory` or `off` sessions to skip physical lease handling.
- Preserve existing enforce, missing-identity, malformed-identity, dirty-checkout, and foreign-owner protections.

## Test-First Evidence

- RED: `checkout_lease_does_not_contend_in_authenticated_advisory_mode` returned exit 1 because the advisory dispatch was blocked by `checkout-lease-guard`.
- GREEN: the focused checkout-lease suite passes and confirms the advisory dispatch leaves the owner's lease bytes unchanged.

## Test plan

- `cargo test -p nils-agent-hook --test dsh_policy checkout_lease -- --nocapture`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- Public repository CI must pass before merge.

## Risk / Notes

- The new early allow depends on the existing authenticated mode resolver; forged or inconsistent environment hints remain untrusted and fail closed.
- Existing enforce lease tests remain unchanged and green.
