### PR TITLE
feat(agent-hook): add native workspace lease authority

### DIFF
--- a/completions/bash/agent-hook
+++ b/completions/bash/agent-hook
@@ -40,6 +40,9 @@ _agent__hook() {
             agent__hook,validate)
                 cmd="agent__hook__validate"
                 ;;
+            agent__hook,workspace-lease)
+                cmd="agent__hook__workspace__lease"
+                ;;
             agent__hook__finish__line,begin)
                 cmd="agent__hook__finish__line__begin"
                 ;;
@@ -70,6 +73,21 @@ _agent__hook() {
             agent__hook__recovery,status)
                 cmd="agent__hook__recovery__status"
                 ;;
+            agent__hook__workspace__lease,begin)
+                cmd="agent__hook__workspace__lease__begin"
+                ;;
+            agent__hook__workspace__lease,bind)
+                cmd="agent__hook__workspace__lease__bind"
+                ;;
+            agent__hook__workspace__lease,complete)
+                cmd="agent__hook__workspace__lease__complete"
+                ;;
+            agent__hook__workspace__lease,release)
+                cmd="agent__hook__workspace__lease__release"
+                ;;
+            agent__hook__workspace__lease,renew)
+                cmd="agent__hook__workspace__lease__renew"
+                ;;
             *)
                 ;;
         esac
@@ -77,7 +95,7 @@ _agent__hook() {
 
     case "${cmd}" in
         agent__hook)
-            opts="-h -V --config --policy --state-dir --help --version dispatch validate inventory doctor setup recovery finish-line completion"
+            opts="-h -V --config --policy --state-dir --help --version dispatch validate inventory doctor setup recovery finish-line workspace-lease completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1212,6 +1230,332 @@ _agent__hook() {
         agent__hook__validate)
             opts="-h --format --config --policy --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease)
+            opts="-h --config --policy --state-dir --help bind begin complete renew release"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease__begin)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease__bind)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease__complete)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease__release)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__lease__renew)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi

--- a/completions/zsh/_agent-hook
+++ b/completions/zsh/_agent-hook
@@ -272,6 +272,82 @@ json\:"Single-record JSON envelope (snake_case)"))' \
     ;;
 esac
 ;;
+(workspace-lease)
+_arguments "${_arguments_options[@]}" : \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_agent-hook__subcmd__workspace-lease_commands" \
+"*::: :->workspace-lease" \
+&& ret=0
+
+    case $state in
+    (workspace-lease)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:agent-hook-workspace-lease-command-$line[1]:"
+        case $line[1] in
+            (bind)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(begin)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(complete)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(renew)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(release)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (completion)
 _arguments "${_arguments_options[@]}" : \
 '--config=[Override the strict user config path]:PATH:_files' \
@@ -297,6 +373,7 @@ _agent-hook_commands() {
 'setup:Preview, apply, repair, or remove exact owned provider ingress' \
 'recovery:Create, authorize, inspect, consume, or revoke governed recovery' \
 'finish-line:Persist edit generations, execute declared validations, and enforce the DSH stop boundary' \
+'workspace-lease:Bind canonical workspaces and operate durable cross-process mutation leases' \
 'completion:Print a shell completion script' \
     )
     _describe -t commands 'agent-hook commands' commands "$@"
@@ -402,6 +479,42 @@ _agent-hook__subcmd__setup_commands() {
 _agent-hook__subcmd__validate_commands() {
     local commands; commands=()
     _describe -t commands 'agent-hook validate commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease_commands] )) ||
+_agent-hook__subcmd__workspace-lease_commands() {
+    local commands; commands=(
+'bind:Resolve canonical workspace identity and acquire one binding generation' \
+'begin:Classify one tool call and fence it before execution' \
+'complete:Complete one exact fenced operation' \
+'renew:Renew one exact binding generation' \
+'release:Release one exact binding generation' \
+    )
+    _describe -t commands 'agent-hook workspace-lease commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease__subcmd__begin_commands] )) ||
+_agent-hook__subcmd__workspace-lease__subcmd__begin_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-lease begin commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease__subcmd__bind_commands] )) ||
+_agent-hook__subcmd__workspace-lease__subcmd__bind_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-lease bind commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease__subcmd__complete_commands] )) ||
+_agent-hook__subcmd__workspace-lease__subcmd__complete_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-lease complete commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease__subcmd__release_commands] )) ||
+_agent-hook__subcmd__workspace-lease__subcmd__release_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-lease release commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-lease__subcmd__renew_commands] )) ||
+_agent-hook__subcmd__workspace-lease__subcmd__renew_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-lease renew commands' commands "$@"
 }
 
 if [ "$funcstack[1]" = "_agent-hook" ]; then

--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -49,6 +49,11 @@ printf '%s' "$FINISH_LINE_JSON" | agent-hook finish-line begin --format json
 printf '%s' "$FINISH_LINE_RUN_JSON" | agent-hook finish-line run --format json
 printf '%s' "$FINISH_LINE_JSON" | agent-hook finish-line stop --format json
 printf '%s' "$FINISH_LINE_JSON" | agent-hook finish-line status --format json
+printf '%s' "$WORKSPACE_BIND_JSON" | agent-hook workspace-lease bind
+printf '%s' "$WORKSPACE_BEGIN_JSON" | agent-hook workspace-lease begin
+printf '%s' "$WORKSPACE_COMPLETE_JSON" | agent-hook workspace-lease complete
+printf '%s' "$WORKSPACE_RENEW_JSON" | agent-hook workspace-lease renew
+printf '%s' "$WORKSPACE_RELEASE_JSON" | agent-hook workspace-lease release
 agent-hook completion zsh
 ```
 
@@ -101,6 +106,34 @@ native write/edit tools. Raw commit-producing rewrites are denied on the
 default branch while exact recovery and owned `git-cli`, `forge-cli`, and
 `semantic-commit` routes remain usable. Path-backed semantic commit messages
 and ambiguous repeated scalar options fail closed.
+
+The separate `workspace-lease` service is the native WorkspaceLease v1 policy
+provider for dsh-runtime-kit. `bind` resolves an optional DSH cwd to one
+physical Git worktree using canonical root, filesystem identity, per-worktree
+Git directory, and shared Git directory facts. Equivalent path spellings
+therefore converge while linked worktrees remain distinct. A non-Git cwd is
+bound as `unmanaged` and needs no mutation operation.
+
+For a managed worktree, `bind` acquires one durable owner generation only when
+the checkout is clean. A live foreign generation returns `foreign-active`; a
+dirty checkout returns `dirty`; and an expired generation with an unterminated
+operation returns `uncertain`. An expired clean generation with no active
+operation is fenced and replaced atomically. `begin` classifies known
+read-only tools as `not-required` and gives every other tool call a unique
+operation ID and fence before execution. `complete` accepts only the exact
+binding, generation, operation, fence, and call identity. `renew` cannot revive
+an expired generation, and `release` refuses an unterminated operation.
+
+Every command reads one strict, duplicate-free WorkspaceLease v1 JSON request
+from standard input and defaults to a versioned service JSON response. Exact
+active requests and terminal lifecycle messages are idempotent; copied or
+stale authority fails closed. Provider-visible results contain only opaque
+IDs, stable state/code/reason values, and renewal timing. Canonical paths,
+session IDs, parent IDs, tool arguments, and command output are never emitted.
+Private state lives below
+`${XDG_STATE_HOME:-$HOME/.local/state}/agent-hook/workspace-leases/` (or the
+global `--state-dir` override) behind owner-only directories, bounded files,
+and per-workspace cross-process locks.
 
 The separate `finish-line` service exposes only five public operations: `open`,
 `begin`, `run`, `stop`, and `status`. On a supported Linux containment host,

--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -124,6 +124,11 @@ operation ID and fence before execution. `complete` accepts only the exact
 binding, generation, operation, fence, and call identity. `renew` cannot revive
 an expired generation, and `release` refuses an unterminated operation.
 
+An explicit `resume` or `compact` may recover dirty work only when the prior
+generation has no active operation and its session plus optional parent
+lineage exactly match. Recovery mints a fresh binding ID and generation;
+startup, clear, foreign-session, and changed-lineage takeovers remain denied.
+
 Every command reads one strict, duplicate-free WorkspaceLease v1 JSON request
 from standard input and defaults to a versioned service JSON response. Exact
 active requests and terminal lifecycle messages are idempotent; copied or

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -326,6 +326,13 @@ a new binding ID and generation and tombstones the prior generation so delayed
 release cannot affect the new owner. No expired exact bind replay can revive
 old authority.
 
+An explicit `resume` or `compact` may also replace a dirty released or expired
+generation when the host-authenticated session and optional parent lineage are
+exactly the same and every operation is terminal. This is recovery of the same
+owner's work, not reassignment: it still mints a new binding ID and generation.
+A startup, clear, foreign session, changed parent, or unterminated operation
+remains fail-closed.
+
 `begin` binds the exact call/root/tool/arguments/nesting facts to one operation
 ID and unpredictable fence before tool dispatch. Known read-only DSH tools
 return `not-required`; unknown tools are conservatively fenced. `complete`
@@ -339,8 +346,9 @@ Active bind/begin retries and terminal complete/release retries are idempotent.
 Reusing a request ID for different facts fails closed. State is stored below
 the private `workspace-leases/` state root using bounded owner-only files,
 atomic replacement, and a bounded per-workspace cross-process lock. A clean
-expired owner can be recovered; dirty, active-operation, malformed, identity-
-mismatched, untrusted, busy, or unknown state is never guessed through.
+expired owner or the exact explicit same-session recovery above can be
+recovered; foreign dirty state and active-operation, malformed, identity-
+mismatched, untrusted, busy, or unknown state are never guessed through.
 
 Provider-visible results contain opaque IDs, renewal timing, and stable
 `owned`, `unmanaged`, `foreign-active`, `stale-clean`, `dirty`, or `uncertain`

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -1,6 +1,7 @@
 # agent-hook v1 contract
 
-Status: frozen for `graysurf/agent-runtime-kit#686` Lane A.
+Status: frozen for `graysurf/agent-runtime-kit#686` Lane A and extended with
+the native WorkspaceLease v1 boundary for `sympoies/dsh-runtime-kit#56`.
 
 Ownership: crate-local canonical specification for `nils-agent-hook` and the
 `agent-hook` binary.
@@ -26,6 +27,8 @@ The CLI resolves only absolute XDG roots and rejects relative roots.
 | policy bundle | config-selected absolute path, normally below `${XDG_DATA_HOME:-$HOME/.local/share}/agent-hook/policies/` | 1 MiB, regular file, no symlink |
 | runtime state | `${XDG_STATE_HOME:-$HOME/.local/state}/agent-hook/` | directories `0700`, secret files `0600` |
 | provider payload | standard input | 1 MiB |
+| workspace-lease request | standard input | 256 KiB, strict duplicate-free JSON |
+| workspace-lease state | state-owned per-worktree JSON | 512 KiB, `0600`, keyed private identity |
 | trace | state-owned JSONL | 256 entries, 256 KiB, redacted metadata only |
 | rule inventory | one policy bundle | 512 rules, unique IDs |
 | reason metadata | one aggregate decision | 64 reasons, 256 bytes per code/message |
@@ -92,6 +95,10 @@ above.
   session-retirement requests. Their matching result and service schemas follow
   the same naming rule, but both commands are intentionally absent from public
   help and completion.
+- `agent-hook.workspace-lease.{bind,begin,complete,renew,release}.v1`: strict
+  native WorkspaceLease provider requests. Matching results use
+  `agent-hook.workspace-lease.<command>-result.v1` inside the normal
+  `cli.agent-hook.workspace-lease-<command>.v1` service envelope.
 - `agent-hook.normalized-decision.v1`: aggregate action, ordered reason codes,
   optional bounded context or replacement, shadow observations, and config /
   policy digests.
@@ -130,8 +137,9 @@ above.
 Service JSON uses the workspace envelope: `schema_version`, `ok`, then `data`;
 failures contain `error.code`, `error.message`, and
 optional redacted `error.details`. Text is the human default except `dispatch`,
-whose default is provider output, and `finish-line`, whose default is service
-JSON. `--format json` always selects the service envelope.
+whose default is provider output, and `finish-line` plus `workspace-lease`,
+whose default is service JSON. `--format json` always selects the service
+envelope.
 
 ## Provider normalization and rendering
 
@@ -290,6 +298,57 @@ return raw provider content. DSH ingress requires this service JSON form; the
 runtime bundle maps `block` to a `tools/pre-execute` denial, delegates `allow`,
 and fails closed on every malformed, truncated, signaled, exit-mismatched,
 replayed, timed-out, oversized, or unsupported response.
