### PR TITLE
fix(release): mark delivery PR ready before merge

### DIFF
--- a/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
+++ b/.agents/skills/project-bump-version-tag-release/scripts/project-bump-version-tag-release.sh
@@ -1636,6 +1636,10 @@ PY
   release_pr_head="$(record_release_review_genesis "$release_pr_number")" ||
     die "could not record the release review-loop genesis; branch ${release_branch} left in place for recovery"
 
+  note "marking release PR #${release_pr_number} ready"
+  forge-cli pr ready "$release_pr_number" ||
+    die "release PR #${release_pr_number} could not be marked ready; branch ${release_branch} left in place for recovery"
+
   note "merging release PR #${release_pr_number} at ${release_pr_head}"
   forge-cli pr merge "$release_pr_number" \
     --method squash \

--- a/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
+++ b/.agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh
@@ -1255,7 +1255,9 @@ test_pr_mode_default_opens_pr_and_tags_merge_commit() {
   assert_contains "$log_file" 'review-specialists:bundle'
   assert_contains "$log_file" '--mode delivery'
   assert_contains "$log_file" 'forge-cli:pr review-loop observe 999'
-  assert_precedes "$log_file" 'pr review-loop observe 999' 'pr merge 999'
+  assert_contains "$log_file" 'forge-cli:pr ready 999'
+  assert_precedes "$log_file" 'pr review-loop observe 999' 'pr ready 999'
+  assert_precedes "$log_file" 'pr ready 999' 'pr merge 999'
   # Genesis is validated before it is written: a live observe appends durable
   # provider-visible state, so it is not a probe.
   assert_precedes "$log_file" '--dry-run' 'pr merge 999'


### PR DESCRIPTION
## Summary

Make the repository-owned release workflow promote its checked draft PR to ready after review-loop genesis and before the expected-head merge.

## Problem

- Expected: release delivery owns `deliver → ledger → ready → merge` before tagging.
- Actual: the script skipped `ready`, so GitHub rejected the checked release PR with `draft_merge_refused`.
- Impact: source release, tag, tap, and install verification stopped after a successful PR CI run and required operator recovery.

## Reproduction

1. Run `.agents/scripts/release.sh --version 1.27.7` in PR mode.
2. Let `forge-cli pr deliver --no-merge` finish and the script record review-loop genesis.
3. Observe `forge-cli pr merge` reject the still-draft PR.

## Issues Found

Fixes #1493

Refs sympoies/dsh-runtime-kit#55

## Fix Approach

Call `forge-cli pr ready` after the exact-head review ledger is recorded and before merge. Fail closed and retain the recovery branch if promotion fails. Extend the mock-driven release regression to prove `observe → ready → merge` order.

## Test-First Evidence

- Before the production edit, the new release-order assertion failed because the mock log contained `review-loop observe` followed directly by `pr merge` and no `pr ready`.
- Evidence is bound from `origin/main@99796de0` to candidate `32871706` with no residual gaps.

## Test plan

- `bash .agents/skills/project-bump-version-tag-release/tests/test_bump_version_tag_release.sh` — all release-skill smoke cases passed.
- `agent-run exec --cwd <candidate> -- ./.agents/scripts/pre-pr.sh` — docs/shell/tempdir/fmt/clippy passed; 8,623/8,623 nextest tests and doctests passed.

## Risk / Notes

- The ready transition does not change the PR head, so the existing expected-head CAS remains authoritative.
- Failure to promote stops before merge, tag, or publication and leaves the release branch for recovery.
