### PR TITLE
fix(agent-hook): admit governed feature-worktree commits

### DIFF
--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -98,14 +98,18 @@ session is unchanged. Post-only lookups create no state; certain denials remove
 their whole provisional directory. Terminal retries compact to 64 by a durable
 monotonic completion sequence behind a private session lock, and a
 128-directory ceiling blocks new admission rather than evicting active or
-uncertain work. The default-delivery
-evaluator pins the primary/default
-branch consensus in owner-private state before admitting Bash or native file
-mutation, rejects later Git metadata drift, and protects Git metadata from
-native write/edit tools. Raw commit-producing rewrites are denied on the
-default branch while exact recovery and owned `git-cli`, `forge-cli`, and
-`semantic-commit` routes remain usable. Path-backed semantic commit messages
-and ambiguous repeated scalar options fail closed.
+uncertain work. The default-delivery evaluator pins the remote-advertised
+default branch in owner-private state before admitting Bash or native file
+mutation. The primary checkout's current branch is independent: it may be an
+integration branch, detached, or absent without redefining the remote default.
+Disagreeing remotes, missing evidence, or later metadata drift fail closed,
+and native write/edit tools cannot target Git metadata. Raw commit-producing
+rewrites are denied on the default branch while exact recovery and owned
+`git-cli`, `forge-cli`, and `semantic-commit` routes remain usable. The
+structured `runtime_kit_governed_commit` path additionally requires the
+authenticated execution root to be that exact linked worktree; it accepts no
+repository retarget. Path-backed semantic commit messages and ambiguous
+repeated scalar options fail closed.
 
 The separate `workspace-lease` service is the native WorkspaceLease v1 policy
 provider for dsh-runtime-kit. `bind` resolves an optional DSH cwd to one

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -714,11 +714,15 @@ generic `token`, `authorization`, or `private_key` labels, and rendered only as 
 untrusted container.
 
 For `block-unsafe-default-delivery`, the engine records an owner-private
-projection of the canonical common Git directory identity and the primary
-branch before admitting Bash or native file mutation. A usable default branch
-requires that pinned branch and the cached remote HEAD agree; drift is
-fail-closed and native write/edit/str-replace targets inside Git metadata are
-denied. Raw merge, pull, cherry-pick, rebase, revert, am, reset, update-ref,
+projection of the canonical common Git directory identity and the unambiguous
+cached remote HEAD before admitting Bash or native file mutation. The primary
+checkout's current branch is not default-branch evidence and may differ from
+the remote default. Multiple remotes must advertise the same default; missing,
+contradictory, or drifted evidence is fail-closed, and native
+write/edit/str-replace targets inside Git metadata are denied. The structured
+`runtime_kit_governed_commit` tool is admissible only from its exact linked
+worktree binding and has no repository-routing argument. Raw merge, pull,
+cherry-pick, rebase, revert, am, reset, update-ref,
 branch, push, and fetch shapes are classified against the resolved `git -C` or
 semantic `--repo` target. `fetch --update-head-ok`, protected fetch
 destinations, and stdin/server-driven ref-update plumbing are denied. A shell

--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -27,8 +27,9 @@ use crate::policy_parity::DshCapabilityGroup;
 
 const MAX_COMMAND_BYTES: usize = 256 * 1024;
 const MAX_PARSE_DEPTH: usize = 5;
+const GOVERNED_COMMIT_TOOL: &str = "runtime_kit_governed_commit";
 const LEASE_SCHEMA: &str = "agent-hook.dsh-checkout-lease.v1";