+
+## Native DSH workspace lease
+
+`agent-hook workspace-lease <command> --format json` reads one strict JSON
+object from standard input, capped at 256 KiB. Duplicate keys, unknown fields,
+unsupported versions, non-absolute supplied cwd values, invalid lifecycle
+enums, and oversized or control-bearing identity strings fail with exit `65`.
+The public surface is exactly `bind`, `begin`, `complete`, `renew`, and
+`release`; every command defaults to its versioned service JSON envelope.
+
+`bind` accepts the runtime-owned WorkspaceLease v1 facts: request, session,
+optional parent, optional cwd, and DSH session-start source. The provider
+canonicalizes cwd without inherited Git repository-selection state. A managed
+identity binds the physical Git top-level and its device/inode identity, the
+per-worktree Git directory, and the shared Git directory. Thus nested and
+symlink-equivalent path spellings converge while two linked worktrees remain
+distinct. A missing or non-Git cwd produces an `unmanaged` binding and never a
+mutation lease.
+
+Managed state permits one active binding generation per physical worktree. A
+clean unowned checkout becomes `owned`; a live other owner returns
+`foreign-active`; dirty state returns `dirty`; and an expired binding with an
+active operation returns `uncertain`. An expired or explicitly released clean
+binding with no active operation may be replaced atomically. Replacement mints
+a new binding ID and generation and tombstones the prior generation so delayed
+release cannot affect the new owner. No expired exact bind replay can revive
+old authority.
+
+`begin` binds the exact call/root/tool/arguments/nesting facts to one operation
+ID and unpredictable fence before tool dispatch. Known read-only DSH tools
+return `not-required`; unknown tools are conservatively fenced. `complete`
+requires the exact live binding, generation, operation ID, fence, and
+call/root/tool projection, and records one of `succeeded`, `failed`, or
+`cancelled`. `renew` extends only a still-live exact generation. `release`
+retires only its exact generation and fails unavailable while any operation
+lacks a terminal outcome.
+
+Active bind/begin retries and terminal complete/release retries are idempotent.
+Reusing a request ID for different facts fails closed. State is stored below
+the private `workspace-leases/` state root using bounded owner-only files,
+atomic replacement, and a bounded per-workspace cross-process lock. A clean
+expired owner can be recovered; dirty, active-operation, malformed, identity-
+mismatched, untrusted, busy, or unknown state is never guessed through.
+
+Provider-visible results contain opaque IDs, renewal timing, and stable
+`owned`, `unmanaged`, `foreign-active`, `stale-clean`, `dirty`, or `uncertain`
+states with bounded stable codes/reasons. Results and diagnostics never expose
+canonical paths, Git directories, session/parent IDs, tool arguments, command
+output, or persisted digests. Canonical paths exist only in the private state
+needed to revalidate physical identity and run a trusted, hooks-disabled Git
+dirty-state probe.
 
 ## Native DSH finish line
 