-const DEFAULT_BRANCH_SCHEMA: &str = "agent-hook.dsh-default-branch.v1";
+const DEFAULT_BRANCH_SCHEMA: &str = "agent-hook.dsh-default-branch.v2";
 const LEASE_TTL_SECONDS: u64 = 8 * 60 * 60;
 
 pub(crate) struct Outcome {
@@ -99,12 +100,18 @@ pub(crate) fn evaluate(
         DshCapabilityGroup::BlockDirectGitWorktree => direct_git_worktree(&invocations),
         DshCapabilityGroup::BlockDirectPrCreate => direct_pr_create(&invocations),
         DshCapabilityGroup::BlockDirectPython => direct_python(&invocations, request),
-        DshCapabilityGroup::SemanticCommitBodyGate => semantic_body_missing(&invocations),
+        DshCapabilityGroup::SemanticCommitBodyGate => {
+            if request.matcher.as_deref() == Some(GOVERNED_COMMIT_TOOL) {
+                !governed_commit_arguments_valid(raw)
+            } else {
+                semantic_body_missing(&invocations)
+            }
+        }
         DshCapabilityGroup::BlockUnsafeDefaultDelivery => {
             if request.matcher.as_deref() == Some("bash") {
                 unsafe_default_delivery(&invocations, request, run_child)?
             } else {
-                unsafe_default_native_mutation(request, effect)?
+                unsafe_default_native_mutation(request, raw, effect)?
             }
         }
         DshCapabilityGroup::PreEditIntentGate => {
@@ -167,15 +174,16 @@ fn command_dependent(group: DshCapabilityGroup, request: &NormalizedRequest) -> 
             | DshCapabilityGroup::BlockDirectGitWorktree
             | DshCapabilityGroup::BlockDirectPrCreate
             | DshCapabilityGroup::BlockDirectPython
-            | DshCapabilityGroup::SemanticCommitBodyGate
             | DshCapabilityGroup::ForgeLabelReminder
-    ) || (matches!(
-        group,
-        DshCapabilityGroup::McpSecretScan
-            | DshCapabilityGroup::BlockProjectMemoryWrite
-            | DshCapabilityGroup::MemoryWritePrincipleReminder
-            | DshCapabilityGroup::PortablePathsScan
-    ) && request.matcher.as_deref() == Some("bash"))
+    ) || (group == DshCapabilityGroup::SemanticCommitBodyGate
+        && request.matcher.as_deref() == Some("bash"))
+        || (matches!(
+            group,
+            DshCapabilityGroup::McpSecretScan
+                | DshCapabilityGroup::BlockProjectMemoryWrite
+                | DshCapabilityGroup::MemoryWritePrincipleReminder
+                | DshCapabilityGroup::PortablePathsScan
+        ) && request.matcher.as_deref() == Some("bash"))
         || (group == DshCapabilityGroup::CheckoutLeaseGuard
             && request.matcher.as_deref() == Some("bash"))
         || (group == DshCapabilityGroup::BlockUnsafeDefaultDelivery
@@ -219,6 +227,87 @@ fn tool_arguments(raw: &[u8]) -> Option<serde_json::Map<String, Value>> {
         .get("arguments")?
         .as_object()
         .cloned()
+}
+
+fn bounded_governed_line(value: &Value, max_bytes: usize) -> bool {
+    value.as_str().is_some_and(|value| {
+        !value.is_empty()
+            && value == value.trim()
+            && !value
+                .bytes()
+                .any(|byte| matches!(byte, b'\0' | b'\n' | b'\r'))
+            && value.len() <= max_bytes
+    })
+}
+
+pub(crate) fn governed_commit_arguments_valid(raw: &[u8]) -> bool {
+    let Some(arguments) = tool_arguments(raw) else {
+        return false;
+    };
+    let expected_keys: &[&str] = if arguments.contains_key("scope") {
+        &["body_bullets", "expected_head", "scope", "subject", "type"]
+    } else {
+        &["body_bullets", "expected_head", "subject", "type"]
+    };
+    if arguments.len() != expected_keys.len()
+        || !expected_keys.iter().all(|key| arguments.contains_key(*key))
+    {
+        return false;
+    }
+    let valid_type = arguments
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|value| {
+            matches!(
+                value,
+                "build"
+                    | "chore"
+                    | "ci"
+                    | "docs"
+                    | "feat"
+                    | "fix"
+                    | "perf"
+                    | "refactor"
+                    | "revert"
+                    | "style"
+                    | "test"
+            )
+        });
+    let valid_scope = arguments.get("scope").is_none_or(|value| {
+        value.as_str().is_some_and(|scope| {
+            !scope.is_empty()
+                && scope.len() <= 49
+                && scope.bytes().enumerate().all(|(index, byte)| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || (index > 0 && matches!(byte, b'.' | b'_' | b'/' | b'-'))
+                })
+        })
+    });
+    let valid_bullets = arguments
+        .get("body_bullets")
+        .and_then(Value::as_array)
+        .is_some_and(|bullets| {
+            !bullets.is_empty()
+                && bullets.len() <= 20
+                && bullets
+                    .iter()
+                    .all(|bullet| bounded_governed_line(bullet, 500))
+        });
+    let valid_head = arguments
+        .get("expected_head")
+        .and_then(Value::as_str)
+        .is_some_and(|head| {
+            matches!(head.len(), 40 | 64)
+                && head
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        });
+    valid_type
+        && valid_scope
+        && bounded_governed_line(arguments.get("subject").unwrap_or(&Value::Null), 100)
+        && valid_bullets
+        && valid_head
 }
 
 fn prompt(raw: &[u8]) -> Option<String> {
@@ -2581,10 +2670,14 @@ fn branch_name_is_default(value: &str, default: &str) -> bool {
 
 fn unsafe_default_native_mutation(
     request: &NormalizedRequest,
+    raw: &[u8],
     effect: OperationEffectClass,
 ) -> Result<bool, HookError> {
     if effect == OperationEffectClass::ReadOnly {
         return Ok(false);
+    }
+    if request.matcher.as_deref() == Some(GOVERNED_COMMIT_TOOL) {
+        return governed_commit_delivery_blocked(request, raw);
     }
     if request.target_paths.is_empty() {
         return Ok(true);
@@ -2610,6 +2703,43 @@ fn unsafe_default_native_mutation(
         }
     }
     Ok(false)
+}
+
+fn governed_commit_delivery_blocked(
+    request: &NormalizedRequest,
+    raw: &[u8],
+) -> Result<bool, HookError> {
+    if !governed_commit_arguments_valid(raw) {
+        return Ok(true);
+    }
+    let Some(state_home) = request
+        .dsh_subject
+        .as_ref()
+        .map(|subject| subject.agent_docs_state_home.as_path())
+    else {
+        return Ok(true);
+    };
+    let Some(execution) = request.execution_path.as_ref() else {
+        return Ok(true);
+    };
+    let Some(layout) = git_layout(execution) else {
+        return Ok(true);
+    };
+    if layout.git_dir == layout.common_dir
+        || !request.binding_roots.iter().any(|root| {
+            git_layout(root).is_some_and(|bound| {
+                bound.root == layout.root
+                    && bound.git_dir == layout.git_dir
+                    && bound.common_dir == layout.common_dir
+            })
+        })
+    {
+        return Ok(true);
+    }
+    let Some(default) = protected_default_branch(&layout, state_home)? else {
+        return Ok(true);
+    };
+    Ok(current_branch(&layout).is_none_or(|current| current == default))
 }
 
 fn target_is_git_metadata(target: &Path, layout: &GitLayout) -> bool {
@@ -2640,7 +2770,23 @@ fn semantic_delivery_blocked(
     base: Option<&Path>,
     state_home: &Path,
 ) -> Result<bool, HookError> {
-    if words.first().map(String::as_str) != Some("semantic-commit") {
+    let Some(program) = words.first().map(String::as_str) else {
+        return Ok(true);
+    };
+    if basename(program) != "semantic-commit" {
+        return Ok(true);
+    }
+    if Path::new(program).components().count() > 1 {
+        let Some(candidate) = fs::canonicalize(program).ok() else {
+            return Ok(true);
+        };
+        let Some(companion) = trusted_sibling("semantic-commit").ok() else {
+            return Ok(true);
+        };
+        if candidate != companion {
+            return Ok(true);
+        }
+    } else if program != "semantic-commit" {
         return Ok(true);
     }
     if semantic_options_ambiguous(words) || message_file_option(words) {
@@ -3289,16 +3435,7 @@ fn protected_default_branch(
     layout: &GitLayout,
     state_home: &Path,
 ) -> Result<Option<String>, HookError> {
-    let observed_remote = default_branch(layout);
-    let Some(observed_primary) = fs::read_to_string(layout.common_dir.join("HEAD"))
-        .ok()
-        .and_then(|value| {
-            value
-                .trim()
-                .strip_prefix("ref: refs/heads/")
-                .map(str::to_string)
-        })
-        .filter(|branch| safe_branch_name(branch))
+    let Some(observed_remote) = default_branch(layout).filter(|branch| safe_branch_name(branch))
     else {
         return Ok(None);
     };
@@ -3335,18 +3472,19 @@ fn protected_default_branch(
             "default-branch repository identity is unavailable",
         )
     })?;
-    let path = directory.join("projection.json");
+    // v1 incorrectly projected the primary checkout's current branch and
+    // required it to equal the remote-advertised default. Keep v2 state
+    // separate so an old, integration-branch projection cannot be treated as
+    // authenticated default-branch evidence after upgrade.
+    let path = directory.join("projection-v2.json");
     if let Some(existing) = read_default_branch_projection(&path)? {
         let identity_matches = existing.common_dir == layout.common_dir.to_string_lossy()
             && existing.common_dev == metadata.dev()
             && existing.common_ino == metadata.ino();
-        if !identity_matches || existing.branch != observed_primary {
+        if !identity_matches || existing.branch != observed_remote {
             return Ok(None);
         }
-        return Ok(
-            (observed_remote.as_deref() == Some(existing.branch.as_str()))
-                .then_some(existing.branch),
-        );
+        return Ok(Some(existing.branch));
     }
 
     let projection = DefaultBranchProjection {
@@ -3354,7 +3492,7 @@ fn protected_default_branch(
         common_dir: layout.common_dir.to_string_lossy().into_owned(),
         common_dev: metadata.dev(),
         common_ino: metadata.ino(),
-        branch: observed_primary.clone(),
+        branch: observed_remote.clone(),
     };
     let bytes = serde_json::to_vec(&projection).map_err(|_| {
         HookError::runtime(
@@ -3368,7 +3506,7 @@ fn protected_default_branch(
             "default-branch projection could not be published",
         )
     })?;
-    Ok((observed_remote.as_deref() == Some(observed_primary.as_str())).then_some(observed_primary))
+    Ok(Some(observed_remote))
 }
 
 fn safe_branch_name(branch: &str) -> bool {

--- a/crates/agent-hook/src/effect.rs
+++ b/crates/agent-hook/src/effect.rs
@@ -43,7 +43,29 @@ pub(crate) fn classify(raw: &[u8], request: &NormalizedRequest) -> OperationEffe
         }
         Some("Read" | "Glob" | "Grep") => OperationEffectClass::ReadOnly,
         Some("Bash" | "bash") => classify_bash(raw, request),
+        Some("runtime_kit_governed_commit") => classify_governed_commit(raw, request),
         _ => OperationEffectClass::Unknown,
+    }
+}
+
+fn classify_governed_commit(raw: &[u8], request: &NormalizedRequest) -> OperationEffectClass {
+    if !crate::dsh_policy::governed_commit_arguments_valid(raw) {
+        return OperationEffectClass::Unknown;
+    }
+    let Some(execution) = request
+        .execution_path
+        .as_ref()
+        .and_then(|path| fs::canonicalize(path).ok())
+    else {
+        return OperationEffectClass::Unknown;
+    };
+    let Some((git_dir, common_dir)) = git_directories(&execution) else {
+        return OperationEffectClass::Unknown;
+    };
+    if git_dir == common_dir {
+        OperationEffectClass::Unknown
+    } else {
+        OperationEffectClass::LocalReversible
     }
 }
 

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -11,6 +11,10 @@ use serde_json::{Value, json};
 use support::{Fixture, now_epoch};
 
 fn policy(group: &str, product: &str) -> String {
+    policy_for_matcher(group, product, "bash")
+}
+
+fn policy_for_matcher(group: &str, product: &str, matcher: &str) -> String {
     format!(
         r#"schema_version = "agent-hook.policy.v1"
 bundle_id = "dsh-runtime-kit-task-3-2"
@@ -20,7 +24,7 @@ version = "2026.08.18.1"
 id = "dsh.task-3-2"
 products = ["{product}"]
 events = ["PreToolUse"]
-matcher = "bash"
+matcher = "{matcher}"
 priority = 10
 mode = "enforce"
 failure_posture = "closed"
@@ -1834,6 +1838,218 @@ fn unsafe_default_delivery_preserves_governed_recovery_and_feature_worktrees() {
     );
     assert_eq!(output.code, 1, "envelope={}", output.stdout_text());
     assert_eq!(output.stdout_json()["data"]["action"], "block");
+}
+
+#[test]
+fn unsafe_default_delivery_accepts_the_absolute_release_semantic_commit_sibling() {
+    let fixture = Fixture::new(&policy("block-unsafe-default-delivery", "dsh"));
+    git(&fixture, &["init", "--quiet", "--initial-branch=main"]);
+    let remote = fixture.root.join(".git/refs/remotes/origin");
+    fs::create_dir_all(&remote).expect("remote refs");
+    fs::write(remote.join("HEAD"), "ref: refs/remotes/origin/main\n").expect("remote HEAD");
+
+    let release = fixture.root.join("release");
+    fs::create_dir(&release).expect("release directory");
+    let agent_hook = release.join("agent-hook");
+    install_release_binary(&agent_hook);
+    let semantic_commit = release.join("semantic-commit");
+    fs::write(&semantic_commit, "#!/bin/sh\nexit 0\n").expect("semantic-commit companion");
+    fs::set_permissions(&semantic_commit, fs::Permissions::from_mode(0o700))
+        .expect("semantic-commit mode");
+
+    let command = format!(
+        "{} default-branch --dry-run --message 'fix: repair' --repo .",
+        shell_words::quote(semantic_commit.to_str().expect("semantic-commit UTF-8")),
+    );
+    let input = request(&fixture, "bash", json!({"command": command}));
+    let allowed = dispatch_with_release_binary(&fixture, &agent_hook, &input);
+    assert_eq!(allowed["data"]["action"], "allow", "envelope={allowed}");
+}
+
+#[test]
+fn unsafe_default_delivery_resolves_remote_default_independently_of_primary_checkout() {
+    for default_branch in ["main", "trunk"] {
+        let fixture = Fixture::new(&policy("block-unsafe-default-delivery", "dsh"));
+        git(
+            &fixture,
+            &["init", "--quiet", "--initial-branch", default_branch],
+        );
+        git(&fixture, &["config", "user.email", "test@example.com"]);
+        git(&fixture, &["config", "user.name", "Test"]);
+        fs::write(fixture.root.join("tracked.txt"), "base\n").expect("tracked file");
+        git(&fixture, &["add", "--all"]);
+        git(&fixture, &["commit", "--quiet", "-m", "test: initial"]);
+        let remote = fixture.root.join(".git/refs/remotes/origin");
+        fs::create_dir_all(&remote).expect("remote refs");
+        fs::write(
+            remote.join("HEAD"),
+            format!("ref: refs/remotes/origin/{default_branch}\n"),
+        )
+        .expect("remote HEAD");
+
+        let feature = fixture
+            .state_home
+            .join(format!("{default_branch}-feature-worktree"));
+        let worktree = Command::new("git")
+            .arg("-C")
+            .arg(&fixture.root)
+            .args(["worktree", "add", "--quiet", "-b", "feature"])
+            .arg(&feature)
+            .output()
+            .expect("feature worktree");
+        assert!(
+            worktree.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&worktree.stderr)
+        );
+        git(&fixture, &["switch", "--quiet", "-c", "integration"]);
+
+        let output = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request_for_path(
+                &fixture,
+                "dsh-session-1",
+                &feature,
+                "bash",
+                json!({
+                    "command": "semantic-commit commit --message 'feat: change\n\nExplain the user-visible contract.'"
+                }),
+            )),
+        );
+        assert_eq!(
+            output.code,
+            0,
+            "default={default_branch} envelope={}",
+            output.stdout_text()
+        );
+        assert_eq!(output.stdout_json()["data"]["action"], "allow");
+    }
+}
+
+#[test]
+fn native_governed_commit_requires_the_exact_linked_worktree_and_pinned_remote_default() {
+    for default_branch in ["main", "trunk"] {
+        let fixture = Fixture::new(&policy_for_matcher(
+            "block-unsafe-default-delivery",
+            "dsh",
+            "runtime_kit_governed_commit",
+        ));
+        git(
+            &fixture,
+            &["init", "--quiet", "--initial-branch", default_branch],
+        );
+        git(&fixture, &["config", "user.email", "test@example.com"]);
+        git(&fixture, &["config", "user.name", "Test"]);
+        fs::write(fixture.root.join("tracked.txt"), "base\n").expect("tracked file");
+        git(&fixture, &["add", "--all"]);
+        git(&fixture, &["commit", "--quiet", "-m", "test: initial"]);
+        let head_output = Command::new("git")
+            .arg("-C")
+            .arg(&fixture.root)
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .expect("resolve HEAD");
+        assert!(head_output.status.success());
+        let head = String::from_utf8(head_output.stdout)
+            .expect("HEAD UTF-8")
+            .trim()
+            .to_string();
+        let remote_head = fixture.root.join(".git/refs/remotes/origin/HEAD");
+        fs::create_dir_all(remote_head.parent().expect("remote directory")).expect("remote refs");
+        fs::write(
+            &remote_head,
+            format!("ref: refs/remotes/origin/{default_branch}\n"),
+        )
+        .expect("remote HEAD");
+
+        let feature = fixture
+            .state_home
+            .join(format!("native-{default_branch}-feature"));
+        let worktree = Command::new("git")
+            .arg("-C")
+            .arg(&fixture.root)
+            .args(["worktree", "add", "--quiet", "-b", "feature"])
+            .arg(&feature)
+            .output()
+            .expect("feature worktree");
+        assert!(
+            worktree.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&worktree.stderr)
+        );
+        git(&fixture, &["switch", "--quiet", "-c", "integration"]);
+
+        let arguments = json!({
+            "type": "feat",
+            "scope": "runtime",
+            "subject": "add native governed commit",
+            "body_bullets": ["Bind the commit to the authenticated session worktree."],
+            "expected_head": head,
+        });
+        let allowed = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request_for_path(
+                &fixture,
+                "dsh-session-1",
+                &feature,
+                "runtime_kit_governed_commit",
+                arguments.clone(),
+            )),
+        );
+        assert_eq!(
+            allowed.code,
+            0,
+            "default={default_branch} envelope={}",
+            allowed.stdout_text()
+        );
+        assert_eq!(allowed.stdout_json()["data"]["action"], "allow");
+
+        let primary_integration = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request(
+                &fixture,
+                "runtime_kit_governed_commit",
+                arguments.clone(),
+            )),
+        );
+        assert_eq!(
+            primary_integration.code,
+            1,
+            "primary integration envelope={}",
+            primary_integration.stdout_text()
+        );
+
+        let retargeted = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request_for_path(
+                &fixture,
+                "dsh-session-1",
+                &feature,
+                "runtime_kit_governed_commit",
+                json!({
+                    "type": "feat",
+                    "subject": "retarget the commit",
+                    "body_bullets": ["This must remain denied."],
+                    "expected_head": head,
+                    "repo": fixture.root,
+                }),
+            )),
+        );
+        assert_eq!(retargeted.code, 1, "envelope={}", retargeted.stdout_text());
+
+        fs::write(&remote_head, "ref: refs/remotes/origin/drifted\n").expect("drift remote HEAD");
+        let drifted = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request_for_path(
+                &fixture,
+                "dsh-session-1",
+                &feature,
+                "runtime_kit_governed_commit",
+                arguments,
+            )),
+        );
+        assert_eq!(drifted.code, 1, "envelope={}", drifted.stdout_text());
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fix the agent-hook delivery classification that conflated a repository's remote-advertised default branch with the branch currently checked out in its primary worktree, and expose the narrow policy contract needed by dsh-runtime-kit to perform one governed commit in the session's exact linked feature worktree.