--- a/crates/agent-hook/src/cli.rs
+++ b/crates/agent-hook/src/cli.rs
@@ -49,8 +49,55 @@ pub enum Command {
     Recovery(RecoveryArgs),
     /// Persist edit generations, execute declared validations, and enforce the DSH stop boundary.
     FinishLine(FinishLineArgs),
+    /// Bind canonical workspaces and operate durable cross-process mutation leases.
+    WorkspaceLease(WorkspaceLeaseArgs),
     /// Print a shell completion script.
     Completion(CompletionArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct WorkspaceLeaseArgs {
+    #[command(subcommand)]
+    pub command: WorkspaceLeaseCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkspaceLeaseCommand {
+    /// Resolve canonical workspace identity and acquire one binding generation.
+    Bind(WorkspaceLeaseFormatArgs),
+    /// Classify one tool call and fence it before execution.
+    Begin(WorkspaceLeaseFormatArgs),
+    /// Complete one exact fenced operation.
+    Complete(WorkspaceLeaseFormatArgs),
+    /// Renew one exact binding generation.
+    Renew(WorkspaceLeaseFormatArgs),
+    /// Release one exact binding generation.
+    Release(WorkspaceLeaseFormatArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct WorkspaceLeaseFormatArgs {
+    /// Automation-safe output format. Workspace lease defaults to strict JSON.
+    #[arg(long, value_enum, default_value_t = WorkspaceLeaseOutputFormat::Json)]
+    pub format: WorkspaceLeaseOutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum WorkspaceLeaseOutputFormat {
+    /// Human-readable text output.
+    Text,
+    /// Single-record JSON envelope (snake_case).
+    #[default]
+    Json,
+}
+
+impl From<WorkspaceLeaseOutputFormat> for OutputFormat {
+    fn from(value: WorkspaceLeaseOutputFormat) -> Self {
+        match value {
+            WorkspaceLeaseOutputFormat::Text => Self::Text,
+            WorkspaceLeaseOutputFormat::Json => Self::Json,
+        }
+    }
 }
 
 #[derive(Debug, Args)]

--- a/crates/agent-hook/src/completion.rs
+++ b/crates/agent-hook/src/completion.rs
@@ -40,6 +40,8 @@ fn public_completion(shell: Shell, script: &str) -> String {
     let mut skip_until_function_end = false;
     let mut removed_sections = 0_u8;
     let mut removed_entries = 0_u8;
+    let mut zsh_finish_release_case_removed = false;
+    let mut zsh_finish_release_entry_removed = false;
 
     for line in script.split_inclusive('\n') {
         let trimmed = line.trim();
@@ -72,11 +74,14 @@ fn public_completion(shell: Shell, script: &str) -> String {
                 skip_until_case_end = Some(indentation + 4);
                 continue;
             }
-            Shell::Zsh
-                if INTERNAL_COMMANDS
-                    .iter()
-                    .any(|command| trimmed == format!("({command})")) =>
+            Shell::Zsh if trimmed == "(quiesce)" =>
             {
+                removed_sections = removed_sections.saturating_add(1);
+                skip_until_case_end = Some(indentation);
+                continue;
+            }
+            Shell::Zsh if trimmed == "(release)" && !zsh_finish_release_case_removed => {
+                zsh_finish_release_case_removed = true;
                 removed_sections = removed_sections.saturating_add(1);
                 skip_until_case_end = Some(indentation);
                 continue;
@@ -92,11 +97,13 @@ fn public_completion(shell: Shell, script: &str) -> String {
                 skip_until_function_end = true;
                 continue;
             }
-            Shell::Zsh
-                if INTERNAL_COMMANDS
-                    .iter()
-                    .any(|command| trimmed == format!("'{command}:' \\")) =>
+            Shell::Zsh if trimmed == "'quiesce:' \\" =>
             {
+                removed_entries = removed_entries.saturating_add(1);
+                continue;
+            }
+            Shell::Zsh if trimmed == "'release:' \\" && !zsh_finish_release_entry_removed => {
+                zsh_finish_release_entry_removed = true;
                 removed_entries = removed_entries.saturating_add(1);
                 continue;
             }
@@ -140,11 +147,15 @@ fn public_completion(shell: Shell, script: &str) -> String {
         ),
         "clap completion shape changed around internal finish-line commands: {internal_lines:?}"
     );
-    for command in INTERNAL_COMMANDS {
-        assert!(
-            !filtered.contains(command),
-            "internal finish-line {command} survived completion filtering"
-        );
-    }
+    assert!(
+        !filtered.contains("quiesce"),
+        "internal finish-line quiesce survived completion filtering"
+    );
+    assert!(
+        !filtered.contains("finish-line__subcmd__release")
+            && !filtered.contains("finish__line__release")
+            && !filtered.contains("open begin run stop status release"),
+        "internal finish-line release survived completion filtering"
+    );
     filtered
 }

--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -3206,13 +3206,13 @@ fn sole_git_recovery(invocations: &[Invocation]) -> bool {
 }
 
 #[derive(Clone, Debug)]
-struct GitLayout {
-    root: PathBuf,
-    git_dir: PathBuf,
-    common_dir: PathBuf,
+pub(crate) struct GitLayout {
+    pub(crate) root: PathBuf,
+    pub(crate) git_dir: PathBuf,
+    pub(crate) common_dir: PathBuf,
 }
 
-fn git_layout(start: &Path) -> Option<GitLayout> {
+pub(crate) fn git_layout(start: &Path) -> Option<GitLayout> {
     let start = if start.is_file() {
         start.parent()?
     } else {
@@ -3436,7 +3436,7 @@ fn current_branch(layout: &GitLayout) -> Option<String> {
         .map(str::to_string)
 }
 
-fn checkout_dirty(
+pub(crate) fn checkout_dirty(
     layout: &GitLayout,
     run_child: &mut dyn FnMut(Command) -> Result<Output, HookError>,
 ) -> Result<bool, HookError> {

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -29,6 +29,7 @@ pub mod recovery;
 pub mod setup;
 mod strict_json;
 mod trace;
+mod workspace_lease;
 
 use std::collections::BTreeMap;
 use std::env;
@@ -43,7 +44,9 @@ use nils_common::cli_contract::{
 use serde::Serialize;
 use serde_json::json;
 
-use cli::{Cli, Command, DispatchFormat, FinishLineCommand, RecoveryCommand};
+use cli::{
+    Cli, Command, DispatchFormat, FinishLineCommand, RecoveryCommand, WorkspaceLeaseCommand,
+};
 use error::HookError;
 use model::{
     Capability, DECISION_VERSION, DecisionAction, DecisionReason, NormalizedDecision,
@@ -155,6 +158,7 @@ fn dispatch(layout: Layout, policy_override: Option<&std::path::Path>, command: 
     match command {
         Command::Completion(args) => completion::run(args.shell),
         Command::FinishLine(args) => run_finish_line(&layout, args.command),
+        Command::WorkspaceLease(args) => run_workspace_lease(&layout, args.command),
         Command::Dispatch(args) => run_dispatch(&layout, policy_override, args),
         Command::Validate(args) => {
             let loaded = match contract::load(&layout, policy_override) {
@@ -325,6 +329,41 @@ fn dispatch(layout: Layout, policy_override: Option<&std::path::Path>, command: 
             }
         }
         Command::Recovery(args) => run_recovery(&layout, policy_override, args.command),
+    }
+}
+
+fn run_workspace_lease(layout: &Layout, command: WorkspaceLeaseCommand) -> i32 {
+    let (name, format, operation) = match command {
+        WorkspaceLeaseCommand::Bind(args) => (
+            "agent-hook workspace-lease bind",
+            args.format,
+            workspace_lease::Operation::Bind,
+        ),
+        WorkspaceLeaseCommand::Begin(args) => (
+            "agent-hook workspace-lease begin",
+            args.format,
+            workspace_lease::Operation::Begin,
+        ),
+        WorkspaceLeaseCommand::Complete(args) => (
+            "agent-hook workspace-lease complete",
+            args.format,
+            workspace_lease::Operation::Complete,
+        ),
+        WorkspaceLeaseCommand::Renew(args) => (
+            "agent-hook workspace-lease renew",
+            args.format,
+            workspace_lease::Operation::Renew,
+        ),
+        WorkspaceLeaseCommand::Release(args) => (
+            "agent-hook workspace-lease release",
+            args.format,
+            workspace_lease::Operation::Release,
+        ),
+    };
+    let format = OutputFormat::from(format);
+    match workspace_lease::run(&layout.state_root, operation) {
+        Ok(outcome) => emit_success(name, format, &outcome.data, || outcome.text),
+        Err(error) => emit_error(name, &error, format == OutputFormat::Json),
     }
 }
 

--- a/crates/agent-hook/src/workspace_lease.rs
+++ b/crates/agent-hook/src/workspace_lease.rs
@@ -1,0 +1,1589 @@
+//! Strict WorkspaceLease v1 automation boundary.
+//!
+//! DSH/runtime-kit owns lifecycle attribution. This module owns canonical
+//! physical workspace identity, durable cross-process exclusivity, operation
+//! fences, idempotency, and conservative stale recovery.
+
+use std::collections::BTreeSet;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read};
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::dsh_policy::{GitLayout, checkout_dirty, git_layout};
+use crate::error::HookError;
+
+const PROTOCOL_VERSION: u64 = 1;
+const STATE_SCHEMA: &str = "agent-hook.workspace-lease.state.v1";
+const BIND_SCHEMA: &str = "agent-hook.workspace-lease.bind.v1";
+const BEGIN_SCHEMA: &str = "agent-hook.workspace-lease.begin.v1";
+const COMPLETE_SCHEMA: &str = "agent-hook.workspace-lease.complete.v1";
+const RENEW_SCHEMA: &str = "agent-hook.workspace-lease.renew.v1";
+const RELEASE_SCHEMA: &str = "agent-hook.workspace-lease.release.v1";
+const BIND_RESULT_SCHEMA: &str = "agent-hook.workspace-lease.bind-result.v1";
+const BEGIN_RESULT_SCHEMA: &str = "agent-hook.workspace-lease.begin-result.v1";
+const COMPLETE_RESULT_SCHEMA: &str = "agent-hook.workspace-lease.complete-result.v1";
+const RENEW_RESULT_SCHEMA: &str = "agent-hook.workspace-lease.renew-result.v1";
+const RELEASE_RESULT_SCHEMA: &str = "agent-hook.workspace-lease.release-result.v1";
+const REQUEST_MAX_BYTES: u64 = 256 * 1024;
+const STATE_MAX_BYTES: u64 = 512 * 1024;
+const MAX_TEXT_BYTES: usize = 512;
+const MAX_OPERATIONS: usize = 256;
+const MAX_TOMBSTONES: usize = 64;
+const LEASE_TTL_SECONDS: u64 = 30;
+const RENEW_AFTER_MS: u64 = 10_000;
+const LOCK_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Operation {
+    Bind,
+    Begin,
+    Complete,
+    Renew,
+    Release,
+}
+
+pub(crate) struct Outcome {
+    pub(crate) data: Value,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BindRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    request_id: String,
+    session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    #[serde(default)]
+    cwd: Option<PathBuf>,
+    source: SessionStartSource,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BeginRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    request_id: String,
+    session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    binding_id: String,
+    workspace_id: String,
+    generation: String,
+    binding_state: BindingMode,
+    call_id: String,
+    root_call_id: String,
+    tool_name: String,
+    arguments: Value,
+    nested: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CompleteRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    request_id: String,
+    session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    binding_id: String,
+    workspace_id: String,
+    generation: String,
+    operation_id: String,
+    fence: String,
+    call_id: String,
+    root_call_id: String,
+    tool_name: String,
+    outcome: OperationOutcome,
+    #[serde(default)]
+    error_code: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RenewRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    request_id: String,
+    session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    binding_id: String,
+    workspace_id: String,
+    generation: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReleaseRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    request_id: String,
+    session_id: String,
+    #[serde(default)]
+    parent_session_id: Option<String>,
+    binding_id: String,
+    workspace_id: String,
+    generation: String,
+    reason: ReleaseReason,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum BindingMode {
+    Owned,
+    Unmanaged,
+}
+
+impl BindingMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Owned => "owned",
+            Self::Unmanaged => "unmanaged",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum BindingStatus {
+    Active,
+    Released,
+    Recovered,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum OperationStatus {
+    Active,
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum OperationOutcome {
+    Succeeded,
+    Failed,
+    Cancelled,
+}
+
+impl OperationOutcome {
+    fn status(self) -> OperationStatus {
+        match self {
+            Self::Succeeded => OperationStatus::Succeeded,
+            Self::Failed => OperationStatus::Failed,
+            Self::Cancelled => OperationStatus::Cancelled,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum ReleaseReason {
+    AgentDisposed,
+    SessionRebound,
+    ProviderDisposed,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum SessionStartSource {
+    Startup,
+    Resume,
+    Clear,
+    Compact,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ManagedIdentity {
+    root: String,
+    root_dev: u64,
+    root_ino: u64,
+    git_dir: String,
+    git_dev: u64,
+    git_ino: u64,
+    common_dir: String,
+    common_dev: u64,
+    common_ino: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
+enum WorkspaceIdentity {
+    Managed { identity: ManagedIdentity },
+    Unmanaged { root: Option<String> },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Binding {
+    binding_id: String,
+    generation: String,
+    session_digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    parent_session_digest: Option<String>,
+    mode: BindingMode,
+    status: BindingStatus,
+    bind_request_digest: String,
+    bind_request_id_digest: String,
+    refreshed_at_epoch: u64,
+    expires_at_epoch: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct OperationRecord {
+    operation_id: String,
+    fence: String,
+    request_id_digest: String,
+    request_digest: String,
+    execution_digest: String,
+    completion_execution_digest: String,
+    status: OperationStatus,
+    started_at_epoch: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completed_at_epoch: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    completion_digest: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct BindingTombstone {
+    binding_id: String,
+    generation: String,
+    session_digest: String,
+    workspace_id: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct State {
+    schema_version: String,
+    workspace_key: String,
+    workspace_id: String,
+    identity: WorkspaceIdentity,
+    binding: Binding,
+    operations: Vec<OperationRecord>,
+    tombstones: Vec<BindingTombstone>,
+}
+
+struct LockedState {
+    _lock: File,
+    directory: PathBuf,
+    key: String,
+    fingerprint_key: String,
+}
+
+pub(crate) fn run(state_root: &Path, operation: Operation) -> Result<Outcome, HookError> {
+    match operation {
+        Operation::Bind => bind(state_root, read_request(BIND_SCHEMA)?),
+        Operation::Begin => begin(state_root, read_request(BEGIN_SCHEMA)?),
+        Operation::Complete => complete(state_root, read_request(COMPLETE_SCHEMA)?),
+        Operation::Renew => renew(state_root, read_request(RENEW_SCHEMA)?),
+        Operation::Release => release(state_root, read_request(RELEASE_SCHEMA)?),
+    }
+}
+
+fn bind(state_root: &Path, request: BindRequest) -> Result<Outcome, HookError> {
+    validate_common(
+        request.version,
+        &request.request_id,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    let session_digest = digest(request.session_id.as_bytes());
+    let parent_session_digest = request
+        .parent_session_id
+        .as_deref()
+        .map(|value| digest(value.as_bytes()));
+    let fingerprint_key = workspace_fingerprint_key(state_root, true)?;
+    let (identity, key, managed) =
+        resolve_identity(request.cwd.as_deref(), &session_digest, &fingerprint_key)?;
+    let request_digest = digest_value(
+        "workspace-bind",
+        &json!({
+            "version": request.version,
+            "session_digest": session_digest,
+            "parent_session_digest": parent_session_digest,
+            "identity": identity,
+            "source": request.source,
+        }),
+    )?;
+    let request_id_digest = digest(request.request_id.as_bytes());
+    let locked = lock_workspace(state_root, &key, Some(fingerprint_key))?;
+    let mut state = read_state(&locked)?;
+    let now = now_epoch()?;
+    if let Some(existing) = state.as_ref() {
+        validate_state(existing, &locked, &identity)?;
+        if existing.binding.bind_request_id_digest == request_id_digest {
+            if existing.binding.bind_request_digest != request_digest {
+                return Err(idempotency_reused());
+            }
+            if existing.binding.status == BindingStatus::Active
+                && existing.binding.expires_at_epoch > now
+            {
+                return Ok(bound(existing));
+            }
+        }
+    }
+
+    if managed {
+        if let Some(existing) = state.as_ref()
+            && existing.binding.status == BindingStatus::Active
+            && existing.binding.expires_at_epoch > now
+        {
+            return Ok(denied(
+                BIND_RESULT_SCHEMA,
+                "foreign-active",
+                "WORKSPACE_FOREIGN_ACTIVE",
+                "another live session owns this workspace",
+            ));
+        }
+        if let Some(existing) = state.as_ref()
+            && existing.binding.status == BindingStatus::Active
+            && existing.operations.iter().any(|operation| {
+                operation.status == OperationStatus::Active
+                    && operation.operation_id.starts_with("wlo1.")
+            })
+        {
+            return Ok(denied(
+                BIND_RESULT_SCHEMA,
+                "uncertain",
+                "WORKSPACE_OPERATION_UNCERTAIN",
+                "an expired workspace operation has no durable terminal outcome",
+            ));
+        }
+        let identity = managed_identity(&identity)?;
+        if dirty(identity)? {
+            return Ok(denied(
+                BIND_RESULT_SCHEMA,
+                "dirty",
+                "WORKSPACE_DIRTY",
+                "the workspace has uncommitted state and cannot be reassigned safely",
+            ));
+        }
+    }
+
+    let workspace_id = state
+        .as_ref()
+        .map(|state| state.workspace_id.clone())
+        .unwrap_or_else(|| opaque("wlw1"));
+    let mode = if managed {
+        BindingMode::Owned
+    } else {
+        BindingMode::Unmanaged
+    };
+    let binding = Binding {
+        binding_id: format!("wlb1.{key}.{}", Uuid::new_v4().simple()),
+        generation: opaque("wlg1"),
+        session_digest: session_digest.clone(),
+        parent_session_digest,
+        mode,
+        status: BindingStatus::Active,
+        bind_request_digest: request_digest,
+        bind_request_id_digest: request_id_digest,
+        refreshed_at_epoch: now,
+        expires_at_epoch: now.saturating_add(LEASE_TTL_SECONDS),
+    };
+    let mut tombstones = state
+        .as_ref()
+        .map(|state| state.tombstones.clone())
+        .unwrap_or_default();
+    if let Some(existing) = state.as_mut() {
+        existing.binding.status = BindingStatus::Recovered;
+        tombstones.push(tombstone(existing));
+        compact_tombstones(&mut tombstones);
+    }
+    let state = State {
+        schema_version: STATE_SCHEMA.to_string(),
+        workspace_key: key,
+        workspace_id,
+        identity,
+        binding,
+        operations: Vec::new(),
+        tombstones,
+    };
+    write_state(&locked, &state)?;
+    Ok(bound(&state))
+}
+
+fn begin(state_root: &Path, request: BeginRequest) -> Result<Outcome, HookError> {
+    validate_common(
+        request.version,
+        &request.request_id,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    for (value, field) in [
+        (&request.binding_id, "binding_id"),
+        (&request.workspace_id, "workspace_id"),
+        (&request.generation, "generation"),
+        (&request.call_id, "call_id"),
+        (&request.root_call_id, "root_call_id"),
+        (&request.tool_name, "tool_name"),
+    ] {
+        validate_text(value, field)?;
+    }
+    let key = binding_key(&request.binding_id)?;
+    let locked = lock_workspace(state_root, key, None)?;
+    let mut state = read_required_state(&locked)?;
+    validate_loaded_state(&state, &locked)?;
+    if let Some(denial) = binding_denial(
+        &state,
+        &request.binding_id,
+        &request.workspace_id,
+        &request.generation,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    ) {
+        return Ok(denial);
+    }
+    revalidate_managed_identity(&state)?;
+    if request.binding_state != state.binding.mode {
+        return Err(HookError::data(
+            "workspace-binding-state-invalid",
+            "workspace binding state does not match durable authority",
+        ));
+    }
+    if state.binding.mode == BindingMode::Unmanaged || tool_is_read_only(&request) {
+        return Ok(Outcome {
+            data: json!({
+                "schema_version": BEGIN_RESULT_SCHEMA,
+                "kind": "not-required",
+            }),
+            text: "workspace lease: operation does not require a mutation fence\n".to_string(),
+        });
+    }
+    let now = now_epoch()?;
+    if state.binding.expires_at_epoch <= now {
+        return expired_denial(&state);
+    }
+    let execution_digest = execution_digest(&request)?;
+    let request_digest = digest_value(
+        "workspace-begin",
+        &json!({
+            "request": execution_digest,
+            "binding_id": request.binding_id,
+            "generation": request.generation,
+        }),
+    )?;
+    let request_id_digest = digest(request.request_id.as_bytes());
+    if let Some(existing) = state
+        .operations
+        .iter()
+        .find(|operation| operation.request_id_digest == request_id_digest)
+    {
+        if existing.request_digest != request_digest {
+            return Err(idempotency_reused());
+        }
+        if existing.status != OperationStatus::Active {
+            return Ok(denied(
+                BEGIN_RESULT_SCHEMA,
+                "uncertain",
+                "WORKSPACE_OPERATION_REPLAYED",
+                "the operation identity already reached a terminal state",
+            ));
+        }
+        return Ok(granted(existing));
+    }
+    if state.operations.len() >= MAX_OPERATIONS {
+        compact_operations(&mut state.operations);
+    }
+    if state.operations.len() >= MAX_OPERATIONS {
+        return Err(workspace_unavailable(
+            "workspace-operation-capacity-exhausted",
+            "workspace operation history is at its conservative capacity",
+            "complete or release prior operations, then retry the exact request once",
+        ));
+    }
+    let completion_execution_digest = digest_value(
+        "workspace-execution-complete",
+        &json!({
+            "call_id": request.call_id,
+            "root_call_id": request.root_call_id,
+            "tool_name": request.tool_name,
+        }),
+    )?;
+    state.operations.push(OperationRecord {
+        operation_id: opaque("wlo1"),
+        fence: opaque("wlf1"),
+        request_id_digest,
+        request_digest,
+        execution_digest,
+        completion_execution_digest,
+        status: OperationStatus::Active,
+        started_at_epoch: now,
+        completed_at_epoch: None,
+        completion_digest: None,
+    });
+    let outcome = state
+        .operations
+        .last()
+        .map(granted)
+        .ok_or_else(state_invalid)?;
+    write_state(&locked, &state)?;
+    Ok(outcome)
+}
+
+fn complete(state_root: &Path, request: CompleteRequest) -> Result<Outcome, HookError> {
+    validate_common(
+        request.version,
+        &request.request_id,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    for (value, field) in [
+        (&request.binding_id, "binding_id"),
+        (&request.workspace_id, "workspace_id"),
+        (&request.generation, "generation"),
+        (&request.operation_id, "operation_id"),
+        (&request.fence, "fence"),
+        (&request.call_id, "call_id"),
+        (&request.root_call_id, "root_call_id"),
+        (&request.tool_name, "tool_name"),
+    ] {
+        validate_text(value, field)?;
+    }
+    if let Some(error_code) = request.error_code.as_deref() {
+        validate_text(error_code, "error_code")?;
+    }
+    let key = binding_key(&request.binding_id)?;
+    let locked = lock_workspace(state_root, key, None)?;
+    let mut state = read_required_state(&locked)?;
+    validate_loaded_state(&state, &locked)?;
+    require_binding(
+        &state,
+        &request.binding_id,
+        &request.workspace_id,
+        &request.generation,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    let operation = state
+        .operations
+        .iter_mut()
+        .find(|operation| operation.operation_id == request.operation_id)
+        .ok_or_else(|| {
+            HookError::data(
+                "workspace-operation-unavailable",
+                "workspace operation identity is unavailable",
+            )
+        })?;
+    if operation.fence != request.fence {
+        return Err(HookError::data(
+            "workspace-operation-fence-invalid",
+            "workspace operation fence is invalid",
+        ));
+    }
+    let observed_execution = digest_value(
+        "workspace-execution-complete",
+        &json!({
+            "call_id": request.call_id,
+            "root_call_id": request.root_call_id,
+            "tool_name": request.tool_name,
+        }),
+    )?;
+    if observed_execution != operation.completion_execution_digest {
+        return Err(HookError::data(
+            "workspace-operation-identity-invalid",
+            "workspace operation completion identity is invalid",
+        ));
+    }
+    let completion_digest = digest_value(
+        "workspace-complete",
+        &json!({
+            "operation_id": request.operation_id,
+            "fence": request.fence,
+            "execution": observed_execution,
+            "outcome": request.outcome,
+            "error_code": request.error_code,
+        }),
+    )?;
+    if operation.status != OperationStatus::Active {
+        if operation.completion_digest.as_deref() == Some(completion_digest.as_str()) {
+            return Ok(ack(
+                COMPLETE_RESULT_SCHEMA,
+                "duplicate",
+                "completion already recorded",
+            ));
+        }
+        return Err(HookError::data(
+            "workspace-operation-outcome-conflict",
+            "workspace operation already has a different terminal outcome",
+        ));
+    }
+    operation.status = request.outcome.status();
+    operation.completed_at_epoch = Some(now_epoch()?);
+    operation.completion_digest = Some(completion_digest);
+    write_state(&locked, &state)?;
+    Ok(ack(
+        COMPLETE_RESULT_SCHEMA,
+        "completed",
+        "operation completed",
+    ))
+}
+
+fn renew(state_root: &Path, request: RenewRequest) -> Result<Outcome, HookError> {
+    validate_common(
+        request.version,
+        &request.request_id,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    let key = binding_key(&request.binding_id)?;
+    let locked = lock_workspace(state_root, key, None)?;
+    let mut state = read_required_state(&locked)?;
+    validate_loaded_state(&state, &locked)?;
+    if let Some(denial) = binding_denial(
+        &state,
+        &request.binding_id,
+        &request.workspace_id,
+        &request.generation,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    ) {
+        return Ok(lost_from_denial(denial));
+    }
+    revalidate_managed_identity(&state)?;
+    let now = now_epoch()?;
+    if state.binding.expires_at_epoch <= now {
+        return Ok(lost_from_denial(expired_denial(&state)?));
+    }
+    state.binding.refreshed_at_epoch = now;
+    state.binding.expires_at_epoch = now.saturating_add(LEASE_TTL_SECONDS);
+    write_state(&locked, &state)?;
+    Ok(Outcome {
+        data: json!({
+            "schema_version": RENEW_RESULT_SCHEMA,
+            "kind": "renewed",
+            "renew_after_ms": RENEW_AFTER_MS,
+        }),
+        text: "workspace lease renewed\n".to_string(),
+    })
+}
+
+fn release(state_root: &Path, request: ReleaseRequest) -> Result<Outcome, HookError> {
+    validate_common(
+        request.version,
+        &request.request_id,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    let _ = request.reason;
+    let key = binding_key(&request.binding_id)?;
+    let locked = lock_workspace(state_root, key, None)?;
+    let mut state = read_required_state(&locked)?;
+    validate_loaded_state(&state, &locked)?;
+    let session_digest = digest(request.session_id.as_bytes());
+    if state.binding.status != BindingStatus::Active {
+        if exact_binding(
+            &state.binding,
+            &request.binding_id,
+            &request.workspace_id,
+            &request.generation,
+            &session_digest,
+            request.parent_session_id.as_deref(),
+            &state.workspace_id,
+        ) || state.tombstones.iter().any(|tombstone| {
+            tombstone.binding_id == request.binding_id
+                && tombstone.generation == request.generation
+                && tombstone.session_digest == session_digest
+                && tombstone.workspace_id == request.workspace_id
+        }) {
+            return Ok(ack(
+                RELEASE_RESULT_SCHEMA,
+                "duplicate",
+                "binding already released",
+            ));
+        }
+        return Err(stale_binding());
+    }
+    require_binding(
+        &state,
+        &request.binding_id,
+        &request.workspace_id,
+        &request.generation,
+        &request.session_id,
+        request.parent_session_id.as_deref(),
+    )?;
+    if state
+        .operations
+        .iter()
+        .any(|operation| operation.status == OperationStatus::Active)
+    {
+        return Err(workspace_unavailable(
+            "workspace-release-uncertain",
+            "workspace binding has an operation without a terminal outcome",
+            "complete the exact active operation, then retry the exact release once",
+        ));
+    }
+    state.binding.status = BindingStatus::Released;
+    state.binding.expires_at_epoch = now_epoch()?;
+    write_state(&locked, &state)?;
+    Ok(ack(RELEASE_RESULT_SCHEMA, "released", "binding released"))
+}
+
+fn read_request<T: DeserializeOwned>(expected_schema: &str) -> Result<T, HookError> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take(REQUEST_MAX_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| wire_invalid())?;
+    if bytes.is_empty() || bytes.len() as u64 > REQUEST_MAX_BYTES {
+        return Err(wire_invalid());
+    }
+    let value = crate::strict_json::from_slice(&bytes).map_err(|_| wire_invalid())?;
+    let actual_schema = value
+        .get("schema_version")
+        .and_then(Value::as_str)
+        .ok_or_else(wire_invalid)?;
+    if actual_schema != expected_schema {
+        return Err(wire_invalid());
+    }
+    serde_json::from_value(value).map_err(|_| wire_invalid())
+}
+
+fn validate_common(
+    version: u64,
+    request_id: &str,
+    session_id: &str,
+    parent_session_id: Option<&str>,
+) -> Result<(), HookError> {
+    if version != PROTOCOL_VERSION {
+        return Err(HookError::data(
+            "workspace-protocol-unsupported",
+            "workspace lease protocol version is unsupported",
+        ));
+    }
+    validate_text(request_id, "request_id")?;
+    validate_text(session_id, "session_id")?;
+    if let Some(parent) = parent_session_id {
+        validate_text(parent, "parent_session_id")?;
+        if parent == session_id {
+            return Err(wire_invalid());
+        }
+    }
+    Ok(())
+}
+
+fn validate_text(value: &str, _field: &str) -> Result<(), HookError> {
+    if value.is_empty()
+        || value.len() > MAX_TEXT_BYTES
+        || value.chars().any(|character| character.is_control())
+    {
+        return Err(wire_invalid());
+    }
+    Ok(())
+}
+
+fn resolve_identity(
+    cwd: Option<&Path>,
+    session_digest: &str,
+    fingerprint_key: &str,
+) -> Result<(WorkspaceIdentity, String, bool), HookError> {
+    let Some(cwd) = cwd else {
+        let identity = WorkspaceIdentity::Unmanaged { root: None };
+        let key = keyed_value(
+            fingerprint_key,
+            "workspace-unmanaged-key",
+            &json!({"session": session_digest, "root": null}),
+        )?;
+        return Ok((identity, key, false));
+    };
+    if !cwd.is_absolute() {
+        return Err(HookError::data(
+            "workspace-cwd-invalid",
+            "workspace cwd must be an absolute path",
+        ));
+    }
+    let canonical = fs::canonicalize(cwd).map_err(|_| {
+        workspace_unavailable(
+            "workspace-identity-unavailable",
+            "workspace identity could not be resolved",
+            "restore the exact workspace and retry the exact request once",
+        )
+    })?;
+    if let Some(layout) = git_layout(&canonical) {
+        let identity = WorkspaceIdentity::Managed {
+            identity: identity_from_layout(&layout)?,
+        };
+        let key = keyed_value(fingerprint_key, "workspace-key", &identity)?;
+        Ok((identity, key, true))
+    } else if has_git_marker(&canonical)? {
+        Err(identity_unavailable())
+    } else {
+        let root = path_text(&canonical)?;
+        let identity = WorkspaceIdentity::Unmanaged {
+            root: Some(root.clone()),
+        };
+        let key = keyed_value(
+            fingerprint_key,
+            "workspace-unmanaged-key",
+            &json!({"session": session_digest, "root": root}),
+        )?;
+        Ok((identity, key, false))
+    }
+}
+
+fn identity_from_layout(layout: &GitLayout) -> Result<ManagedIdentity, HookError> {
+    let root = fs::metadata(&layout.root).map_err(|_| identity_unavailable())?;
+    let git = fs::metadata(&layout.git_dir).map_err(|_| identity_unavailable())?;
+    let common = fs::metadata(&layout.common_dir).map_err(|_| identity_unavailable())?;
+    Ok(ManagedIdentity {
+        root: path_text(&layout.root)?,
+        root_dev: root.dev(),
+        root_ino: root.ino(),
+        git_dir: path_text(&layout.git_dir)?,
+        git_dev: git.dev(),
+        git_ino: git.ino(),
+        common_dir: path_text(&layout.common_dir)?,
+        common_dev: common.dev(),
+        common_ino: common.ino(),
+    })
+}
+
+fn managed_identity(identity: &WorkspaceIdentity) -> Result<&ManagedIdentity, HookError> {
+    match identity {
+        WorkspaceIdentity::Managed { identity } => Ok(identity),
+        WorkspaceIdentity::Unmanaged { .. } => Err(identity_unavailable()),
+    }
+}
+
+fn dirty(identity: &ManagedIdentity) -> Result<bool, HookError> {
+    let layout = GitLayout {
+        root: PathBuf::from(&identity.root),
+        git_dir: PathBuf::from(&identity.git_dir),
+        common_dir: PathBuf::from(&identity.common_dir),
+    };
+    let mut run_child = |mut command: Command| {
+        command.output().map_err(|_| {
+            workspace_unavailable(
+                "workspace-git-unavailable",
+                "workspace dirty-state inspection is unavailable",
+                "verify trusted Git and retry the exact request once",
+            )
+        })
+    };
+    checkout_dirty(&layout, &mut run_child).map_err(|_| {
+        workspace_unavailable(
+            "workspace-git-unavailable",
+            "workspace dirty-state inspection is unavailable",
+            "verify trusted Git and retry the exact request once",
+        )
+    })
+}
+
+fn has_git_marker(start: &Path) -> Result<bool, HookError> {
+    for ancestor in start.ancestors() {
+        match fs::symlink_metadata(ancestor.join(".git")) {
+            Ok(_) => return Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(_) => return Err(identity_unavailable()),
+        }
+    }
+    Ok(false)
+}
+
+fn revalidate_managed_identity(state: &State) -> Result<(), HookError> {
+    let WorkspaceIdentity::Managed { identity } = &state.identity else {
+        return Ok(());
+    };
+    let layout = git_layout(Path::new(&identity.root)).ok_or_else(identity_unavailable)?;
+    let observed = identity_from_layout(&layout)?;
+    if &observed != identity {
+        return Err(workspace_unavailable(
+            "workspace-identity-changed",
+            "workspace physical identity changed after binding",
+            "release the stale binding and bind the exact current workspace",
+        ));
+    }
+    Ok(())
+}
+
+fn workspace_fingerprint_key(state_root: &Path, create: bool) -> Result<String, HookError> {
+    let root = state_root.join("workspace-leases");
+    crate::paths::ensure_private_state_dir(&root, "workspace-lease-state")?;
+    let lock_path = root.join("fingerprint.lock");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(&lock_path)
+        .map_err(|_| lock_unavailable())?;
+    validate_private_file(&lock.metadata().map_err(|_| lock_unavailable())?, 0)?;
+    let deadline = Instant::now() + LOCK_TIMEOUT;
+    loop {
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            break;
+        }
+        if io::Error::last_os_error().raw_os_error() != Some(libc::EWOULDBLOCK) {
+            return Err(lock_unavailable());
+        }
+        if Instant::now() >= deadline {
+            return Err(workspace_temporary(
+                "workspace-fingerprint-lock-busy",
+                "workspace fingerprint state is busy",
+                "wait for the bounded lock window and retry the exact request once",
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let key_path = root.join("fingerprint.key");
+    let key = match read_private_bytes(&key_path, 64)? {
+        Some(bytes) => {
+            let value = std::str::from_utf8(&bytes).map_err(|_| state_invalid())?;
+            if value.len() != 64 || !is_lower_hex(value) {
+                return Err(state_invalid());
+            }
+            value.to_string()
+        }
+        None if create => {
+            let mut retained_state = false;
+            for entry in fs::read_dir(&root).map_err(|_| state_unavailable())? {
+                let entry = entry.map_err(|_| state_unavailable())?;
+                if entry.file_name().to_str().is_some_and(is_hex_digest) {
+                    retained_state = true;
+                    break;
+                }
+            }
+            if retained_state {
+                return Err(state_invalid());
+            }
+            let value = format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple());
+            nils_common::fs::write_atomic(&key_path, value.as_bytes(), 0o600)
+                .map_err(|_| state_unavailable())?;
+            value
+        }
+        None => {
+            return Err(state_unavailable());
+        }
+    };
+    unsafe {
+        libc::flock(lock.as_raw_fd(), libc::LOCK_UN);
+    }
+    Ok(key)
+}
+
+fn lock_workspace(
+    state_root: &Path,
+    key: &str,
+    fingerprint_key: Option<String>,
+) -> Result<LockedState, HookError> {
+    if !is_hex_digest(key) {
+        return Err(wire_invalid());
+    }
+    let root = state_root.join("workspace-leases");
+    crate::paths::ensure_private_state_dir(&root, "workspace-lease-state")?;
+    let fingerprint_key = match fingerprint_key {
+        Some(fingerprint_key) => fingerprint_key,
+        None => workspace_fingerprint_key(state_root, false)?,
+    };
+    let directory = root.join(key);
+    crate::paths::ensure_private_state_dir(&directory, "workspace-lease-state")?;
+    let path = directory.join("state.lock");
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .mode(0o600)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(&path)
+        .map_err(|_| lock_unavailable())?;
+    validate_private_file(&lock.metadata().map_err(|_| lock_unavailable())?, 0)?;
+    let deadline = Instant::now() + LOCK_TIMEOUT;
+    loop {
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            break;
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EWOULDBLOCK) {
+            return Err(lock_unavailable());
+        }
+        if Instant::now() >= deadline {
+            return Err(workspace_temporary(
+                "workspace-lease-lock-busy",
+                "workspace lease state is busy; retry the exact request",
+                "wait for the bounded lock window and retry the exact request once",
+            ));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    Ok(LockedState {
+        _lock: lock,
+        directory,
+        key: key.to_string(),
+        fingerprint_key,
+    })
+}
+
+impl Drop for LockedState {
+    fn drop(&mut self) {
+        unsafe {
+            libc::flock(self._lock.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+fn read_required_state(locked: &LockedState) -> Result<State, HookError> {
+    read_state(locked)?.ok_or_else(stale_binding)
+}
+
+fn read_state(locked: &LockedState) -> Result<Option<State>, HookError> {
+    let path = locked.directory.join("state.json");
+    let Some(bytes) = read_private_bytes(&path, STATE_MAX_BYTES)? else {
+        return Ok(None);
+    };
+    let value = crate::strict_json::from_slice(&bytes).map_err(|_| state_invalid())?;
+    let state: State = serde_json::from_value(value).map_err(|_| state_invalid())?;
+    validate_loaded_state(&state, locked)?;
+    Ok(Some(state))
+}
+
+fn write_state(locked: &LockedState, state: &State) -> Result<(), HookError> {
+    validate_loaded_state(state, locked)?;
+    let bytes = serde_json::to_vec_pretty(state).map_err(|_| state_unavailable())?;
+    if bytes.len() as u64 > STATE_MAX_BYTES {
+        return Err(workspace_unavailable(
+            "workspace-lease-capacity-exhausted",
+            "workspace lease state exceeded its conservative capacity",
+            "complete or release prior lifecycle state before retrying",
+        ));
+    }
+    nils_common::fs::write_atomic(&locked.directory.join("state.json"), &bytes, 0o600)
+        .map_err(|_| state_unavailable())
+}
+
+fn read_private_bytes(path: &Path, max: u64) -> Result<Option<Vec<u8>>, HookError> {
+    let mut file = match OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => return Err(state_unavailable()),
+    };
+    let metadata = file.metadata().map_err(|_| state_unavailable())?;
+    validate_private_file(&metadata, max)?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.by_ref()
+        .take(max.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| state_unavailable())?;
+    if bytes.len() as u64 > max {
+        return Err(HookError::data(
+            "workspace-lease-state-untrusted",
+            "workspace lease state is not a bounded private file",
+        ));
+    }
+    Ok(Some(bytes))
+}
+
+fn validate_private_file(metadata: &fs::Metadata, max: u64) -> Result<(), HookError> {
+    if metadata.file_type().is_symlink()
+        || !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.permissions().mode() & 0o077 != 0
+        || metadata.nlink() != 1
+        || (max > 0 && metadata.len() > max)
+    {
+        return Err(HookError::data(
+            "workspace-lease-state-untrusted",
+            "workspace lease state is not a bounded private file",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_state(
+    state: &State,
+    locked: &LockedState,
+    identity: &WorkspaceIdentity,
+) -> Result<(), HookError> {
+    validate_loaded_state(state, locked)?;
+    if &state.identity != identity {
+        return Err(state_invalid());
+    }
+    Ok(())
+}
+
+fn validate_loaded_state(state: &State, locked: &LockedState) -> Result<(), HookError> {
+    let expected_key = match &state.identity {
+        WorkspaceIdentity::Managed { .. } => {
+            keyed_value(&locked.fingerprint_key, "workspace-key", &state.identity)
+        }
+        WorkspaceIdentity::Unmanaged { root } => keyed_value(
+            &locked.fingerprint_key,
+            "workspace-unmanaged-key",
+            &json!({"session": state.binding.session_digest, "root": root}),
+        ),
+    }
+    .map_err(|_| state_invalid())?;
+    if state.schema_version != STATE_SCHEMA
+        || state.workspace_key != locked.key
+        || state.workspace_key != expected_key
+        || !is_hex_digest(&state.workspace_key)
+        || !valid_opaque(&state.workspace_id, "wlw1")
+        || !valid_binding_id(&state.binding.binding_id, &locked.key)
+        || !valid_opaque(&state.binding.generation, "wlg1")
+        || !is_hex_digest(&state.binding.session_digest)
+        || state
+            .binding
+            .parent_session_digest
+            .as_deref()
+            .is_some_and(|value| !is_hex_digest(value))
+        || !is_hex_digest(&state.binding.bind_request_digest)
+        || !is_hex_digest(&state.binding.bind_request_id_digest)
+        || state.binding.refreshed_at_epoch > state.binding.expires_at_epoch
+        || state.operations.len() > MAX_OPERATIONS
+        || state.tombstones.len() > MAX_TOMBSTONES
+    {
+        return Err(state_invalid());
+    }
+    match &state.identity {
+        WorkspaceIdentity::Managed { identity } => {
+            if !absolute_state_path(&identity.root)
+                || !absolute_state_path(&identity.git_dir)
+                || !absolute_state_path(&identity.common_dir)
+            {
+                return Err(state_invalid());
+            }
+        }
+        WorkspaceIdentity::Unmanaged { root } => {
+            if root
+                .as_deref()
+                .is_some_and(|path| !absolute_state_path(path))
+            {
+                return Err(state_invalid());
+            }
+        }
+    }
+    let mut operation_ids = BTreeSet::new();
+    let mut fences = BTreeSet::new();
+    for operation in &state.operations {
+        if !valid_opaque(&operation.operation_id, "wlo1")
+            || !valid_opaque(&operation.fence, "wlf1")
+            || !operation_ids.insert(&operation.operation_id)
+            || !fences.insert(&operation.fence)
+            || !is_hex_digest(&operation.request_id_digest)
+            || !is_hex_digest(&operation.request_digest)
+            || !is_hex_digest(&operation.execution_digest)
+            || !is_hex_digest(&operation.completion_execution_digest)
+            || operation
+                .completion_digest
+                .as_deref()
+                .is_some_and(|value| !is_hex_digest(value))
+            || (operation.status == OperationStatus::Active
+                && (operation.completed_at_epoch.is_some()
+                    || operation.completion_digest.is_some()))
+            || (operation.status != OperationStatus::Active
+                && (operation.completed_at_epoch.is_none()
+                    || operation.completion_digest.is_none()))
+        {
+            return Err(state_invalid());
+        }
+    }
+    Ok(())
+}
+
+fn absolute_state_path(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 16 * 1024
+        && !value.chars().any(|character| character == '\0')
+        && Path::new(value).is_absolute()
+}
+
+fn bound(state: &State) -> Outcome {
+    Outcome {
+        data: json!({
+            "schema_version": BIND_RESULT_SCHEMA,
+            "kind": "bound",
+            "binding_id": state.binding.binding_id,
+            "workspace_id": state.workspace_id,
+            "generation": state.binding.generation,
+            "state": state.binding.mode.as_str(),
+            "renew_after_ms": RENEW_AFTER_MS,
+        }),
+        text: format!("workspace lease: {}\n", state.binding.mode.as_str()),
+    }
+}
+
+fn granted(operation: &OperationRecord) -> Outcome {
+    Outcome {
+        data: json!({
+            "schema_version": BEGIN_RESULT_SCHEMA,
+            "kind": "granted",
+            "operation_id": operation.operation_id,
+            "fence": operation.fence,
+        }),
+        text: "workspace lease: operation granted\n".to_string(),
+    }
+}
+
+fn denied(schema: &str, state: &str, code: &str, reason: &str) -> Outcome {
+    Outcome {
+        data: json!({
+            "schema_version": schema,
+            "kind": "denied",
+            "state": state,
+            "code": code,
+            "reason": reason,
+        }),
+        text: format!("workspace lease denied: {code}\n"),
+    }
+}
+
+fn ack(schema: &str, kind: &str, text: &str) -> Outcome {
+    Outcome {
+        data: json!({"schema_version": schema, "kind": kind}),
+        text: format!("workspace lease: {text}\n"),
+    }
+}
+
+fn binding_denial(
+    state: &State,
+    binding_id: &str,
+    workspace_id: &str,
+    generation: &str,
+    session_id: &str,
+    parent_session_id: Option<&str>,
+) -> Option<Outcome> {
+    let session_digest = digest(session_id.as_bytes());
+    let exact = exact_binding(
+        &state.binding,
+        binding_id,
+        workspace_id,
+        generation,
+        &session_digest,
+        parent_session_id,
+        &state.workspace_id,
+    );
+    if exact && state.binding.status == BindingStatus::Active {
+        return None;
+    }
+    Some(if state.binding.status == BindingStatus::Active {
+        denied(
+            BEGIN_RESULT_SCHEMA,
+            "foreign-active",
+            "WORKSPACE_BINDING_STALE",
+            "workspace binding generation no longer owns this workspace",
+        )
+    } else {
+        denied(
+            BEGIN_RESULT_SCHEMA,
+            "stale-clean",
+            "WORKSPACE_BINDING_RELEASED",
+            "workspace binding generation was released and must be rebound",
+        )
+    })
+}
+
+fn exact_binding(
+    binding: &Binding,
+    binding_id: &str,
+    workspace_id: &str,
+    generation: &str,
+    session_digest: &str,
+    parent_session_id: Option<&str>,
+    expected_workspace_id: &str,
+) -> bool {
+    binding.binding_id == binding_id
+        && binding.generation == generation
+        && workspace_id == expected_workspace_id
+        && binding.session_digest == session_digest
+        && binding.parent_session_digest
+            == parent_session_id.map(|parent| digest(parent.as_bytes()))
+}
+
+fn require_binding(
+    state: &State,
+    binding_id: &str,
+    workspace_id: &str,
+    generation: &str,
+    session_id: &str,
+    parent_session_id: Option<&str>,
+) -> Result<(), HookError> {
+    let session_digest = digest(session_id.as_bytes());
+    if state.binding.status != BindingStatus::Active
+        || !exact_binding(
+            &state.binding,
+            binding_id,
+            workspace_id,
+            generation,
+            &session_digest,
+            parent_session_id,
+            &state.workspace_id,
+        )
+    {
+        return Err(stale_binding());
+    }
+    Ok(())
+}
+
+fn expired_denial(state: &State) -> Result<Outcome, HookError> {
+    if state
+        .operations
+        .iter()
+        .any(|operation| operation.status == OperationStatus::Active)
+    {
+        return Ok(denied(
+            BEGIN_RESULT_SCHEMA,
+            "uncertain",
+            "WORKSPACE_OPERATION_UNCERTAIN",
+            "workspace lease expired with an operation lacking a terminal outcome",
+        ));
+    }
+    if state.binding.mode == BindingMode::Owned && dirty(managed_identity(&state.identity)?)? {
+        return Ok(denied(
+            BEGIN_RESULT_SCHEMA,
+            "dirty",
+            "WORKSPACE_DIRTY",
+            "workspace lease expired while the workspace remained dirty",
+        ));
+    }
+    Ok(denied(
+        BEGIN_RESULT_SCHEMA,
+        "stale-clean",
+        "WORKSPACE_LEASE_EXPIRED",
+        "workspace lease generation expired and must be rebound",
+    ))
+}
+
+fn lost_from_denial(mut outcome: Outcome) -> Outcome {
+    if let Some(object) = outcome.data.as_object_mut() {
+        object.insert("schema_version".to_string(), json!(RENEW_RESULT_SCHEMA));
+        object.insert("kind".to_string(), json!("lost"));
+    }
+    outcome.text = "workspace lease lost\n".to_string();
+    outcome
+}
+
+fn execution_digest(request: &BeginRequest) -> Result<String, HookError> {
+    digest_value(
+        "workspace-execution",
+        &json!({
+            "call_id": request.call_id,
+            "root_call_id": request.root_call_id,
+            "tool_name": request.tool_name,
+            "arguments": request.arguments,
+            "nested": request.nested,
+        }),
+    )
+}
+
+fn tool_is_read_only(request: &BeginRequest) -> bool {
+    match request.tool_name.as_str() {
+        "Read" | "read" | "Glob" | "glob" | "Grep" | "grep" => true,
+        "str_replace_editor" => request
+            .arguments
+            .get("command")
+            .and_then(Value::as_str)
+            .is_some_and(|command| command == "view"),
+        _ => false,
+    }
+}
+
+fn compact_operations(operations: &mut Vec<OperationRecord>) {
+    let mut terminal_to_remove = operations.len().saturating_sub(MAX_OPERATIONS - 1);
+    operations.retain(|operation| {
+        if terminal_to_remove > 0 && operation.status != OperationStatus::Active {
+            terminal_to_remove -= 1;
+            false
+        } else {
+            true
+        }
+    });
+}
+
+fn compact_tombstones(tombstones: &mut Vec<BindingTombstone>) {
+    if tombstones.len() > MAX_TOMBSTONES {
+        tombstones.drain(..tombstones.len() - MAX_TOMBSTONES);
+    }
+}
+
+fn tombstone(state: &State) -> BindingTombstone {
+    BindingTombstone {
+        binding_id: state.binding.binding_id.clone(),
+        generation: state.binding.generation.clone(),
+        session_digest: state.binding.session_digest.clone(),
+        workspace_id: state.workspace_id.clone(),
+    }
+}
+
+fn binding_key(binding_id: &str) -> Result<&str, HookError> {
+    let mut parts = binding_id.split('.');
+    let prefix = parts.next();
+    let key = parts.next();
+    let nonce = parts.next();
+    if prefix != Some("wlb1")
+        || key.is_none_or(|value| !is_hex_digest(value))
+        || nonce.is_none_or(|value| value.len() != 32 || !is_lower_hex(value))
+        || parts.next().is_some()
+    {
+        return Err(wire_invalid());
+    }
+    key.ok_or_else(wire_invalid)
+}
+
+fn valid_binding_id(value: &str, key: &str) -> bool {
+    binding_key(value).is_ok_and(|observed| observed == key)
+}
+
+fn valid_opaque(value: &str, prefix: &str) -> bool {
+    value
+        .strip_prefix(prefix)
+        .and_then(|value| value.strip_prefix('.'))
+        .is_some_and(|value| value.len() == 32 && is_lower_hex(value))
+}
+
+fn opaque(prefix: &str) -> String {
+    format!("{prefix}.{}", Uuid::new_v4().simple())
+}
+
+fn path_text(path: &Path) -> Result<String, HookError> {
+    path.to_str()
+        .map(str::to_string)
+        .ok_or_else(identity_unavailable)
+}
+
+fn digest_value(domain: &str, value: &impl Serialize) -> Result<String, HookError> {
+    let bytes = serde_json::to_vec(value).map_err(|_| wire_invalid())?;
+    let mut material = domain.as_bytes().to_vec();
+    material.push(0);
+    material.extend_from_slice(&bytes);
+    Ok(digest(&material))
+}
+
+fn keyed_value(key: &str, domain: &str, value: &impl Serialize) -> Result<String, HookError> {
+    let bytes = serde_json::to_vec(value).map_err(|_| wire_invalid())?;
+    let mut material = domain.as_bytes().to_vec();
+    material.push(0);
+    material.extend_from_slice(&bytes);
+    nils_common::coordination_projection::keyed_digest(key.as_bytes(), &material)
+        .ok_or_else(state_invalid)
+}
+
+fn digest(bytes: &[u8]) -> String {
+    let hash = Sha256::digest(bytes);
+    hash.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn is_hex_digest(value: &str) -> bool {
+    value.len() == 64 && is_lower_hex(value)
+}
+
+fn is_lower_hex(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn now_epoch() -> Result<u64, HookError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| {
+            workspace_unavailable(
+                "workspace-clock-unavailable",
+                "workspace lease clock is unavailable",
+                "restore the system clock and retry the exact request once",
+            )
+        })
+}
+
+fn wire_invalid() -> HookError {
+    HookError::data(
+        "workspace-wire-invalid",
+        "workspace lease request does not match the strict protocol",
+    )
+}
+
+fn identity_unavailable() -> HookError {
+    workspace_unavailable(
+        "workspace-identity-unavailable",
+        "workspace identity could not be resolved",
+        "restore the exact workspace and retry the exact request once",
+    )
+}
+
+fn lock_unavailable() -> HookError {
+    workspace_unavailable(
+        "workspace-lease-lock-unavailable",
+        "workspace lease lock is unavailable",
+        "verify the private state directory and retry the exact request once",
+    )
+}
+
+fn state_unavailable() -> HookError {
+    workspace_unavailable(
+        "workspace-lease-state-unavailable",
+        "workspace lease state is unavailable",
+        "verify the private state directory and retry the exact request once",
+    )
+}
+
+fn workspace_unavailable(code: &str, message: &str, next_action: &str) -> HookError {
+    HookError::unavailable_with(code, message, recoverable_details(next_action))
+}
+
+fn workspace_temporary(code: &str, message: &str, next_action: &str) -> HookError {
+    HookError::temporary_with(code, message, recoverable_details(next_action))
+}
+
+fn recoverable_details(next_action: &str) -> Value {
+    json!({
+        "retryable": true,
+        "next_action": next_action,
+        "recovery": {
+            "kind": "bounded-retry",
+            "max_attempts": 1,
+        },
+    })
+}
+
+fn state_invalid() -> HookError {
+    HookError::data(
+        "workspace-lease-state-invalid",
+        "workspace lease state invariants are invalid",
+    )
+}
+
+fn stale_binding() -> HookError {
+    HookError::data(
+        "workspace-binding-stale",
+        "workspace binding generation no longer owns this workspace",
+    )
+}
+
+fn idempotency_reused() -> HookError {
+    HookError::data(
+        "workspace-idempotency-key-reused",
+        "workspace request id is already bound to different facts",
+    )
+}

--- a/crates/agent-hook/src/workspace_lease.rs
+++ b/crates/agent-hook/src/workspace_lease.rs
@@ -336,6 +336,17 @@ fn bind(state_root: &Path, request: BindRequest) -> Result<Outcome, HookError> {
     let locked = lock_workspace(state_root, &key, Some(fingerprint_key))?;
     let mut state = read_state(&locked)?;
     let now = now_epoch()?;
+    let same_principal_recovery = state.as_ref().is_some_and(|existing| {
+        matches!(
+            request.source,
+            SessionStartSource::Resume | SessionStartSource::Compact
+        ) && existing.binding.session_digest == session_digest
+            && existing.binding.parent_session_digest == parent_session_digest
+            && existing
+                .operations
+                .iter()
+                .all(|operation| operation.status != OperationStatus::Active)
+    });
     if let Some(existing) = state.as_ref() {
         validate_state(existing, &locked, &identity)?;
         if existing.binding.bind_request_id_digest == request_id_digest {
@@ -377,7 +388,7 @@ fn bind(state_root: &Path, request: BindRequest) -> Result<Outcome, HookError> {
             ));
         }
         let identity = managed_identity(&identity)?;
-        if dirty(identity)? {
+        if !same_principal_recovery && dirty(identity)? {
             return Ok(denied(
                 BIND_RESULT_SCHEMA,
                 "dirty",

--- a/crates/agent-hook/tests/contracts.rs
+++ b/crates/agent-hook/tests/contracts.rs
@@ -394,6 +394,7 @@ fn cli_help_version_and_completion_surface_are_complete() {
         "setup",
         "recovery",
         "finish-line",
+        "workspace-lease",
         "completion",
         "-V, --version",
     ] {
@@ -446,6 +447,28 @@ fn cli_help_version_and_completion_surface_are_complete() {
     assert!(run_help.stdout_text().contains("[default: json]"));
     assert!(!run_help.stdout_text().contains("text output (default)"));
 
+    let workspace_help = fixture.run(&["workspace-lease", "--help"], None);
+    assert_eq!(
+        workspace_help.code,
+        0,
+        "stderr={}",
+        workspace_help.stderr_text()
+    );
+    let workspace_help_text = workspace_help.stdout_text();
+    for required in ["bind", "begin", "complete", "renew", "release"] {
+        assert!(
+            workspace_help_text.contains(required),
+            "workspace-lease help missing {required}: {workspace_help_text}"
+        );
+    }
+    let workspace_bind_help = fixture.run(&["workspace-lease", "bind", "--help"], None);
+    assert_eq!(workspace_bind_help.code, 0);
+    assert!(
+        workspace_bind_help
+            .stdout_text()
+            .contains("[default: json]")
+    );
+
     for shell in ["bash", "zsh"] {
         let completion = fixture.run(&["completion", shell], None);
         assert_eq!(completion.code, 0, "shell={shell}");
@@ -454,11 +477,9 @@ fn cli_help_version_and_completion_surface_are_complete() {
             !script.contains("quiesce"),
             "internal quiesce leaked anywhere in public completion; shell={shell}"
         );
-        assert!(
-            !script.contains("release"),
-            "internal release leaked anywhere in public completion; shell={shell}"
-        );
         assert!(script.contains("dispatch"), "shell={shell}");
+        assert!(script.contains("workspace-lease"), "shell={shell}");
+        assert!(script.contains("renew"), "shell={shell}");
         assert!(script.contains("--expected-plan-digest"), "shell={shell}");
         let (scope_start, scope_end) = if shell == "bash" {
             (

--- a/crates/agent-hook/tests/workspace_lease.rs
+++ b/crates/agent-hook/tests/workspace_lease.rs
@@ -279,6 +279,92 @@ fn dirty_state_refuses_takeover_and_clean_expiry_recovers_with_a_new_generation(
 }
 
 #[test]
+fn released_same_session_resumes_dirty_work_but_a_foreign_session_cannot_take_it_over() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    let release = json!({
+        "schema_version": "agent-hook.workspace-lease.release.v1",
+        "version": 1,
+        "request_id": "release-owner",
+        "session_id": "session-owner",
+        "binding_id": owner["binding_id"],
+        "workspace_id": owner["workspace_id"],
+        "generation": owner["generation"],
+        "reason": "agent-disposed"
+    });
+    let (code, released) = invoke(&fixture, "release", release);
+    assert_eq!(code, 0, "envelope={released}");
+
+    fs::write(fixture.root.join("resume.txt"), "owned work\n").expect("dirty work");
+    let mut resume_request = bind_request("session-owner", "bind-owner-resume", &fixture.root);
+    resume_request["source"] = json!("resume");
+    let (code, envelope) = invoke(&fixture, "bind", resume_request);
+    assert_eq!(code, 0, "envelope={envelope}");
+    let resumed = envelope["data"].clone();
+    assert_eq!(resumed["kind"], "bound");
+    assert_ne!(resumed["generation"], owner["generation"]);
+
+    let second_release = json!({
+        "schema_version": "agent-hook.workspace-lease.release.v1",
+        "version": 1,
+        "request_id": "release-owner-resume",
+        "session_id": "session-owner",
+        "binding_id": resumed["binding_id"],
+        "workspace_id": resumed["workspace_id"],
+        "generation": resumed["generation"],
+        "reason": "agent-disposed"
+    });
+    let (code, released) = invoke(&fixture, "release", second_release);
+    assert_eq!(code, 0, "envelope={released}");
+
+    let same_session_startup = bind(
+        &fixture,
+        "session-owner",
+        "bind-owner-startup",
+        &fixture.root,
+    );
+    assert_eq!(same_session_startup["kind"], "denied");
+    assert_eq!(same_session_startup["state"], "dirty");
+    assert_eq!(same_session_startup["code"], "WORKSPACE_DIRTY");
+
+    let foreign = bind(&fixture, "session-foreign", "bind-foreign", &fixture.root);
+    assert_eq!(foreign["kind"], "denied");
+    assert_eq!(foreign["state"], "dirty");
+    assert_eq!(foreign["code"], "WORKSPACE_DIRTY");
+}
+
+#[test]
+fn same_session_resume_cannot_recover_an_expired_active_operation() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    let mutation = begin_request(&owner, "session-owner", "begin-active", "write");
+    let (code, granted) = invoke(&fixture, "begin", mutation);
+    assert_eq!(code, 0, "envelope={granted}");
+    assert_eq!(granted["data"]["kind"], "granted");
+
+    fs::write(fixture.root.join("active.txt"), "active work\n").expect("dirty work");
+    let state = workspace_state_file(&fixture);
+    let mut persisted: Value =
+        serde_json::from_slice(&fs::read(&state).expect("state bytes")).expect("state JSON");
+    persisted["binding"]["refreshed_at_epoch"] = json!(1);
+    persisted["binding"]["expires_at_epoch"] = json!(1);
+    fs::write(
+        &state,
+        serde_json::to_vec_pretty(&persisted).expect("state render"),
+    )
+    .expect("expire active state");
+    Fixture::set_private(&state);
+
+    let mut resume = bind_request("session-owner", "bind-owner-resume", &fixture.root);
+    resume["source"] = json!("resume");
+    let (code, envelope) = invoke(&fixture, "bind", resume);
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["kind"], "denied");
+    assert_eq!(envelope["data"]["state"], "uncertain");
+    assert_eq!(envelope["data"]["code"], "WORKSPACE_OPERATION_UNCERTAIN");
+}
+
+#[test]
 fn read_only_tools_need_no_operation_and_copied_fences_fail_closed() {
     let fixture = fixture();
     let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);

--- a/crates/agent-hook/tests/workspace_lease.rs
+++ b/crates/agent-hook/tests/workspace_lease.rs
@@ -1,0 +1,529 @@
+mod support;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use pretty_assertions::{assert_eq, assert_ne};
+use serde_json::{Value, json};
+
+use support::Fixture;
+
+const POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "workspace-lease-test"
+version = "2026.08.24.1"
+"#;
+
+fn fixture() -> Fixture {
+    let fixture = Fixture::new(POLICY);
+    git(&fixture.root, &["init", "--quiet"]);
+    git(
+        &fixture.root,
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(&fixture.root, &["config", "user.name", "Workspace Test"]);
+    fs::write(
+        fixture.root.join(".gitignore"),
+        "/config/\n/data/\n/home/\n/state/\n/session-state/\n/linked/\n",
+    )
+    .expect("fixture ignores");
+    fs::write(fixture.root.join("tracked.txt"), "base\n").expect("tracked file");
+    git(&fixture.root, &["add", "--all"]);
+    git(&fixture.root, &["commit", "--quiet", "-m", "test: initial"]);
+    fixture
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn invoke(fixture: &Fixture, operation: &str, request: Value) -> (i32, Value) {
+    let output = fixture.run(
+        &["workspace-lease", operation, "--format", "json"],
+        Some(&request.to_string()),
+    );
+    (output.code, output.stdout_json())
+}
+
+fn bind_request(session: &str, request_id: &str, cwd: &Path) -> Value {
+    json!({
+        "schema_version": "agent-hook.workspace-lease.bind.v1",
+        "version": 1,
+        "request_id": request_id,
+        "session_id": session,
+        "cwd": cwd,
+        "source": "startup"
+    })
+}
+
+fn bind(fixture: &Fixture, session: &str, request_id: &str, cwd: &Path) -> Value {
+    let (code, envelope) = invoke(fixture, "bind", bind_request(session, request_id, cwd));
+    assert_eq!(code, 0, "envelope={envelope}");
+    envelope["data"].clone()
+}
+
+fn begin_request(binding: &Value, session: &str, request_id: &str, tool: &str) -> Value {
+    json!({
+        "schema_version": "agent-hook.workspace-lease.begin.v1",
+        "version": 1,
+        "request_id": request_id,
+        "session_id": session,
+        "binding_id": binding["binding_id"],
+        "workspace_id": binding["workspace_id"],
+        "generation": binding["generation"],
+        "binding_state": binding["state"],
+        "call_id": format!("call:{request_id}"),
+        "root_call_id": format!("root:{request_id}"),
+        "tool_name": tool,
+        "arguments": {"path": "tracked.txt", "content": "next"},
+        "nested": false
+    })
+}
+
+fn complete_request(binding: &Value, operation: &Value, session: &str, request_id: &str) -> Value {
+    json!({
+        "schema_version": "agent-hook.workspace-lease.complete.v1",
+        "version": 1,
+        "request_id": request_id,
+        "session_id": session,
+        "binding_id": binding["binding_id"],
+        "workspace_id": binding["workspace_id"],
+        "generation": binding["generation"],
+        "operation_id": operation["operation_id"],
+        "fence": operation["fence"],
+        "call_id": "call:begin-1",
+        "root_call_id": "root:begin-1",
+        "tool_name": "write",
+        "outcome": "succeeded"
+    })
+}
+
+#[test]
+fn canonical_binding_converges_path_spellings_but_distinguishes_linked_worktrees() {
+    let fixture = fixture();
+    let dotted = fixture.root.join("subdir/..");
+    fs::create_dir_all(fixture.root.join("subdir")).expect("subdir");
+
+    let first = bind(&fixture, "session-a", "bind-a", &dotted);
+    assert_eq!(
+        first["schema_version"],
+        "agent-hook.workspace-lease.bind-result.v1"
+    );
+    assert_eq!(first["kind"], "bound");
+    assert_eq!(first["state"], "owned");
+    assert_eq!(first["renew_after_ms"], 10_000);
+
+    let replay = bind(&fixture, "session-a", "bind-a", &fixture.root);
+    assert_eq!(
+        replay, first,
+        "the exact request id must replay after canonicalization"
+    );
+
+    let linked = fixture.root.join("linked");
+    git(
+        &fixture.root,
+        &[
+            "worktree",
+            "add",
+            "--quiet",
+            "--detach",
+            linked.to_str().expect("linked UTF-8"),
+            "HEAD",
+        ],
+    );
+    let second = bind(&fixture, "session-b", "bind-b", &linked);
+    assert_eq!(second["kind"], "bound");
+    assert_ne!(second["workspace_id"], first["workspace_id"]);
+    assert!(
+        !second
+            .to_string()
+            .contains(fixture.root.to_str().expect("root UTF-8"))
+    );
+}
+
+#[test]
+fn cross_process_contention_release_and_duplicate_lifecycle_are_fenced() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+
+    let denied = bind(&fixture, "session-peer", "bind-peer", &fixture.root);
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["state"], "foreign-active");
+    assert_eq!(denied["code"], "WORKSPACE_FOREIGN_ACTIVE");
+
+    let first_begin_request = begin_request(&owner, "session-owner", "begin-1", "write");
+    let (code, first_begin) = invoke(&fixture, "begin", first_begin_request.clone());
+    assert_eq!(code, 0, "envelope={first_begin}");
+    assert_eq!(first_begin["data"]["kind"], "granted");
+    let (code, replayed_begin) = invoke(&fixture, "begin", first_begin_request);
+    assert_eq!(code, 0, "envelope={replayed_begin}");
+    assert_eq!(replayed_begin["data"], first_begin["data"]);
+
+    let operation = &first_begin["data"];
+    let completion = complete_request(&owner, operation, "session-owner", "complete-1");
+    let (code, first_complete) = invoke(&fixture, "complete", completion.clone());
+    assert_eq!(code, 0, "envelope={first_complete}");
+    assert_eq!(first_complete["data"]["kind"], "completed");
+    let (code, duplicate_complete) = invoke(&fixture, "complete", completion);
+    assert_eq!(code, 0, "envelope={duplicate_complete}");
+    assert_eq!(duplicate_complete["data"]["kind"], "duplicate");
+
+    let release = json!({
+        "schema_version": "agent-hook.workspace-lease.release.v1",
+        "version": 1,
+        "request_id": "release-1",
+        "session_id": "session-owner",
+        "binding_id": owner["binding_id"],
+        "workspace_id": owner["workspace_id"],
+        "generation": owner["generation"],
+        "reason": "agent-disposed"
+    });
+    let (code, first_release) = invoke(&fixture, "release", release.clone());
+    assert_eq!(code, 0, "envelope={first_release}");
+    assert_eq!(first_release["data"]["kind"], "released");
+    let (code, duplicate_release) = invoke(&fixture, "release", release);
+    assert_eq!(code, 0, "envelope={duplicate_release}");
+    assert_eq!(duplicate_release["data"]["kind"], "duplicate");
+
+    let peer = bind(&fixture, "session-peer", "bind-peer-2", &fixture.root);
+    assert_eq!(peer["kind"], "bound");
+    assert_ne!(peer["generation"], owner["generation"]);
+
+    let stale = begin_request(&owner, "session-owner", "stale-begin", "write");
+    let (code, envelope) = invoke(&fixture, "begin", stale);
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["kind"], "denied");
+    assert_eq!(envelope["data"]["state"], "foreign-active");
+}
+
+#[test]
+fn simultaneous_processes_publish_exactly_one_workspace_owner() {
+    let fixture = fixture();
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| bind(&fixture, "session-a", "bind-a", &fixture.root));
+        let second = scope.spawn(|| bind(&fixture, "session-b", "bind-b", &fixture.root));
+        (
+            first.join().expect("first bind process"),
+            second.join().expect("second bind process"),
+        )
+    });
+    let mut kinds = [
+        first["kind"].as_str().expect("first kind"),
+        second["kind"].as_str().expect("second kind"),
+    ];
+    kinds.sort_unstable();
+    assert_eq!(kinds, ["bound", "denied"]);
+    let denial = if first["kind"] == "denied" {
+        first
+    } else {
+        second
+    };
+    assert_eq!(denial["state"], "foreign-active");
+}
+
+#[test]
+fn dirty_state_refuses_takeover_and_clean_expiry_recovers_with_a_new_generation() {
+    let fixture = fixture();
+    fs::write(fixture.root.join("dirty.txt"), "dirty\n").expect("dirty file");
+    let dirty = bind(&fixture, "session-a", "dirty-bind", &fixture.root);
+    assert_eq!(dirty["kind"], "denied");
+    assert_eq!(dirty["state"], "dirty");
+    assert_eq!(dirty["code"], "WORKSPACE_DIRTY");
+
+    fs::remove_file(fixture.root.join("dirty.txt")).expect("clean checkout");
+    let owner = bind(&fixture, "session-a", "clean-bind", &fixture.root);
+    assert_eq!(owner["kind"], "bound");
+
+    let state = workspace_state_file(&fixture);
+    let mut persisted: Value =
+        serde_json::from_slice(&fs::read(&state).expect("state bytes")).expect("state JSON");
+    persisted["binding"]["refreshed_at_epoch"] = json!(1);
+    persisted["binding"]["expires_at_epoch"] = json!(1);
+    fs::write(
+        &state,
+        serde_json::to_vec_pretty(&persisted).expect("state render"),
+    )
+    .expect("expire state");
+    Fixture::set_private(&state);
+
+    let recovered = bind(&fixture, "session-b", "recover-bind", &fixture.root);
+    assert_eq!(recovered["kind"], "bound");
+    assert_ne!(recovered["generation"], owner["generation"]);
+    assert_ne!(recovered["binding_id"], owner["binding_id"]);
+
+    fs::write(fixture.root.join("dirty-again.txt"), "dirty\n").expect("dirty again");
+    let state = workspace_state_file(&fixture);
+    let mut persisted: Value =
+        serde_json::from_slice(&fs::read(&state).expect("state bytes")).expect("state JSON");
+    persisted["binding"]["refreshed_at_epoch"] = json!(1);
+    persisted["binding"]["expires_at_epoch"] = json!(1);
+    fs::write(
+        &state,
+        serde_json::to_vec_pretty(&persisted).expect("state render"),
+    )
+    .expect("expire dirty state");
+    Fixture::set_private(&state);
+
+    let refused = bind(&fixture, "session-c", "dirty-takeover", &fixture.root);
+    assert_eq!(refused["kind"], "denied");
+    assert_eq!(refused["state"], "dirty");
+}
+
+#[test]
+fn read_only_tools_need_no_operation_and_copied_fences_fail_closed() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+
+    let read = begin_request(&owner, "session-owner", "read-1", "read");
+    let (code, envelope) = invoke(&fixture, "begin", read);
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["kind"], "not-required");
+
+    let mutation = begin_request(&owner, "session-owner", "begin-1", "write");
+    let (code, granted) = invoke(&fixture, "begin", mutation);
+    assert_eq!(code, 0, "envelope={granted}");
+    let mut forged = complete_request(&owner, &granted["data"], "session-owner", "complete-x");
+    forged["fence"] = json!("wlf1.copied");
+    let (code, denied) = invoke(&fixture, "complete", forged);
+    assert_eq!(code, 65, "envelope={denied}");
+    assert_eq!(denied["error"]["code"], "workspace-operation-fence-invalid");
+    assert!(
+        !denied
+            .to_string()
+            .contains(fixture.root.to_str().expect("root UTF-8")),
+        "diagnostics must not leak checkout paths: {denied}"
+    );
+}
+
+#[test]
+fn renew_is_exact_and_non_git_directories_remain_unmanaged() {
+    let fixture = fixture();
+    let non_git = tempfile::TempDir::new().expect("non-Git cwd");
+    let binding = bind(
+        &fixture,
+        "unmanaged-session",
+        "unmanaged-bind",
+        non_git.path(),
+    );
+    assert_eq!(binding["kind"], "bound");
+    assert_eq!(binding["state"], "unmanaged");
+
+    let mutation = begin_request(&binding, "unmanaged-session", "unmanaged-write", "write");
+    let (code, result) = invoke(&fixture, "begin", mutation);
+    assert_eq!(code, 0, "envelope={result}");
+    assert_eq!(result["data"]["kind"], "not-required");
+
+    let renew = json!({
+        "schema_version": "agent-hook.workspace-lease.renew.v1",
+        "version": 1,
+        "request_id": "unmanaged-renew",
+        "session_id": "unmanaged-session",
+        "binding_id": binding["binding_id"],
+        "workspace_id": binding["workspace_id"],
+        "generation": binding["generation"]
+    });
+    let (code, renewed) = invoke(&fixture, "renew", renew.clone());
+    assert_eq!(code, 0, "envelope={renewed}");
+    assert_eq!(renewed["data"]["kind"], "renewed");
+    assert_eq!(renewed["data"]["renew_after_ms"], 10_000);
+
+    let release = json!({
+        "schema_version": "agent-hook.workspace-lease.release.v1",
+        "version": 1,
+        "request_id": "unmanaged-release",
+        "session_id": "unmanaged-session",
+        "binding_id": binding["binding_id"],
+        "workspace_id": binding["workspace_id"],
+        "generation": binding["generation"],
+        "reason": "provider-disposed"
+    });
+    let (code, released) = invoke(&fixture, "release", release);
+    assert_eq!(code, 0, "envelope={released}");
+    let (code, lost) = invoke(&fixture, "renew", renew);
+    assert_eq!(code, 0, "envelope={lost}");
+    assert_eq!(lost["data"]["kind"], "lost");
+    assert_eq!(lost["data"]["state"], "stale-clean");
+    assert_eq!(lost["data"]["code"], "WORKSPACE_BINDING_RELEASED");
+}
+
+#[test]
+fn strict_wire_rejects_duplicate_and_unknown_fields() {
+    let fixture = fixture();
+    let duplicate = format!(
+        r#"{{"schema_version":"agent-hook.workspace-lease.bind.v1","version":1,"request_id":"a","request_id":"b","session_id":"s","cwd":{},"source":"startup"}}"#,
+        serde_json::to_string(&fixture.root).expect("cwd JSON")
+    );
+    let output = fixture.run(
+        &["workspace-lease", "bind", "--format", "json"],
+        Some(&duplicate),
+    );
+    assert_eq!(output.code, 65, "stdout={}", output.stdout_text());
+    assert_eq!(
+        output.stdout_json()["error"]["code"],
+        "workspace-wire-invalid"
+    );
+
+    let mut unknown = bind_request("session-a", "unknown", &fixture.root);
+    unknown["repository"] = json!("forged/repository");
+    let (code, envelope) = invoke(&fixture, "bind", unknown);
+    assert_eq!(code, 65, "envelope={envelope}");
+    assert_eq!(envelope["error"]["code"], "workspace-wire-invalid");
+}
+
+#[test]
+fn expired_active_operation_blocks_recovery_until_exact_completion() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    let mutation = begin_request(&owner, "session-owner", "begin-1", "write");
+    let (code, granted) = invoke(&fixture, "begin", mutation);
+    assert_eq!(code, 0, "envelope={granted}");
+    assert_eq!(granted["data"]["kind"], "granted");
+
+    expire_workspace_state(&fixture);
+    let refused = bind(&fixture, "session-peer", "bind-peer", &fixture.root);
+    assert_eq!(refused["kind"], "denied");
+    assert_eq!(refused["state"], "uncertain");
+    assert_eq!(refused["code"], "WORKSPACE_OPERATION_UNCERTAIN");
+
+    let release = json!({
+        "schema_version": "agent-hook.workspace-lease.release.v1",
+        "version": 1,
+        "request_id": "release-active",
+        "session_id": "session-owner",
+        "binding_id": owner["binding_id"],
+        "workspace_id": owner["workspace_id"],
+        "generation": owner["generation"],
+        "reason": "agent-disposed"
+    });
+    let (code, envelope) = invoke(&fixture, "release", release.clone());
+    assert_eq!(code, 69, "envelope={envelope}");
+    assert_eq!(envelope["error"]["code"], "workspace-release-uncertain");
+    assert_eq!(envelope["error"]["details"]["retryable"], true);
+    assert_eq!(
+        envelope["error"]["details"]["recovery"]["kind"],
+        "bounded-retry"
+    );
+
+    let completion = complete_request(&owner, &granted["data"], "session-owner", "complete-1");
+    let (code, envelope) = invoke(&fixture, "complete", completion);
+    assert_eq!(code, 0, "envelope={envelope}");
+    let (code, envelope) = invoke(&fixture, "release", release);
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["kind"], "released");
+
+    let peer = bind(&fixture, "session-peer", "bind-peer-2", &fixture.root);
+    assert_eq!(peer["kind"], "bound");
+    assert_ne!(peer["generation"], owner["generation"]);
+}
+
+#[test]
+fn malformed_durable_state_fails_closed_without_protected_values() {
+    let fixture = fixture();
+    let _owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    let state = workspace_state_file(&fixture);
+    fs::write(&state, b"{").expect("malformed state");
+    Fixture::set_private(&state);
+
+    let (code, envelope) = invoke(
+        &fixture,
+        "bind",
+        bind_request("session-peer", "bind-peer", &fixture.root),
+    );
+    assert_eq!(code, 65, "envelope={envelope}");
+    assert_eq!(envelope["error"]["code"], "workspace-lease-state-invalid");
+    assert!(
+        !envelope
+            .to_string()
+            .contains(fixture.root.to_str().expect("root UTF-8")),
+        "diagnostics must not expose protected paths: {envelope}"
+    );
+    assert!(!envelope.to_string().contains("session-owner"));
+}
+
+#[test]
+fn durable_state_hashes_session_call_and_tool_facts_and_keeps_its_key_private() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = fixture();
+    let owner = bind(&fixture, "private-session", "private-bind", &fixture.root);
+    let mutation = begin_request(&owner, "private-session", "private-begin", "write");
+    let (code, granted) = invoke(&fixture, "begin", mutation);
+    assert_eq!(code, 0, "envelope={granted}");
+
+    let state_text = fs::read_to_string(workspace_state_file(&fixture)).expect("state text");
+    for protected in [
+        "private-session",
+        "private-bind",
+        "private-begin",
+        "call:private-begin",
+        "root:private-begin",
+        "tracked.txt",
+        "next",
+    ] {
+        assert!(
+            !state_text.contains(protected),
+            "durable state retained protected value {protected:?}"
+        );
+    }
+
+    let key_path = fixture
+        .state_home
+        .join("agent-hook/workspace-leases/fingerprint.key");
+    let key = fs::read_to_string(&key_path).expect("fingerprint key");
+    assert_eq!(key.len(), 64);
+    assert_eq!(
+        fs::metadata(&key_path)
+            .expect("fingerprint key metadata")
+            .permissions()
+            .mode()
+            & 0o777,
+        0o600
+    );
+    assert!(!owner.to_string().contains(&key));
+    assert!(!granted.to_string().contains(&key));
+}
+
+#[test]
+fn expired_exact_bind_request_never_replays_stale_authority() {
+    let fixture = fixture();
+    let owner = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    expire_workspace_state(&fixture);
+
+    let rebound = bind(&fixture, "session-owner", "bind-owner", &fixture.root);
+    assert_eq!(rebound["kind"], "bound");
+    assert_ne!(rebound["binding_id"], owner["binding_id"]);
+    assert_ne!(rebound["generation"], owner["generation"]);
+}
+
+fn workspace_state_file(fixture: &Fixture) -> PathBuf {
+    let root = fixture.state_home.join("agent-hook/workspace-leases");
+    fs::read_dir(root)
+        .expect("workspace lease root")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path().join("state.json"))
+        .find(|path| path.is_file())
+        .expect("workspace lease state")
+}
+
+fn expire_workspace_state(fixture: &Fixture) {
+    let state = workspace_state_file(fixture);
+    let mut persisted: Value =
+        serde_json::from_slice(&fs::read(&state).expect("state bytes")).expect("state JSON");
+    persisted["binding"]["refreshed_at_epoch"] = json!(1);
+    persisted["binding"]["expires_at_epoch"] = json!(1);
+    fs::write(
+        &state,
+        serde_json::to_vec_pretty(&persisted).expect("state render"),
+    )
+    .expect("expire state");
+    Fixture::set_private(&state);
+}

--- a/crates/nils-common/src/coordination_projection.rs
+++ b/crates/nils-common/src/coordination_projection.rs
@@ -243,8 +243,16 @@ pub fn worktree_fingerprint(epoch: u64, key: &str, checkout: &Path) -> Option<St
         return None;
     }
     let canonical = fs::canonicalize(checkout).unwrap_or_else(|_| checkout.to_path_buf());
-    let digest = hmac_sha256(key.as_bytes(), canonical.as_os_str().as_encoded_bytes());
-    Some(format!("hmac-sha256:{epoch}:{}", hex(&digest)))
+    let digest = keyed_digest(key.as_bytes(), canonical.as_os_str().as_encoded_bytes())?;
+    Some(format!("hmac-sha256:{epoch}:{digest}"))
+}
+
+/// Return a lowercase HMAC-SHA256 digest for private identity indexing.
+///
+/// The key must carry at least 256 bits of caller-owned entropy. This keeps
+/// canonical paths and other low-entropy host facts out of public opaque IDs.
+pub fn keyed_digest(key: &[u8], message: &[u8]) -> Option<String> {
+    (key.len() >= 32).then(|| hex(&hmac_sha256(key, message)))
 }
 
 fn read_private(path: &Path, max_bytes: u64) -> io::Result<Vec<u8>> {
@@ -308,6 +316,21 @@ fn hex(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn keyed_digest_requires_private_entropy_and_is_key_bound() {
+        assert_eq!(
+            keyed_digest(&[0x0b; 20], b"Hi There"),
+            None,
+            "short keys are not valid durable identity keys"
+        );
+        let first = keyed_digest(&[0x0b; 32], b"Hi There").expect("keyed digest");
+        let replay = keyed_digest(&[0x0b; 32], b"Hi There").expect("keyed digest replay");
+        let another = keyed_digest(&[0x0c; 32], b"Hi There").expect("other key");
+        assert_eq!(first, replay);
+        assert_ne!(first, another);
+        assert_eq!(first.len(), 64);
+    }
 
     #[test]
     fn projection_reader_accepts_legacy_and_fence_aware_registry_markers() {


### PR DESCRIPTION
## Summary

Add the canonical WorkspaceLease v1 authority to agent-hook so callers can bind a physical Git worktree, acquire fenced mutation operations, renew ownership, and perform exact same-session dirty recovery without relying on branch names or shell-reconstructed evidence.

## Issues

Refs sympoies/dsh-runtime-kit#56

## Changes

- Canonicalize repository and linked-worktree identity independently of the current branch or default branch.
- Persist private leases, generations, operation fences, idempotency receipts, expiry, release, and fail-closed uncertainty handling.
- Allow explicit resume or compact recovery only for the exact authenticated session lineage after every prior operation is terminal; keep startup, clear, foreign, and uncertain recovery denied.

## Test-First Evidence

- The baseline had no workspace-lease subcommand, typed envelopes, durable state, or contract tests, so the new WorkspaceLease v1 integration target could not resolve.
- The implementation was driven by canonical identity, contention, operation fencing, replay, expiry, and dirty-recovery tests.

## Test plan

- WorkspaceLease contract suite: 13/13 passed.
- Complete `nils-agent-hook` crate suite: passed.
- `cargo fmt --check` and clippy: passed.
- Repository pre-PR gate: passed, including 8,618/8,618 local-fast workspace tests and doctests.
- Contract-consumer smoke passed through packed runtime-kit on DSH rc.7, rc.8, and rc.2.

## Risk / Notes

- High-risk shared mutation authority. Private state is owner-only, every mutating operation is generation-fenced, uncertain operations block recovery, and rollout is paired with an explicit runtime-kit rollback path.