## Issues

Refs sympoies/dsh-runtime-kit#55

Refs sympoies/dsh-runtime-kit#66

## Changes

- Resolve the remote-advertised default independently of the primary checkout, while failing closed on missing, contradictory, or drifting evidence.
- Validate the exact structured native commit operation, linked worktree, session binding, non-default branch, and trusted semantic-commit executable path.
- Add main/trunk, retargeting, projection-drift, linked-worktree, and release-sibling regression coverage plus contract documentation.

## Test-First Evidence

- Regression first: `unsafe_default_delivery_resolves_remote_default_independently_of_primary_checkout` failed with exit 101 before the fix for both `main` and `trunk` remote defaults when the primary checkout was on an integration branch.
- Added the missing native governed-commit owner regression for the exact linked worktree and pinned remote default.
- The complete v2 evidence record is bound from baseline `8cc86349` to delivery head `5e6bb294` with no residual gaps.

## Test plan

- `agent-run exec --cwd <candidate> -- ./.agents/scripts/pre-pr.sh` — passed docs, tempdir, fmt, clippy with denied warnings, 297 nextest tests, and doctests.
- `npm run verify:policy-source -- <runtime-source> <candidate>` — all 101 runtime policy rows matched.
- `CI=true DSH_SOURCE_ROOT=<pinned-row> npm run test:smoke` — packed signed delivery rehearsal passed on DSH 0.2.0-rc.7, 0.2.0-rc.8, and 0.1.1-rc.2.

## Risk / Notes

- High-impact delivery boundary: default-branch and foreign-worktree mutations remain fail-closed, and the native operation accepts no model-supplied repository routing or arbitrary argv.
- Rollback is to revert this PR before dsh-runtime-kit advances its exact nils-cli release pin; the runtime issue remains gated until release, install/update/rollback acceptance, deployment, and post-deploy smoke all pass.
