### PR TITLE
feat(agent-docs): add transactional DSH prerequisites

### DIFF
--- a/completions/bash/agent-docs
+++ b/completions/bash/agent-docs
@@ -70,11 +70,17 @@ _agent__docs() {
             agent__docs__session,activate)
                 cmd="agent__docs__session__activate"
                 ;;
+            agent__docs__session,commit-prerequisite)
+                cmd="agent__docs__session__commit__prerequisite"
+                ;;
             agent__docs__session,context)
                 cmd="agent__docs__session__context"
                 ;;
             agent__docs__session,prepare)
                 cmd="agent__docs__session__prepare"
+                ;;
+            agent__docs__session,prerequisite)
+                cmd="agent__docs__session__prerequisite"
                 ;;
             agent__docs__session,status)
                 cmd="agent__docs__session__status"
@@ -711,7 +717,7 @@ _agent__docs() {
             return 0
             ;;
         agent__docs__session)
-            opts="-h --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help activate prepare context status verify"
+            opts="-h --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help activate prepare context prerequisite commit-prerequisite status verify"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -768,6 +774,84 @@ _agent__docs() {
                     return 0
                     ;;
                 --phase)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --docs-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --project-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --worktree-fallback)
+                    COMPREPLY=($(compgen -W "auto local-only" -- "${cur}"))
+                    return 0
+                    ;;
+                --integration-fingerprint)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__docs__session__commit__prerequisite)
+            opts="-h --session-id --product --state-home --format --receipt --agent-id --workspace-generation --call-id --turn --step --tool-name --definition-id --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --session-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --product)
+                    COMPREPLY=($(compgen -W "dsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --receipt)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --agent-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --workspace-generation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --call-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --turn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --step)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tool-name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --definition-id)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -884,6 +968,96 @@ _agent__docs() {
                     return 0
                     ;;
                 --phase)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --docs-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --project-path)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --worktree-fallback)
+                    COMPREPLY=($(compgen -W "auto local-only" -- "${cur}"))
+                    return 0
+                    ;;
+                --integration-fingerprint)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__docs__session__prerequisite)
+            opts="-h --session-id --product --state-home --format --intent --phase --request-id --max-bytes --agent-id --workspace-generation --call-id --turn --step --tool-name --definition-id --docs-home --project-path --worktree-fallback --user-config --integration-fingerprint --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --session-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --product)
+                    COMPREPLY=($(compgen -W "dsh" -- "${cur}"))
+                    return 0
+                    ;;
+                --state-home)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --intent)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --phase)
+                    COMPREPLY=($(compgen -W "edit" -- "${cur}"))
+                    return 0
+                    ;;
+                --request-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-bytes)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --agent-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --workspace-generation)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --call-id)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --turn)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --step)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --tool-name)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --definition-id)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_agent-docs
+++ b/completions/zsh/_agent-docs
@@ -322,6 +322,55 @@ _arguments "${_arguments_options[@]}" : \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
 ;;
+(prerequisite)
+_arguments "${_arguments_options[@]}" : \
+'--session-id=[]:ID:_default' \
+'--product=[]:PRODUCT:(dsh)' \
+'--state-home=[]:DIR:_files' \
+'--format=[]:FORMAT:(text json)' \
+'--intent=[]:INTENT:_default' \
+'--phase=[Required prerequisite phase (currently\: edit)]:PHASE:(edit)' \
+'--request-id=[Bounded caller correlation id echoed by the prerequisite decision]:ID:_default' \
+'--max-bytes=[Maximum aggregate UTF-8 bytes of returned policy content (hard cap\: 65536)]:BYTES:_default' \
+'--agent-id=[]:ID:_default' \
+'--workspace-generation=[]:ID:_default' \
+'--call-id=[]:ID:_default' \
+'--turn=[]:NUMBER:_default' \
+'--step=[]:NUMBER:_default' \
+'--tool-name=[]:NAME:_default' \
+'--definition-id=[]:ID:_default' \
+'--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
+'--project-path=[Override the project root path]:PATH:_files' \
+'--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
+'--integration-fingerprint=[Require the current integration decision to match this fingerprint]:SHA256:_default' \
+'--user-config[Select the effective private user catalog for this operation]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(commit-prerequisite)
+_arguments "${_arguments_options[@]}" : \
+'--session-id=[]:ID:_default' \
+'--product=[]:PRODUCT:(dsh)' \
+'--state-home=[]:DIR:_files' \
+'--format=[]:FORMAT:(text json)' \
+'--receipt=[]:RECEIPT:_default' \
+'--agent-id=[]:ID:_default' \
+'--workspace-generation=[]:ID:_default' \
+'--call-id=[]:ID:_default' \
+'--turn=[]:NUMBER:_default' \
+'--step=[]:NUMBER:_default' \
+'--tool-name=[]:NAME:_default' \
+'--definition-id=[]:ID:_default' \
+'--docs-home=[Override the docs-home root (otherwise derived from the install symlink)]:PATH:_files' \
+'--project-path=[Override the project root path]:PATH:_files' \
+'--worktree-fallback=[Project worktree fallback mode]:MODE:(auto local-only)' \
+'--integration-fingerprint=[Require the current integration decision to match this fingerprint]:SHA256:_default' \
+'--user-config[Select the effective private user catalog for this operation]' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
 (status)
 _arguments "${_arguments_options[@]}" : \
 '--session-id=[]:ID:_default' \
@@ -499,6 +548,8 @@ _agent-docs__subcmd__session_commands() {
 'activate:Strictly preflight and atomically activate one or more declared intents' \
 'prepare:Atomically prepare one or more declared intents (activate + strict preflight) and report a stable JSON result usable by a runtime hook' \
 'context:Resolve and prepare exactly one DSH intent, returning only its bounded satisfied required document content as a replay-bound decision' \
+'prerequisite:Resolve one exact DSH prerequisite without activating it' \
+'commit-prerequisite:Commit a previously resolved exact DSH prerequisite' \
 'status:Show active intents for the current session/project/product scope' \
 'verify:Re-resolve the catalog and verify required intents are active and fresh' \
     )
@@ -509,6 +560,11 @@ _agent-docs__subcmd__session__subcmd__activate_commands() {
     local commands; commands=()
     _describe -t commands 'agent-docs session activate commands' commands "$@"
 }
+(( $+functions[_agent-docs__subcmd__session__subcmd__commit-prerequisite_commands] )) ||
+_agent-docs__subcmd__session__subcmd__commit-prerequisite_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-docs session commit-prerequisite commands' commands "$@"
+}
 (( $+functions[_agent-docs__subcmd__session__subcmd__context_commands] )) ||
 _agent-docs__subcmd__session__subcmd__context_commands() {
     local commands; commands=()
@@ -518,6 +574,11 @@ _agent-docs__subcmd__session__subcmd__context_commands() {
 _agent-docs__subcmd__session__subcmd__prepare_commands() {
     local commands; commands=()
     _describe -t commands 'agent-docs session prepare commands' commands "$@"
+}
+(( $+functions[_agent-docs__subcmd__session__subcmd__prerequisite_commands] )) ||
+_agent-docs__subcmd__session__subcmd__prerequisite_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-docs session prerequisite commands' commands "$@"
 }
 (( $+functions[_agent-docs__subcmd__session__subcmd__status_commands] )) ||
 _agent-docs__subcmd__session__subcmd__status_commands() {

--- a/crates/agent-docs/README.md
+++ b/crates/agent-docs/README.md
@@ -162,8 +162,10 @@ the no-phase set rather than erroring — so a phase with no dedicated documents
 still works. A malformed `--phase` value is a usage error (exit `64`).
 
 `--phase` is accepted by `preflight`, `session prepare`, `session context`, and
-`session verify` (one phase per call, "the current phase"; `--intent` stays
-repeatable except for `session context`, which requires exactly one intent).
+`session verify` (one phase per call, "the current phase"). The provider-only
+`session prerequisite` command requires the exact `edit` phase. `--intent`
+stays repeatable except for `session context` and `session prerequisite`, which
+require exactly one intent.
 
 ### `when` grammar
 
@@ -499,6 +501,37 @@ callers that know the current workflow phase should pass it to select the
 no-phase plus matching phase documents. A failed context refresh never mutates
 the prior record; the caller repairs the catalog or increases the requested
 budget within the hard cap, then repeats `session context`.
+
+### Transactional DSH prerequisites
+
+`session prerequisite` is the side-effect-free counterpart used by a DSH
+runtime before policy admission. It requires `--phase edit` and accepts the
+same DSH intent, request, and response-budget fields as `session context`, plus
+exact bounded agent, workspace-generation, call, turn/step, tool, and
+visible-definition identifiers. It uses the verifier's default catalog
+selection: `--user-config`, `--integration-fingerprint`, and
+`--worktree-fallback local-only` are rejected. It returns
+`decision.prerequisite.v1`: `reason = pending` includes a bounded opaque
+receipt, while `already-current` omits the receipt. Neither result writes or
+refreshes a session activation. A full activation still covers ordinary phase
+verification, but the first phase prerequisite conservatively returns
+`pending` and materializes a phase activation so its returned content and reuse
+decision come from one resolved fingerprint.
+
+After DSH waterfall, approval, monotonic guards, cancellation, and definition
+revalidation admit the call, the runtime invokes `session commit-prerequisite`
+with the same execution binding and receipt. Commit re-resolves the catalog
+under the session-record lock and writes only when the receipt fingerprint is
+still current. A changed policy returns `prerequisite-stale`; another session,
+state home, repository, agent, workspace generation, call, turn/step, tool, or
+definition returns `prerequisite-receipt-mismatch`. Abandoned receipts require
+no cleanup because begin creates no pending state. Repeating an exact commit is
+idempotent and returns `already-current`.
+
+These commands are a machine-to-machine provider protocol. The receipt grants
+no authority and contains only hashes plus public intent/phase identifiers;
+the policy hook independently revalidates it. Human and explicit agent flows
+may continue to use `session context`.
 
 ### Phase-scoped preparation
 

--- a/crates/agent-docs/src/cli.rs
+++ b/crates/agent-docs/src/cli.rs
@@ -82,7 +82,7 @@ pub enum Command {
     /// Resolve the typed automatic integration decision for this checkout.
     Integration(IntegrationArgs),
     /// Manage durable selective intent activation scoped to a session, project, and product.
-    Session(SessionArgs),
+    Session(Box<SessionArgs>),
     /// Describe the effect of one exact typed agent-docs invocation.
     #[command(hide = true)]
     OperationEffect(OperationEffectArgs),
@@ -409,6 +409,10 @@ pub enum SessionCommand {
     /// Resolve and prepare exactly one DSH intent, returning only its bounded
     /// satisfied required document content as a replay-bound decision.
     Context(SessionContextArgs),
+    /// Resolve one exact DSH prerequisite without activating it.
+    Prerequisite(SessionPrerequisiteArgs),
+    /// Commit a previously resolved exact DSH prerequisite.
+    CommitPrerequisite(SessionCommitPrerequisiteArgs),
     /// Show active intents for the current session/project/product scope.
     Status(SessionCommonArgs),
     /// Re-resolve the catalog and verify required intents are active and fresh.
@@ -472,6 +476,76 @@ pub struct SessionContextArgs {
         help = "Maximum aggregate UTF-8 bytes of returned policy content (hard cap: 65536)"
     )]
     pub max_bytes: usize,
+}
+
+#[derive(Debug, Args)]
+pub struct SessionPrerequisiteArgs {
+    #[arg(long = "session-id", value_name = "ID")]
+    pub session_id: String,
+    #[arg(long, value_enum)]
+    pub product: ContextProduct,
+    #[arg(long = "state-home", value_name = "DIR")]
+    pub state_home: PathBuf,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+    #[arg(long, value_name = "INTENT", required = true)]
+    pub intent: String,
+    #[arg(
+        long,
+        value_name = "PHASE",
+        value_parser = ["edit"],
+        help = "Required prerequisite phase (currently: edit)"
+    )]
+    pub phase: String,
+    #[arg(
+        long = "request-id",
+        value_name = "ID",
+        help = "Bounded caller correlation id echoed by the prerequisite decision"
+    )]
+    pub request_id: String,
+    #[arg(
+        long = "max-bytes",
+        value_name = "BYTES",
+        default_value_t = 20 * 1024,
+        help = "Maximum aggregate UTF-8 bytes of returned policy content (hard cap: 65536)"
+    )]
+    pub max_bytes: usize,
+    #[command(flatten)]
+    pub binding: SessionPrerequisiteBindingArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct SessionCommitPrerequisiteArgs {
+    #[arg(long = "session-id", value_name = "ID")]
+    pub session_id: String,
+    #[arg(long, value_enum)]
+    pub product: ContextProduct,
+    #[arg(long = "state-home", value_name = "DIR")]
+    pub state_home: PathBuf,
+    #[arg(long, value_enum, default_value_t = OutputFormat::Text)]
+    pub format: OutputFormat,
+    #[arg(long, value_name = "RECEIPT")]
+    pub receipt: String,
+    #[command(flatten)]
+    pub binding: SessionPrerequisiteBindingArgs,
+}
+
+#[derive(Debug, Args)]
+pub struct SessionPrerequisiteBindingArgs {
+    #[arg(long = "agent-id", value_name = "ID")]
+    pub agent_id: String,
+    #[arg(long = "workspace-generation", value_name = "ID")]
+    pub workspace_generation: String,
+    #[arg(long = "call-id", value_name = "ID")]
+    pub call_id: String,
+    #[arg(long, value_name = "NUMBER")]
+    pub turn: u64,
+    #[arg(long, value_name = "NUMBER")]
+    pub step: u64,
+    #[arg(long = "tool-name", value_name = "NAME")]
+    pub tool_name: String,
+    #[arg(long = "definition-id", value_name = "ID")]
+    pub definition_id: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/crates/agent-docs/src/dsh.rs
+++ b/crates/agent-docs/src/dsh.rs
@@ -44,6 +44,50 @@ pub fn session_intent_is_current(
     )
 }
 
+/// Exact DSH execution fields bound into a side-effect-free prerequisite
+/// receipt. Callers must source these from the harness runtime, never from
+/// model-authored tool arguments.
+#[derive(Clone, Copy, Debug)]
+pub struct PrerequisiteBinding<'a> {
+    pub receipt: &'a str,
+    pub agent_id: &'a str,
+    pub workspace_generation: &'a str,
+    pub call_id: &'a str,
+    pub turn: u64,
+    pub step: u64,
+    pub tool_name: &'a str,
+    pub definition_id: &'a str,
+}
+
+/// Verify a pending prerequisite receipt against the current catalog and one
+/// exact DSH execution without creating or refreshing activation state.
+pub fn prerequisite_receipt_is_current(
+    roots: &ResolvedRoots,
+    session_id: &str,
+    state_home: &Path,
+    intent: &Context,
+    phase: Option<&Phase>,
+    fallback: FallbackMode,
+    binding: PrerequisiteBinding<'_>,
+) -> bool {
+    crate::session::dsh_prerequisite_receipt_is_current(
+        roots,
+        session_id,
+        state_home,
+        intent,
+        phase,
+        fallback,
+        binding.receipt,
+        binding.agent_id,
+        binding.workspace_generation,
+        binding.call_id,
+        binding.turn,
+        binding.step,
+        binding.tool_name,
+        binding.definition_id,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/crates/agent-docs/src/lib.rs
+++ b/crates/agent-docs/src/lib.rs
@@ -422,7 +422,7 @@ fn dispatch(cli: Cli, output_format: nils_common::cli_contract::OutputFormat) ->
         Command::Config(args) => user_config::run(args, &overrides),
         Command::Integration(args) => integration::run(args, &overrides, fallback_mode),
         Command::Session(args) => session::run(
-            args,
+            *args,
             overrides,
             fallback_mode,
             use_user_config,

--- a/crates/agent-docs/src/operation_effect.rs
+++ b/crates/agent-docs/src/operation_effect.rs
@@ -108,6 +108,18 @@ fn classify(command: &Command) -> (&'static str, Effect, ProviderEffect, Vec<&'s
                 ProviderEffect::None,
                 Vec::new(),
             ),
+            SessionCommand::Prerequisite(_) => (
+                "session.prerequisite",
+                read,
+                local,
+                vec!["session_state", "catalog", "filesystem"],
+            ),
+            SessionCommand::CommitPrerequisite(_) => (
+                "session.commit-prerequisite",
+                mutation,
+                ProviderEffect::None,
+                Vec::new(),
+            ),
         },
         Command::Config(args) => match args.command {
             ConfigCommand::Show(_) => ("config.show", read, local, vec!["user_config"]),
@@ -229,6 +241,41 @@ mod tests {
         assert_eq!(effect, Effect::ReadOnly);
         assert_eq!(reads, vec!["session_state", "catalog", "filesystem"]);
 
+        let (name, effect, provider, reads) = classify_argv(&[
+            "session",
+            "prerequisite",
+            "--session-id",
+            "s1",
+            "--product",
+            "dsh",
+            "--state-home",
+            "/tmp/state",
+            "--intent",
+            "project-dev",
+            "--phase",
+            "edit",
+            "--request-id",
+            "request-1",
+            "--agent-id",
+            "agent-1",
+            "--workspace-generation",
+            "generation-1",
+            "--call-id",
+            "call-1",
+            "--turn",
+            "1",
+            "--step",
+            "1",
+            "--tool-name",
+            "write",
+            "--definition-id",
+            "definition-1",
+        ]);
+        assert_eq!(name, "session.prerequisite");
+        assert_eq!(effect, Effect::ReadOnly);
+        assert_eq!(provider, ProviderEffect::LocalRead);
+        assert_eq!(reads, vec!["session_state", "catalog", "filesystem"]);
+
         // A mutation declares no managed-state reads and no provider effect.
         for (subcommand, expected) in [
             ("activate", "session.activate"),
@@ -251,6 +298,37 @@ mod tests {
             assert_eq!(provider, ProviderEffect::None);
             assert!(reads.is_empty());
         }
+
+        let (name, effect, provider, reads) = classify_argv(&[
+            "session",
+            "commit-prerequisite",
+            "--session-id",
+            "s1",
+            "--product",
+            "dsh",
+            "--state-home",
+            "/tmp/state",
+            "--receipt",
+            "receipt-1",
+            "--agent-id",
+            "agent-1",
+            "--workspace-generation",
+            "generation-1",
+            "--call-id",
+            "call-1",
+            "--turn",
+            "1",
+            "--step",
+            "1",
+            "--tool-name",
+            "write",
+            "--definition-id",
+            "definition-1",
+        ]);
+        assert_eq!(name, "session.commit-prerequisite");
+        assert_eq!(effect, Effect::Mutation);
+        assert_eq!(provider, ProviderEffect::None);
+        assert!(reads.is_empty());
     }
 
     #[test]

--- a/crates/agent-docs/src/session.rs
+++ b/crates/agent-docs/src/session.rs
@@ -11,7 +11,8 @@ use sha2::{Digest, Sha256};
 use nils_common::cli_contract::{Envelope, EnvelopeError};
 
 use crate::cli::{
-    SessionActivateArgs, SessionArgs, SessionCommand, SessionCommonArgs, SessionContextArgs,
+    SessionActivateArgs, SessionArgs, SessionCommand, SessionCommitPrerequisiteArgs,
+    SessionCommonArgs, SessionContextArgs, SessionPrerequisiteArgs, SessionPrerequisiteBindingArgs,
     SessionVerifyArgs,
 };
 use crate::config::{load_catalog_from_roots, load_dsh_catalog_from_roots};
@@ -41,6 +42,10 @@ const MAX_CONTEXT_REQUEST_ID_BYTES: usize = 128;
 const MAX_CONTEXT_BYTES: usize = 64 * 1024;
 const CONTEXT_DECISION_SCHEMA: &str = "decision.context.v1";
 const CONTEXT_FINGERPRINT_PREFIX: &str = "dsh-context-v1:";
+const PREREQUISITE_DECISION_SCHEMA: &str = "decision.prerequisite.v1";
+const PREREQUISITE_RECEIPT_SCHEMA: &str = "agent-docs.prerequisite-receipt.v1";
+const MAX_PREREQUISITE_BINDING_BYTES: usize = 256;
+const MAX_PREREQUISITE_RECEIPT_BYTES: usize = 4096;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct SessionRecord {
@@ -116,6 +121,59 @@ struct ContextDocument {
     content: String,
 }
 
+#[derive(Debug, Serialize)]
+struct PrerequisiteData {
+    decision: PrerequisiteDecision,
+}
+
+#[derive(Debug, Serialize)]
+struct PrerequisiteDecision {
+    schema_version: &'static str,
+    request_id: String,
+    product: &'static str,
+    intent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    reason: &'static str,
+    verified: bool,
+    documents: Vec<ContextDocument>,
+    document_count: usize,
+    total_bytes: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    receipt: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct PrerequisiteCommitData {
+    product: &'static str,
+    intent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    reason: &'static str,
+    verified: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PrerequisiteReceipt {
+    schema_version: String,
+    session_hash: String,
+    state_home_hash: String,
+    project_hash: String,
+    product: String,
+    intent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    agent_hash: String,
+    workspace_generation_hash: String,
+    call_hash: String,
+    turn: u64,
+    step: u64,
+    tool_hash: String,
+    definition_hash: String,
+    context_fingerprint: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 enum NextAction {
@@ -162,6 +220,8 @@ enum RecoveryCommand {
     SessionPrepare,
     #[serde(rename = "session.context")]
     SessionContext,
+    #[serde(rename = "session.prerequisite")]
+    SessionPrerequisite,
     #[serde(rename = "session.status")]
     SessionStatus,
 }
@@ -358,6 +418,20 @@ pub fn run(
             use_user_config,
             expected_integration_fingerprint.as_deref(),
         ),
+        SessionCommand::Prerequisite(args) => prerequisite(
+            args,
+            overrides,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint.as_deref(),
+        ),
+        SessionCommand::CommitPrerequisite(args) => commit_prerequisite(
+            args,
+            overrides,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint.as_deref(),
+        ),
         SessionCommand::Status(args) => status(
             args,
             overrides,
@@ -536,6 +610,308 @@ fn context(
         })
     })();
     render_context(args.format, result)
+}
+
+/// Resolve one exact DSH prerequisite without mutating activation state. The
+/// returned receipt is a bounded, replay-bound compare-and-swap input; it is
+/// useful only with the same execution binding and current policy fingerprint.
+fn prerequisite(
+    args: SessionPrerequisiteArgs,
+    overrides: PathOverrides,
+    fallback: FallbackMode,
+    use_user_config: bool,
+    expected_integration_fingerprint: Option<&str>,
+) -> i32 {
+    let SessionPrerequisiteArgs {
+        session_id,
+        product,
+        state_home,
+        format,
+        intent,
+        phase,
+        request_id,
+        max_bytes,
+        binding,
+    } = args;
+    let context = SessionContextArgs {
+        session_id,
+        product,
+        state_home,
+        format,
+        intent,
+        phase: Some(phase),
+        request_id,
+        max_bytes,
+    };
+    let result = (|| -> Result<PrerequisiteData, SessionFailure> {
+        validate_prerequisite_selection(
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint,
+        )?;
+        validate_session_scope(&context.session_id, &context.state_home)?;
+        validate_context_args(&context)?;
+        validate_prerequisite_binding(&binding)?;
+        let phase = parse_phase_arg(context.phase.as_deref())?;
+        let roots = resolve_session_roots(&overrides)?;
+        let path = record_path_for(
+            &context.session_id,
+            &context.state_home,
+            context.product.as_str(),
+            &roots.project_path,
+        )?;
+        let existing = if path.exists() {
+            match decode_record(&path)? {
+                DecodedRecord::Current(record) => {
+                    validate_record_identity(
+                        &context.session_id,
+                        context.product.as_str(),
+                        &roots.project_path,
+                        &record,
+                    )?;
+                    Some(*record)
+                }
+                DecodedRecord::LegacyV1 => None,
+            }
+        } else {
+            None
+        };
+        let (catalog, integration_fingerprint) = load_dsh_session_catalog(
+            &roots,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint,
+        )
+        .map_err(|failure| failure.for_dsh_context(&context.intent, phase.as_ref()))?;
+        let available = resolver::declared_intents(&roots, fallback, &catalog.catalog);
+        let intent = Context::parse(&context.intent).map_err(|err| {
+            SessionFailure::data("invalid-intent", err).with_available_intents(&available)
+        })?;
+        if !available.iter().any(|item| item == intent.as_str()) {
+            return Err(SessionFailure::data(
+                "undeclared-intent",
+                format!("intent `{intent}` is not declared"),
+            )
+            .with_available_intents(&available)
+            .for_dsh_context(intent.as_str(), phase.as_ref()));
+        }
+        let report = resolver::resolve_dsh_context_with_effective_catalog_for_scope(
+            &intent,
+            &roots,
+            phase.clone(),
+            true,
+            fallback,
+            context.max_bytes,
+            &catalog,
+        )
+        .map_err(context_resolve_failure)?;
+        if report.has_unsatisfied_required() {
+            return Err(SessionFailure::data(
+                unsatisfied_code(phase.as_ref()),
+                format!("strict preflight failed for `{intent}`"),
+            )
+            .with_preflight_context(&intent, phase.as_ref(), &report)
+            .for_dsh_context(intent.as_str(), phase.as_ref()));
+        }
+        let (documents, total_bytes) = context_documents(&report, context.max_bytes)?;
+        let fingerprint = context_fingerprint(
+            &report,
+            &catalog,
+            fallback,
+            integration_fingerprint.as_deref(),
+        )?;
+        let already_current = existing.as_ref().is_some_and(|record| {
+            record.integration_fingerprint == integration_fingerprint
+                && exact_context_activation_is_current(
+                    &intent,
+                    phase.as_ref(),
+                    record,
+                    &fingerprint,
+                )
+        });
+        // Every call gets an execution-bound receipt, including reuse. A
+        // prerequisite can wait behind downstream approval after this read;
+        // commit-prerequisite must therefore re-resolve the policy immediately
+        // before execution instead of trusting an earlier activation alone.
+        let receipt = Some(encode_prerequisite_receipt(PrerequisiteReceipt {
+            schema_version: PREREQUISITE_RECEIPT_SCHEMA.to_string(),
+            session_hash: digest(context.session_id.trim().as_bytes()),
+            state_home_hash: digest(context.state_home.to_string_lossy().as_bytes()),
+            project_hash: project_hash(&roots.project_path),
+            product: context.product.as_str().to_string(),
+            intent: intent.to_string(),
+            phase: phase.as_ref().map(ToString::to_string),
+            agent_hash: digest(binding.agent_id.as_bytes()),
+            workspace_generation_hash: digest(binding.workspace_generation.as_bytes()),
+            call_hash: digest(binding.call_id.as_bytes()),
+            turn: binding.turn,
+            step: binding.step,
+            tool_hash: digest(binding.tool_name.as_bytes()),
+            definition_hash: digest(binding.definition_id.as_bytes()),
+            context_fingerprint: fingerprint,
+        })?);
+        let document_count = documents.len();
+        Ok(PrerequisiteData {
+            decision: PrerequisiteDecision {
+                schema_version: PREREQUISITE_DECISION_SCHEMA,
+                request_id: context.request_id.clone(),
+                product: context.product.as_str(),
+                intent: intent.to_string(),
+                phase: phase.as_ref().map(ToString::to_string),
+                reason: if already_current {
+                    "already-current"
+                } else {
+                    "pending"
+                },
+                verified: true,
+                documents,
+                document_count,
+                total_bytes,
+                receipt,
+            },
+        })
+    })();
+    render_prerequisite(format, result)
+}
+
+/// Commit an exact prerequisite receipt only if its execution binding and
+/// freshly resolved policy fingerprint still match.
+fn commit_prerequisite(
+    args: SessionCommitPrerequisiteArgs,
+    overrides: PathOverrides,
+    fallback: FallbackMode,
+    use_user_config: bool,
+    expected_integration_fingerprint: Option<&str>,
+) -> i32 {
+    let result = (|| -> Result<PrerequisiteCommitData, SessionFailure> {
+        validate_prerequisite_selection(
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint,
+        )?;
+        validate_session_scope(&args.session_id, &args.state_home)?;
+        validate_prerequisite_binding(&args.binding)?;
+        let receipt = decode_prerequisite_receipt(&args.receipt)?;
+        let roots = resolve_session_roots(&overrides)?;
+        validate_prerequisite_receipt_scope(
+            &receipt,
+            &args.session_id,
+            &args.state_home,
+            args.product.as_str(),
+            &roots.project_path,
+            &args.binding,
+        )?;
+        let intent =
+            Context::parse(&receipt.intent).map_err(|_| prerequisite_receipt_mismatch())?;
+        let phase = parse_phase_arg(receipt.phase.as_deref())
+            .map_err(|_| prerequisite_receipt_mismatch())?;
+        let path = record_path_for(
+            &args.session_id,
+            &args.state_home,
+            args.product.as_str(),
+            &roots.project_path,
+        )?;
+        let _lock = RecordLock::acquire(&path)?;
+        let (catalog, integration_fingerprint) = load_dsh_session_catalog(
+            &roots,
+            fallback,
+            use_user_config,
+            expected_integration_fingerprint,
+        )?;
+        let available = resolver::declared_intents(&roots, fallback, &catalog.catalog);
+        if !available.iter().any(|item| item == intent.as_str()) {
+            return Err(SessionFailure::data(
+                "prerequisite-stale",
+                "the prerequisite intent is no longer declared",
+            )
+            .with_prepare_intent(&intent, phase.as_ref()));
+        }
+        let report = resolver::resolve_dsh_context_with_effective_catalog_for_scope(
+            &intent,
+            &roots,
+            phase.clone(),
+            true,
+            fallback,
+            MAX_CONTEXT_BYTES,
+            &catalog,
+        )
+        .map_err(|_| {
+            SessionFailure::data(
+                "prerequisite-stale",
+                "the prerequisite policy can no longer be resolved",
+            )
+            .with_prepare_intent(&intent, phase.as_ref())
+        })?;
+        if report.has_unsatisfied_required() {
+            return Err(SessionFailure::data(
+                "prerequisite-stale",
+                "the prerequisite policy is no longer satisfied",
+            )
+            .with_prepare_intent(&intent, phase.as_ref()));
+        }
+        let current_fingerprint = context_fingerprint(
+            &report,
+            &catalog,
+            fallback,
+            integration_fingerprint.as_deref(),
+        )?;
+        if receipt.context_fingerprint != current_fingerprint {
+            return Err(SessionFailure::data(
+                "prerequisite-stale",
+                "the prerequisite policy changed before commit",
+            )
+            .with_prepare_intent(&intent, phase.as_ref()));
+        }
+
+        let existing = if path.exists() {
+            match decode_record(&path)? {
+                DecodedRecord::Current(record) => {
+                    validate_record_identity(
+                        &args.session_id,
+                        args.product.as_str(),
+                        &roots.project_path,
+                        &record,
+                    )?;
+                    Some(*record)
+                }
+                DecodedRecord::LegacyV1 => None,
+            }
+        } else {
+            None
+        };
+        let had_existing = existing.is_some();
+        let mut record = existing.unwrap_or_else(|| {
+            new_record_for(
+                &args.session_id,
+                args.product.as_str(),
+                &roots.project_path,
+                integration_fingerprint.clone(),
+            )
+        });
+        let mut changed = !had_existing;
+        if record.integration_fingerprint != integration_fingerprint {
+            record.active_intents.clear();
+            record.active_phase_intents.clear();
+            record.integration_fingerprint = integration_fingerprint;
+            changed = true;
+        }
+        changed |= store_activation(&mut record, &intent, phase.as_ref(), current_fingerprint);
+        let reason = if changed {
+            record.activated_at = jiff::Timestamp::now().to_string();
+            write_record(&path, &record)?;
+            "prepared"
+        } else {
+            "already-current"
+        };
+        Ok(PrerequisiteCommitData {
+            product: args.product.as_str(),
+            intent: intent.to_string(),
+            phase: phase.as_ref().map(ToString::to_string),
+            reason,
+            verified: true,
+        })
+    })();
+    render_prerequisite_commit(args.format, result)
 }
 
 fn activate(
@@ -974,6 +1350,78 @@ pub(crate) fn dsh_session_intent_is_current(
     .unwrap_or(false)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn dsh_prerequisite_receipt_is_current(
+    roots: &ResolvedRoots,
+    session_id: &str,
+    state_home: &Path,
+    intent: &Context,
+    phase: Option<&Phase>,
+    fallback: FallbackMode,
+    receipt_raw: &str,
+    agent_id: &str,
+    workspace_generation: &str,
+    call_id: &str,
+    turn: u64,
+    step: u64,
+    tool_name: &str,
+    definition_id: &str,
+) -> bool {
+    (|| -> Result<bool, SessionFailure> {
+        validate_session_scope(session_id, state_home)?;
+        let binding = SessionPrerequisiteBindingArgs {
+            agent_id: agent_id.to_string(),
+            workspace_generation: workspace_generation.to_string(),
+            call_id: call_id.to_string(),
+            turn,
+            step,
+            tool_name: tool_name.to_string(),
+            definition_id: definition_id.to_string(),
+        };
+        validate_prerequisite_binding(&binding)?;
+        let receipt = decode_prerequisite_receipt(receipt_raw)?;
+        validate_prerequisite_receipt_scope(
+            &receipt,
+            session_id,
+            state_home,
+            "dsh",
+            &roots.project_path,
+            &binding,
+        )?;
+        if receipt.intent != intent.as_str() || receipt.phase.as_deref() != phase.map(Phase::as_str)
+        {
+            return Ok(false);
+        }
+        let (catalog, integration_fingerprint) =
+            load_dsh_session_catalog(roots, fallback, false, None)?;
+        let available = resolver::declared_intents(roots, fallback, &catalog.catalog);
+        if !available.iter().any(|item| item == intent.as_str()) {
+            return Ok(false);
+        }
+        let report = resolver::resolve_dsh_context_with_effective_catalog_for_scope(
+            intent,
+            roots,
+            phase.cloned(),
+            true,
+            fallback,
+            MAX_CONTEXT_BYTES,
+            &catalog,
+        )
+        .map_err(verification_context_failure)?;
+        if report.has_unsatisfied_required() {
+            return Ok(false);
+        }
+        Ok(receipt.context_fingerprint
+            == context_fingerprint(
+                &report,
+                &catalog,
+                fallback,
+                integration_fingerprint.as_deref(),
+            )?)
+    })()
+    .unwrap_or(false)
+}
+
 fn dsh_verify_intent(
     intent: &Context,
     phase: Option<&Phase>,
@@ -1011,6 +1459,30 @@ fn dsh_verify_intent(
     match record.active_intents.get(intent.as_str()) {
         Some(stored) => matches(stored, None),
         None => Ok(false),
+    }
+}
+
+/// Decide prerequisite reuse from the exact report fingerprint already
+/// returned to the caller. A full activation still covers phase verification,
+/// but it cannot prove that separately returned phase-scoped content came from
+/// the same filesystem snapshot. The first phase prerequisite therefore
+/// materializes its own phase activation and later calls reuse it directly.
+fn exact_context_activation_is_current(
+    intent: &Context,
+    phase: Option<&Phase>,
+    record: &SessionRecord,
+    fingerprint: &str,
+) -> bool {
+    match phase {
+        Some(phase) => record
+            .active_phase_intents
+            .get(intent.as_str())
+            .and_then(|phases| phases.get(phase.as_str()))
+            .is_some_and(|stored| stored == fingerprint),
+        None => record
+            .active_intents
+            .get(intent.as_str())
+            .is_some_and(|stored| stored == fingerprint),
     }
 }
 
@@ -1169,6 +1641,150 @@ fn context_resolve_failure(error: resolver::ContextResolveError) -> SessionFailu
     SessionFailure::data(error.code(), error.message())
 }
 
+fn context_documents(
+    report: &PreflightReport,
+    max_bytes: usize,
+) -> Result<(Vec<ContextDocument>, usize), SessionFailure> {
+    let mut total_bytes = 0usize;
+    let mut documents = Vec::with_capacity(report.summary.satisfied_required);
+    for document in report
+        .documents
+        .iter()
+        .filter(|document| document.required && document.satisfied())
+    {
+        let content = document.content.clone().ok_or_else(|| {
+            SessionFailure::runtime(
+                "context-content-missing",
+                "a satisfied required document omitted its content",
+            )
+        })?;
+        total_bytes = total_bytes.checked_add(content.len()).ok_or_else(|| {
+            SessionFailure::data(
+                "context-budget-exceeded",
+                "required policy content exceeds the requested response budget",
+            )
+        })?;
+        if total_bytes > max_bytes {
+            return Err(SessionFailure::data(
+                "context-budget-exceeded",
+                "required policy content exceeds the requested response budget",
+            ));
+        }
+        documents.push(ContextDocument {
+            source: document.source.as_str(),
+            scope: document.scope.as_str(),
+            content,
+        });
+    }
+    Ok((documents, total_bytes))
+}
+
+fn encode_prerequisite_receipt(receipt: PrerequisiteReceipt) -> Result<String, SessionFailure> {
+    let encoded = serde_json::to_string(&receipt).map_err(|_| {
+        SessionFailure::runtime(
+            "prerequisite-receipt-render-failed",
+            "the prerequisite receipt could not be serialized",
+        )
+    })?;
+    if encoded.len() > MAX_PREREQUISITE_RECEIPT_BYTES {
+        return Err(SessionFailure::runtime(
+            "prerequisite-receipt-render-failed",
+            "the prerequisite receipt exceeded its bounded contract",
+        ));
+    }
+    Ok(encoded)
+}
+
+fn decode_prerequisite_receipt(raw: &str) -> Result<PrerequisiteReceipt, SessionFailure> {
+    if raw.is_empty() || raw.len() > MAX_PREREQUISITE_RECEIPT_BYTES {
+        return Err(SessionFailure::data(
+            "prerequisite-receipt-invalid",
+            "the prerequisite receipt is missing or oversized",
+        ));
+    }
+    let receipt: PrerequisiteReceipt = serde_json::from_str(raw).map_err(|_| {
+        SessionFailure::data(
+            "prerequisite-receipt-invalid",
+            "the prerequisite receipt is malformed",
+        )
+    })?;
+    let digests = [
+        receipt.session_hash.as_str(),
+        receipt.state_home_hash.as_str(),
+        receipt.project_hash.as_str(),
+        receipt.agent_hash.as_str(),
+        receipt.workspace_generation_hash.as_str(),
+        receipt.call_hash.as_str(),
+        receipt.tool_hash.as_str(),
+        receipt.definition_hash.as_str(),
+    ];
+    if receipt.schema_version != PREREQUISITE_RECEIPT_SCHEMA
+        || receipt.product != "dsh"
+        || Context::parse(&receipt.intent).is_err()
+        || receipt
+            .phase
+            .as_deref()
+            .is_some_and(|phase| Phase::parse(phase).is_err())
+        || receipt.turn == 0
+        || receipt.step == 0
+        || !digests.into_iter().all(valid_sha256_digest)
+        || !receipt
+            .context_fingerprint
+            .starts_with(CONTEXT_FINGERPRINT_PREFIX)
+        || !valid_sha256_digest(
+            receipt
+                .context_fingerprint
+                .strip_prefix(CONTEXT_FINGERPRINT_PREFIX)
+                .unwrap_or_default(),
+        )
+    {
+        return Err(SessionFailure::data(
+            "prerequisite-receipt-invalid",
+            "the prerequisite receipt fields are invalid",
+        ));
+    }
+    Ok(receipt)
+}
+
+fn valid_sha256_digest(value: &str) -> bool {
+    value.len() == 71
+        && value.starts_with("sha256:")
+        && value[7..].bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_prerequisite_receipt_scope(
+    receipt: &PrerequisiteReceipt,
+    session_id: &str,
+    state_home: &Path,
+    product: &str,
+    project: &Path,
+    binding: &SessionPrerequisiteBindingArgs,
+) -> Result<(), SessionFailure> {
+    let matches = receipt.session_hash == digest(session_id.trim().as_bytes())
+        && receipt.state_home_hash == digest(state_home.to_string_lossy().as_bytes())
+        && receipt.project_hash == project_hash(project)
+        && receipt.product == product
+        && receipt.agent_hash == digest(binding.agent_id.as_bytes())
+        && receipt.workspace_generation_hash == digest(binding.workspace_generation.as_bytes())
+        && receipt.call_hash == digest(binding.call_id.as_bytes())
+        && receipt.turn == binding.turn
+        && receipt.step == binding.step
+        && receipt.tool_hash == digest(binding.tool_name.as_bytes())
+        && receipt.definition_hash == digest(binding.definition_id.as_bytes());
+    if matches {
+        Ok(())
+    } else {
+        Err(prerequisite_receipt_mismatch())
+    }
+}
+
+fn prerequisite_receipt_mismatch() -> SessionFailure {
+    SessionFailure::data(
+        "prerequisite-receipt-mismatch",
+        "the prerequisite receipt belongs to a different execution scope",
+    )
+}
+
 fn verification_context_failure(_error: resolver::ContextResolveError) -> SessionFailure {
     SessionFailure::data(
         "context-policy-invalid",
@@ -1292,6 +1908,51 @@ fn validate_context_args(args: &SessionContextArgs) -> Result<(), SessionFailure
         ));
     }
     Ok(())
+}
+
+fn validate_prerequisite_binding(
+    binding: &SessionPrerequisiteBindingArgs,
+) -> Result<(), SessionFailure> {
+    let valid = [
+        binding.agent_id.as_str(),
+        binding.workspace_generation.as_str(),
+        binding.call_id.as_str(),
+        binding.tool_name.as_str(),
+        binding.definition_id.as_str(),
+    ]
+    .into_iter()
+    .all(|value| {
+        !value.is_empty()
+            && value.len() <= MAX_PREREQUISITE_BINDING_BYTES
+            && !value.bytes().any(|byte| byte.is_ascii_control())
+    }) && binding.turn > 0
+        && binding.step > 0;
+    if valid {
+        Ok(())
+    } else {
+        Err(SessionFailure::data(
+            "invalid-prerequisite-binding",
+            "the prerequisite execution binding is invalid",
+        ))
+    }
+}
+
+fn validate_prerequisite_selection(
+    fallback: FallbackMode,
+    use_user_config: bool,
+    expected_integration_fingerprint: Option<&str>,
+) -> Result<(), SessionFailure> {
+    if fallback == FallbackMode::Auto
+        && !use_user_config
+        && expected_integration_fingerprint.is_none()
+    {
+        Ok(())
+    } else {
+        Err(SessionFailure::data(
+            "unsupported-prerequisite-selection",
+            "prerequisites require the verifier's default catalog selection",
+        ))
+    }
 }
 
 fn validate_record_context(
@@ -1682,6 +2343,95 @@ fn render_context(format: OutputFormat, result: Result<ContextData, SessionFailu
     }
 }
 
+fn render_prerequisite(
+    format: OutputFormat,
+    result: Result<PrerequisiteData, SessionFailure>,
+) -> i32 {
+    const SCHEMA: &str = "cli.agent-docs.session.prerequisite.v1";
+    match result {
+        Ok(data) => {
+            if format == OutputFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "schema_version": SCHEMA,
+                        "ok": true,
+                        "data": data,
+                    }))
+                    .expect("session prerequisite output serializes")
+                );
+            } else {
+                println!(
+                    "agent-docs session prerequisite: product={} intent={} reason={} verified={}",
+                    data.decision.product,
+                    data.decision.intent,
+                    data.decision.reason,
+                    data.decision.verified
+                );
+            }
+            EXIT_OK
+        }
+        Err(failure) => render_prerequisite_failure(SCHEMA, "prerequisite", format, failure),
+    }
+}
+
+fn render_prerequisite_commit(
+    format: OutputFormat,
+    result: Result<PrerequisiteCommitData, SessionFailure>,
+) -> i32 {
+    const SCHEMA: &str = "cli.agent-docs.session.commit-prerequisite.v1";
+    match result {
+        Ok(data) => {
+            if format == OutputFormat::Json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&json!({
+                        "schema_version": SCHEMA,
+                        "ok": true,
+                        "data": data,
+                    }))
+                    .expect("session prerequisite commit output serializes")
+                );
+            } else {
+                println!(
+                    "agent-docs session commit-prerequisite: product={} intent={} reason={} verified={}",
+                    data.product, data.intent, data.reason, data.verified
+                );
+            }
+            EXIT_OK
+        }
+        Err(failure) => render_prerequisite_failure(SCHEMA, "commit-prerequisite", format, failure),
+    }
+}
+
+fn render_prerequisite_failure(
+    schema: &'static str,
+    command: &'static str,
+    format: OutputFormat,
+    failure: SessionFailure,
+) -> i32 {
+    if format == OutputFormat::Json {
+        let details =
+            serde_json::to_value(&failure.details).expect("session failure details serialize");
+        let mut error = EnvelopeError::new(failure.code, &failure.message).with_details(details);
+        if let Some(hint) = &failure.hint {
+            error = error.with_hint(hint);
+        }
+        let envelope: Envelope<serde_json::Value> = Envelope::failure(schema, error);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&envelope).expect("session error serializes")
+        );
+    } else {
+        eprintln!(
+            "agent-docs session {command}: {}; next action: {}",
+            failure.message,
+            failure.details.next_action.as_str()
+        );
+    }
+    failure.exit_code
+}
+
 struct SessionFailure {
     code: &'static str,
     message: String,
@@ -1806,6 +2556,10 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
         | "invalid-product"
         | "invalid-request-id"
         | "invalid-max-bytes"
+        | "invalid-prerequisite-binding"
+        | "unsupported-prerequisite-selection"
+        | "prerequisite-receipt-invalid"
+        | "prerequisite-receipt-mismatch"
         | "context-budget-exceeded"
         | "root-resolution-failed" => (
             false,
@@ -1827,6 +2581,21 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
             NextAction::PrepareIntent,
             SessionRecovery {
                 command: Some(RecoveryCommand::SessionPrepare),
+                action: None,
+                reuse_scope: session_reuse_scope(),
+                intents: Vec::new(),
+                phase: None,
+                refresh_integration_fingerprint: Some(false),
+                then: None,
+                retry_original: Some(true),
+                max_attempts: None,
+            },
+        ),
+        "prerequisite-stale" => (
+            true,
+            NextAction::PrepareIntent,
+            SessionRecovery {
+                command: Some(RecoveryCommand::SessionPrerequisite),
                 action: None,
                 reuse_scope: session_reuse_scope(),
                 intents: Vec::new(),
@@ -1873,6 +2642,7 @@ fn failure_details(code: &str) -> Box<SessionFailureDetails> {
         | "context-content-missing"
         | "record-render-failed"
         | "record-path-not-portable"
+        | "prerequisite-receipt-render-failed"
         | "lock-owner-render-failed"
         | "integration-catalog-invariant-failed" => (
             false,
@@ -1909,6 +2679,13 @@ fn failure_message(code: &str) -> &'static str {
         "invalid-product" => "the selected product is not supported for session context",
         "invalid-request-id" => "the context request identifier is invalid",
         "invalid-max-bytes" => "the context response budget is invalid",
+        "invalid-prerequisite-binding" => "the prerequisite execution binding is invalid",
+        "unsupported-prerequisite-selection" => "the prerequisite catalog selection is unsupported",
+        "prerequisite-receipt-invalid" => "the prerequisite receipt is invalid",
+        "prerequisite-receipt-mismatch" => {
+            "the prerequisite receipt belongs to a different execution scope"
+        }
+        "prerequisite-stale" => "the prerequisite policy changed before commit",
         "context-budget-exceeded" => "required policy content exceeds the response budget",
         "context-policy-invalid" => {
             "the prepared DSH context no longer satisfies the bounded policy contract"
@@ -1941,6 +2718,7 @@ fn failure_message(code: &str) -> &'static str {
         }
         "record-render-failed" => "the session record could not be serialized",
         "record-path-not-portable" => "the session record location violated an invariant",
+        "prerequisite-receipt-render-failed" => "the prerequisite receipt could not be serialized",
         "lock-owner-render-failed" => "the session lock owner could not be serialized",
         "integration-catalog-invariant-failed" => {
             "the integration catalog violated an internal invariant"

--- a/crates/agent-docs/tests/integration/common.rs
+++ b/crates/agent-docs/tests/integration/common.rs
@@ -91,12 +91,16 @@ impl TestEnv {
 
     /// Run `agent-docs <args>` with explicit `--docs-home` / `--project-path`.
     pub fn run(&self, args: &[&str]) -> CliOutput {
+        self.run_for_project(&self.project, args)
+    }
+
+    pub fn run_for_project(&self, project: &Path, args: &[&str]) -> CliOutput {
         let docs_home = self.docs_home.to_str().expect("utf-8 docs_home");
-        let project = self.project.to_str().expect("utf-8 project");
-        let mut full: Vec<&str> = vec!["--docs-home", docs_home, "--project-path", project];
+        let project_arg = project.to_str().expect("utf-8 project");
+        let mut full: Vec<&str> = vec!["--docs-home", docs_home, "--project-path", project_arg];
         full.extend_from_slice(args);
         let options = cmd::CmdOptions::default()
-            .with_cwd(&self.project)
+            .with_cwd(project)
             .with_env("HOME", self.home.to_str().expect("utf-8 home"))
             .with_env(
                 "XDG_CONFIG_HOME",

--- a/crates/agent-docs/tests/integration/dsh_context.rs
+++ b/crates/agent-docs/tests/integration/dsh_context.rs
@@ -25,6 +25,86 @@ fn context_args<'a>(state: &'a str, request_id: &'a str) -> Vec<&'a str> {
     ]
 }
 
+fn prerequisite_args<'a>(state: &'a str, request_id: &'a str) -> Vec<&'a str> {
+    vec![
+        "session",
+        "prerequisite",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--intent",
+        "project-dev",
+        "--phase",
+        "edit",
+        "--request-id",
+        request_id,
+        "--agent-id",
+        "dsh-agent-private-sentinel",
+        "--workspace-generation",
+        "workspace-generation-private-sentinel",
+        "--call-id",
+        "dsh-call-private-sentinel",
+        "--turn",
+        "1",
+        "--step",
+        "2",
+        "--tool-name",
+        "write",
+        "--definition-id",
+        "definition-private-sentinel",
+        "--format",
+        "json",
+    ]
+}
+
+fn commit_prerequisite_args<'a>(state: &'a str, receipt: &'a str) -> Vec<&'a str> {
+    vec![
+        "session",
+        "commit-prerequisite",
+        "--session-id",
+        "dsh-session-private-sentinel",
+        "--product",
+        "dsh",
+        "--state-home",
+        state,
+        "--receipt",
+        receipt,
+        "--agent-id",
+        "dsh-agent-private-sentinel",
+        "--workspace-generation",
+        "workspace-generation-private-sentinel",
+        "--call-id",
+        "dsh-call-private-sentinel",
+        "--turn",
+        "1",
+        "--step",
+        "2",
+        "--tool-name",
+        "write",
+        "--definition-id",
+        "definition-private-sentinel",
+        "--format",
+        "json",
+    ]
+}
+
+fn replace_arg(args: Vec<&str>, flag: &str, value: impl Into<String>) -> Vec<String> {
+    let mut args: Vec<String> = args.into_iter().map(str::to_string).collect();
+    let index = args
+        .iter()
+        .position(|argument| argument == flag)
+        .unwrap_or_else(|| panic!("missing test argument {flag}"));
+    args[index + 1] = value.into();
+    args
+}
+
+fn string_args(args: &[String]) -> Vec<&str> {
+    args.iter().map(String::as_str).collect()
+}
+
 fn session_records(state_home: &Path) -> Vec<PathBuf> {
     let sessions = state_home.join("agent-docs/sessions");
     if !sessions.exists() {
@@ -53,6 +133,409 @@ fn only_session_record(state_home: &Path) -> PathBuf {
     let records = session_records(state_home);
     assert_eq!(records.len(), 1, "expected one DSH session record");
     records.into_iter().next().unwrap()
+}
+
+#[test]
+fn dsh_prerequisite_begin_is_side_effect_free_and_commit_is_exact_and_idempotent() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let begun = env.run(&prerequisite_args(state, "prerequisite-request-1"));
+    assert_eq!(begun.code, 0, "stderr={}", begun.stderr);
+    let json = begun.json();
+    assert_eq!(
+        json["schema_version"],
+        "cli.agent-docs.session.prerequisite.v1"
+    );
+    let decision = &json["data"]["decision"];
+    assert_eq!(decision["schema_version"], "decision.prerequisite.v1");
+    assert_eq!(decision["request_id"], "prerequisite-request-1");
+    assert_eq!(decision["product"], "dsh");
+    assert_eq!(decision["intent"], "project-dev");
+    assert_eq!(decision["phase"], "edit");
+    assert_eq!(decision["reason"], "pending");
+    assert_eq!(decision["verified"], true);
+    assert_eq!(decision["documents"][0]["content"], "bounded policy\n");
+    let receipt = decision["receipt"]
+        .as_str()
+        .expect("pending prerequisite receipt");
+    assert!(receipt.len() <= 4096);
+    assert!(session_records(&state_home).is_empty());
+    for private in [
+        "dsh-session-private-sentinel",
+        "dsh-agent-private-sentinel",
+        "workspace-generation-private-sentinel",
+        "dsh-call-private-sentinel",
+        "definition-private-sentinel",
+        env.project.to_str().unwrap(),
+    ] {
+        assert!(!begun.stdout.contains(private), "leaked {private:?}");
+    }
+
+    let committed = env.run(&commit_prerequisite_args(state, receipt));
+    assert_eq!(committed.code, 0, "stderr={}", committed.stderr);
+    assert_eq!(
+        committed.json()["schema_version"],
+        "cli.agent-docs.session.commit-prerequisite.v1"
+    );
+    assert_eq!(committed.json()["data"]["reason"], "prepared");
+    assert_eq!(session_records(&state_home).len(), 1);
+
+    let replayed = env.run(&commit_prerequisite_args(state, receipt));
+    assert_eq!(replayed.code, 0, "stderr={}", replayed.stderr);
+    assert_eq!(replayed.json()["data"]["reason"], "already-current");
+
+    let reused = env.run(&prerequisite_args(state, "prerequisite-request-2"));
+    assert_eq!(reused.code, 0, "stderr={}", reused.stderr);
+    assert_eq!(
+        reused.json()["data"]["decision"]["reason"],
+        "already-current"
+    );
+    assert!(reused.json()["data"]["decision"]["receipt"].is_string());
+}
+
+#[test]
+fn reused_dsh_prerequisite_is_revalidated_at_the_execution_boundary() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let first = env.run(&prerequisite_args(state, "reuse-first"));
+    let first_json = first.json();
+    let first_receipt = first_json["data"]["decision"]["receipt"]
+        .as_str()
+        .expect("first prerequisite receipt");
+    let committed = env.run(&commit_prerequisite_args(state, first_receipt));
+    assert_eq!(committed.code, 0, "stderr={}", committed.stderr);
+
+    let reused = env.run(&prerequisite_args(state, "reuse-second"));
+    assert_eq!(
+        reused.json()["data"]["decision"]["reason"],
+        "already-current"
+    );
+    let reused_json = reused.json();
+    let reused_receipt = reused_json["data"]["decision"]["receipt"]
+        .as_str()
+        .expect("reuse must retain an execution-bound receipt");
+
+    env.write_project_doc("POLICY.md", "changed during approval\n");
+    let stale = env.run(&commit_prerequisite_args(state, reused_receipt));
+    assert_ne!(stale.code, 0, "stdout={}", stale.stdout);
+    assert_eq!(stale.json()["error"]["code"], "prerequisite-stale");
+}
+
+#[test]
+fn concurrent_dsh_prerequisite_commits_converge_without_corrupting_session_state() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let first_begin = env.run(&prerequisite_args(state, "concurrent-first"));
+    let second_begin_args = replace_arg(
+        prerequisite_args(state, "concurrent-second"),
+        "--call-id",
+        "dsh-call-concurrent-second",
+    );
+    let second_begin = env.run(&string_args(&second_begin_args));
+    assert_eq!(first_begin.code, 0, "stderr={}", first_begin.stderr);
+    assert_eq!(second_begin.code, 0, "stderr={}", second_begin.stderr);
+    let first_json = first_begin.json();
+    let second_json = second_begin.json();
+    let first_receipt = first_json["data"]["decision"]["receipt"].as_str().unwrap();
+    let second_receipt = second_json["data"]["decision"]["receipt"].as_str().unwrap();
+
+    let first_commit = commit_prerequisite_args(state, first_receipt);
+    let second_commit = replace_arg(
+        commit_prerequisite_args(state, second_receipt),
+        "--call-id",
+        "dsh-call-concurrent-second",
+    );
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| env.run(&first_commit));
+        let second = scope.spawn(|| env.run(&string_args(&second_commit)));
+        (first.join().unwrap(), second.join().unwrap())
+    });
+    assert_eq!(first.code, 0, "stderr={}", first.stderr);
+    assert_eq!(second.code, 0, "stderr={}", second.stderr);
+    let mut reasons = [
+        first.json()["data"]["reason"].as_str().unwrap().to_string(),
+        second.json()["data"]["reason"]
+            .as_str()
+            .unwrap()
+            .to_string(),
+    ];
+    reasons.sort();
+    assert_eq!(reasons, ["already-current", "prepared"]);
+    assert_eq!(session_records(&state_home).len(), 1);
+
+    let reused = env.run(&prerequisite_args(state, "concurrent-reuse"));
+    assert_eq!(reused.code, 0, "stderr={}", reused.stderr);
+    assert_eq!(
+        reused.json()["data"]["decision"]["reason"],
+        "already-current"
+    );
+}
+
+#[test]
+fn dsh_prerequisite_unsatisfied_policy_is_typed_side_effect_free_and_content_safe() {
+    for content in [None, Some("")] {
+        let env = TestEnv::new();
+        env.write_project_catalog(
+            r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+        );
+        if let Some(content) = content {
+            env.write_project_doc("POLICY.md", content);
+        }
+        let state_home = env.project_path("state");
+        let failed = env.run(&prerequisite_args(
+            state_home.to_str().unwrap(),
+            "unsatisfied-prerequisite",
+        ));
+        assert_eq!(failed.code, 65, "stdout={}", failed.stdout);
+        let failure = failed.json();
+        assert_eq!(
+            failure["schema_version"],
+            "cli.agent-docs.session.prerequisite.v1"
+        );
+        assert_eq!(failure["error"]["code"], "phase-unsatisfied");
+        assert_eq!(failure["error"]["details"]["next_action"], "repair-catalog");
+        assert!(!failed.stdout.contains("\"content\""));
+        assert!(session_records(&state_home).is_empty());
+    }
+}
+
+#[test]
+fn dsh_phase_prerequisite_materializes_a_phase_activation_from_a_full_activation() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let full = env.run(&context_args(state, "full-context"));
+    assert_eq!(full.code, 0, "stderr={}", full.stderr);
+
+    let begun = env.run(&prerequisite_args(state, "phase-prerequisite"));
+    assert_eq!(begun.code, 0, "stderr={}", begun.stderr);
+    assert_eq!(begun.json()["data"]["decision"]["reason"], "pending");
+    let begun_json = begun.json();
+    let receipt = begun_json["data"]["decision"]["receipt"]
+        .as_str()
+        .expect("phase prerequisite receipt");
+
+    let committed = env.run(&commit_prerequisite_args(state, receipt));
+    assert_eq!(committed.code, 0, "stderr={}", committed.stderr);
+    assert_eq!(committed.json()["data"]["reason"], "prepared");
+
+    let reused = env.run(&prerequisite_args(state, "phase-prerequisite-reuse"));
+    assert_eq!(reused.code, 0, "stderr={}", reused.stderr);
+    assert_eq!(
+        reused.json()["data"]["decision"]["reason"],
+        "already-current"
+    );
+}
+
+#[test]
+fn dsh_prerequisite_requires_edit_phase_and_the_verifier_catalog_selection() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "bounded policy\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let args = prerequisite_args(state, "missing-phase");
+    let without_phase: Vec<&str> = args
+        .into_iter()
+        .filter(|value| *value != "--phase" && *value != "edit")
+        .collect();
+    let missing = env.run(&without_phase);
+    assert_eq!(missing.code, 64, "stdout={}", missing.stdout);
+
+    let mut unsupported = vec!["--user-config"];
+    unsupported.extend(prerequisite_args(state, "unsupported-selection"));
+    let unsupported = env.run(&unsupported);
+    assert_eq!(unsupported.code, 65, "stdout={}", unsupported.stdout);
+    assert_eq!(
+        unsupported.json()["error"]["code"],
+        "unsupported-prerequisite-selection"
+    );
+
+    let mut local_only = vec!["--worktree-fallback", "local-only"];
+    local_only.extend(prerequisite_args(state, "unsupported-fallback"));
+    let local_only = env.run(&local_only);
+    assert_eq!(local_only.code, 65, "stdout={}", local_only.stdout);
+    assert_eq!(
+        local_only.json()["error"]["code"],
+        "unsupported-prerequisite-selection"
+    );
+}
+
+#[test]
+fn dsh_prerequisite_commit_rejects_stale_and_cross_scope_receipts_without_activation() {
+    let env = TestEnv::new();
+    env.write_project_catalog(
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "POLICY.md"
+product = "dsh"
+phase = "edit"
+required = true
+"#,
+    )
+    .write_project_doc("POLICY.md", "policy before change\n");
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+
+    let begun = env.run(&prerequisite_args(state, "prerequisite-stale"));
+    assert_eq!(begun.code, 0, "stderr={}", begun.stderr);
+    let begun_json = begun.json();
+    let receipt = begun_json["data"]["decision"]["receipt"].as_str().unwrap();
+    env.write_project_doc("POLICY.md", "policy after change\n");
+
+    let stale = env.run(&commit_prerequisite_args(state, receipt));
+    assert_eq!(stale.code, 65, "stdout={}", stale.stdout);
+    assert_eq!(stale.json()["error"]["code"], "prerequisite-stale");
+    assert_eq!(
+        stale.json()["error"]["details"]["recovery"]["intents"],
+        serde_json::json!(["project-dev"])
+    );
+    assert_eq!(
+        stale.json()["error"]["details"]["recovery"]["phase"],
+        "edit"
+    );
+    assert!(session_records(&state_home).is_empty());
+
+    let fresh = env.run(&prerequisite_args(state, "prerequisite-cross-scope"));
+    assert_eq!(fresh.code, 0, "stderr={}", fresh.stderr);
+    let fresh_json = fresh.json();
+    let fresh_receipt = fresh_json["data"]["decision"]["receipt"].as_str().unwrap();
+    let other_state = env.project_path("other-state");
+    for (flag, value) in [
+        ("--session-id", "other-session".to_string()),
+        ("--state-home", other_state.to_string_lossy().into_owned()),
+        ("--agent-id", "other-agent".to_string()),
+        (
+            "--workspace-generation",
+            "other-workspace-generation".to_string(),
+        ),
+        ("--call-id", "other-call".to_string()),
+        ("--turn", "2".to_string()),
+        ("--step", "3".to_string()),
+        ("--tool-name", "edit".to_string()),
+        ("--definition-id", "other-definition".to_string()),
+    ] {
+        let foreign_args = replace_arg(commit_prerequisite_args(state, fresh_receipt), flag, value);
+        let foreign = env.run(&string_args(&foreign_args));
+        assert_eq!(foreign.code, 65, "flag={flag} stdout={}", foreign.stdout);
+        assert_eq!(
+            foreign.json()["error"]["code"],
+            "prerequisite-receipt-mismatch",
+            "flag={flag}"
+        );
+    }
+
+    let other_project = env.project_path("other-project");
+    std::fs::create_dir_all(&other_project).expect("other project");
+    let foreign_project = env.run_for_project(
+        &other_project,
+        &commit_prerequisite_args(state, fresh_receipt),
+    );
+    assert_eq!(
+        foreign_project.code, 65,
+        "stdout={}",
+        foreign_project.stdout
+    );
+    assert_eq!(
+        foreign_project.json()["error"]["code"],
+        "prerequisite-receipt-mismatch"
+    );
+    assert!(session_records(&state_home).is_empty());
+}
+
+#[test]
+fn dsh_prerequisite_text_errors_name_the_invoked_command() {
+    let env = TestEnv::new();
+    let state_home = env.project_path("state");
+    let state = state_home.to_str().unwrap();
+    let mut args = commit_prerequisite_args(state, "malformed");
+    args.truncate(args.len() - 2);
+
+    let failed = env.run(&args);
+    assert_eq!(failed.code, 65, "stdout={}", failed.stdout);
+    assert!(
+        failed
+            .stderr
+            .contains("agent-docs session commit-prerequisite:"),
+        "stderr={}",
+        failed.stderr
+    );
 }
 
 #[test]

--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -71,8 +71,8 @@ until Hermes exposes a compatible runner.
 DSH doctor output names `dsh-runtime-kit` as `registration_owner` and reports
 `dispatch_supported: true` even though file-based setup remains unsupported.
 
-DSH sends strict `agent-hook.dsh-ingress.v2` pre-tool JSON, v4 post-tool JSON,
-and v3 lifecycle JSON.
+DSH sends strict `agent-hook.dsh-ingress.v2` ordinary pre-tool JSON, v5
+prerequisite-bound pre-tool JSON, v4 post-tool JSON, and v3 lifecycle JSON.
 V2 extends the retained v1 transport with the adapter-bound session, turn,
 step, and absolute agent-docs state/config roots. V3 adds strict
 `agent/pre-step` and `agent/turn-stopping` shapes, normalized to
@@ -90,6 +90,12 @@ policy boundary. Managed mutations persist hashed correlation and private
 retry material before invoking the same-release `agent-session work-context
 show/admit/complete` commands. Exact retries do not duplicate admission or
 execution; terminal post retries reauthenticate the idempotent completion.
+V5 adds one exact agent, workspace generation, visible tool definition, and
+side-effect-free agent-docs prerequisite receipt to the v2 identity. The
+pre-edit gate re-resolves the receipt against the current catalog and exact
+call/turn/step before allowing it; it does not activate the session. The
+runtime commits the receipt only after DSH waterfall, approval, guards, and
+cancellation have admitted the execution.
 Any partial managed selector set and uncertain operation fails closed. Stop
 uses capability-authenticated `agent-session broker status` and permits exit
 only when authoritative active and uncertain counts are both zero; local

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -86,6 +86,13 @@ above.
   `result.is_error: boolean`. `false` normalizes to `PostToolUse`; `true`
   normalizes to `PostToolUseFailure`. Candidate value, content, error objects,
   stdout, and stderr are neither accepted nor persisted.
+- `agent-hook.dsh-ingress.v5`: the prerequisite-bound DSH pre-tool transport.
+  It retains the strict v2 call, cwd, session, turn/step, tool name, and
+  arguments, and additionally requires bounded `subject.agent_id`,
+  `subject.workspace_generation`, `tool.definition_id`, and
+  `tool.prerequisite_receipt`. The receipt is re-resolved against the current
+  agent-docs catalog and exact execution binding; verification creates no
+  activation. V5 fields are rejected on every older ingress version.
 - `agent-hook.finish-line.{open,begin,run,stop,status}.v1`: strict DSH lifecycle
   requests for the native execution-owned finish line. Their
   command result schemas use the matching
@@ -163,9 +170,10 @@ Supported canonical events are:
 
 The Codex/Claude/Hermes adapter accepts the event from `--event` or the
 provider's documented `hook_event_name`/`event` field and rejects a mismatch.
-The DSH adapter accepts strict `agent-hook.dsh-ingress.v1`, v2, v3, or v4; the
-runtime bundle uses v2 before tools, v4 after tools, and v3 for agent lifecycle
-events. An optional
+The DSH adapter accepts strict `agent-hook.dsh-ingress.v1`, v2, v3, v4, or v5;
+the runtime bundle uses v2 before ordinary tools, v5 when a pending prerequisite
+must cross pre-tool policy, v4 after tools, and v3 for agent lifecycle events.
+An optional
 `--event` must equal its native event string before that string is mapped to
 the canonical policy event. Matcher values are normalized only from documented
 fields:

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -10,7 +10,8 @@ use sha2::{Digest, Sha256};
 use crate::contract::{digest, matcher_input_field, supported_event};
 use crate::error::HookError;
 use crate::model::{
-    DecisionAction, DshSubject, NormalizedDecision, NormalizedRequest, Product, REQUEST_VERSION,
+    DecisionAction, DshPrerequisite, DshSubject, NormalizedDecision, NormalizedRequest, Product,
+    REQUEST_VERSION,
 };
 use crate::path_binding::{TargetBinding, resolve_target_bindings};
 use crate::strict_json;
@@ -20,11 +21,19 @@ const DSH_INGRESS_V1: &str = "agent-hook.dsh-ingress.v1";
 const DSH_INGRESS_V2: &str = "agent-hook.dsh-ingress.v2";
 const DSH_INGRESS_V3: &str = "agent-hook.dsh-ingress.v3";
 const DSH_INGRESS_V4: &str = "agent-hook.dsh-ingress.v4";
+const DSH_INGRESS_V5: &str = "agent-hook.dsh-ingress.v5";
 const DSH_RUNTIME_KIT_PROVIDER_SESSION_ID_ENV: &str = "DSH_RUNTIME_KIT_PROVIDER_SESSION_ID";
 const MAX_PROVIDER_ID_CHARS: usize = 256;
 const MAX_MUTATION_TARGETS: usize = 256;
 const MAX_MUTATION_TARGET_BYTES: usize = 4096;
 const MAX_DSH_PROMPT_BYTES: usize = 64 * 1024;
+const MAX_DSH_PREREQUISITE_RECEIPT_BYTES: usize = 4096;
+
+fn valid_provider_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().count() <= MAX_PROVIDER_ID_CHARS
+        && !value.bytes().any(|byte| byte.is_ascii_control())
+}
 
 #[derive(Debug, Serialize)]
 struct ActivityEvent {
@@ -77,6 +86,10 @@ struct DshIngressSubject {
     agent_docs_state_home: PathBuf,
     #[serde(default)]
     agent_docs_home: Option<PathBuf>,
+    #[serde(default)]
+    agent_id: Option<String>,
+    #[serde(default)]
+    workspace_generation: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -84,6 +97,10 @@ struct DshIngressSubject {
 struct DshToolCall {
     name: String,
     arguments: Value,
+    #[serde(default)]
+    definition_id: Option<String>,
+    #[serde(default)]
+    prerequisite_receipt: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -175,7 +192,7 @@ fn normalize_dsh(
     })?;
     if !matches!(
         ingress.schema_version.as_str(),
-        DSH_INGRESS_V1 | DSH_INGRESS_V2 | DSH_INGRESS_V3 | DSH_INGRESS_V4
+        DSH_INGRESS_V1 | DSH_INGRESS_V2 | DSH_INGRESS_V3 | DSH_INGRESS_V4 | DSH_INGRESS_V5
     ) {
         return Err(HookError::data(
             "dsh-ingress-version-invalid",
@@ -190,6 +207,8 @@ fn normalize_dsh(
                 && subject.turn > 0
                 && subject.step.is_some_and(|step| step > 0)
                 && subject.session_start_source.is_none()
+                && subject.agent_id.is_none()
+                && subject.workspace_generation.is_none()
                 && subject.agent_docs_state_home.is_absolute()
                 && subject
                     .agent_docs_home
@@ -204,6 +223,57 @@ fn normalize_dsh(
                 session_start_source: None,
                 agent_docs_state_home: subject.agent_docs_state_home,
                 agent_docs_home: subject.agent_docs_home,
+                prerequisite: None,
+            })
+        }
+        (DSH_INGRESS_V5, Some(subject))
+            if !subject.session_id.is_empty()
+                && subject.session_id.chars().count() <= MAX_PROVIDER_ID_CHARS
+                && subject.turn > 0
+                && subject.step.is_some_and(|step| step > 0)
+                && subject.session_start_source.is_none()
+                && subject.agent_docs_state_home.is_absolute()
+                && subject
+                    .agent_docs_home
+                    .as_ref()
+                    .is_none_or(|path| path.is_absolute())
+                && subject.agent_id.as_deref().is_some_and(valid_provider_id)
+                && subject
+                    .workspace_generation
+                    .as_deref()
+                    .is_some_and(valid_provider_id)
+                && ingress.tool.as_ref().is_some_and(|tool| {
+                    tool.definition_id.as_deref().is_some_and(valid_provider_id)
+                        && tool.prerequisite_receipt.as_deref().is_some_and(|receipt| {
+                            !receipt.is_empty()
+                                && receipt.len() <= MAX_DSH_PREREQUISITE_RECEIPT_BYTES
+                                && !receipt.bytes().any(|byte| byte.is_ascii_control())
+                        })
+                }) =>
+        {
+            let tool = ingress.tool.as_ref().expect("validated DSH v5 tool");
+            Some(DshSubject {
+                session_id: subject.session_id,
+                call_id: ingress.call_id.clone(),
+                turn: subject.turn,
+                step: subject.step,
+                session_start_source: None,
+                agent_docs_state_home: subject.agent_docs_state_home,
+                agent_docs_home: subject.agent_docs_home,
+                prerequisite: Some(DshPrerequisite {
+                    agent_id: subject.agent_id.expect("validated DSH v5 agent id"),
+                    workspace_generation: subject
+                        .workspace_generation
+                        .expect("validated DSH v5 workspace generation"),
+                    definition_id: tool
+                        .definition_id
+                        .clone()
+                        .expect("validated DSH v5 definition id"),
+                    receipt: tool
+                        .prerequisite_receipt
+                        .clone()
+                        .expect("validated DSH v5 prerequisite receipt"),
+                }),
             })
         }
         (DSH_INGRESS_V3, Some(subject))
@@ -220,6 +290,8 @@ fn normalize_dsh(
                             "startup" | "resume" | "clear" | "compact" | "observed"
                         )
                     })
+                && subject.agent_id.is_none()
+                && subject.workspace_generation.is_none()
                 && subject.agent_docs_state_home.is_absolute()
                 && subject
                     .agent_docs_home
@@ -234,6 +306,7 @@ fn normalize_dsh(
                 session_start_source: subject.session_start_source,
                 agent_docs_state_home: subject.agent_docs_state_home,
                 agent_docs_home: subject.agent_docs_home,
+                prerequisite: None,
             })
         }
         _ => {
@@ -288,12 +361,24 @@ fn normalize_dsh(
             !tool.name.is_empty()
                 && tool.name.chars().count() <= MAX_PROVIDER_ID_CHARS
                 && tool.arguments.is_object()
+                && if ingress.schema_version == DSH_INGRESS_V5 {
+                    tool.definition_id.as_deref().is_some_and(valid_provider_id)
+                        && tool.prerequisite_receipt.as_deref().is_some_and(|receipt| {
+                            !receipt.is_empty()
+                                && receipt.len() <= MAX_DSH_PREREQUISITE_RECEIPT_BYTES
+                                && !receipt.bytes().any(|byte| byte.is_ascii_control())
+                        })
+                } else {
+                    tool.definition_id.is_none() && tool.prerequisite_receipt.is_none()
+                }
         })
         && ingress.prompt.is_none()
         && ingress.result.is_none()
-        && dsh_subject
-            .as_ref()
-            .is_none_or(|subject| subject.step.is_some() && subject.session_start_source.is_none());
+        && dsh_subject.as_ref().is_none_or(|subject| {
+            subject.step.is_some()
+                && subject.session_start_source.is_none()
+                && (ingress.schema_version == DSH_INGRESS_V5) == subject.prerequisite.is_some()
+        });
     let prompt_shape = event == "UserPromptSubmit"
         && ingress.schema_version == DSH_INGRESS_V3
         && ingress.call_id.is_none()
@@ -324,6 +409,8 @@ fn normalize_dsh(
             !tool.name.is_empty()
                 && tool.name.chars().count() <= MAX_PROVIDER_ID_CHARS
                 && tool.arguments.is_object()
+                && tool.definition_id.is_none()
+                && tool.prerequisite_receipt.is_none()
         })
         && ingress.prompt.is_none()
         && ingress.result.is_some()

--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -13,7 +13,9 @@ use std::process::{Command, Output, Stdio};
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use agent_docs::dsh::session_intent_is_current;
+use agent_docs::dsh::{
+    PrerequisiteBinding, prerequisite_receipt_is_current, session_intent_is_current,
+};
 use agent_docs::env::{PathOverrides, resolve_roots};
 use agent_docs::model::{Context as DocsContext, FallbackMode, Phase};
 use regex::Regex;
@@ -3222,13 +3224,43 @@ fn pre_edit_intent(
             Ok(roots) => roots,
             Err(_) => return Ok(Outcome::block(group)),
         };
-        if !session_intent_is_current(
+        if session_intent_is_current(
             &roots,
             &subject.session_id,
             &subject.agent_docs_state_home,
             &intent,
             Some(&phase),
             FallbackMode::Auto,
+        ) {
+            continue;
+        }
+        let Some(prerequisite) = subject.prerequisite.as_ref() else {
+            return Ok(Outcome::block(group));
+        };
+        let (Some(call_id), Some(step), Some(tool_name)) = (
+            subject.call_id.as_deref(),
+            subject.step,
+            request.matcher.as_deref(),
+        ) else {
+            return Ok(Outcome::block(group));
+        };
+        if !prerequisite_receipt_is_current(
+            &roots,
+            &subject.session_id,
+            &subject.agent_docs_state_home,
+            &intent,
+            Some(&phase),
+            FallbackMode::Auto,
+            PrerequisiteBinding {
+                receipt: &prerequisite.receipt,
+                agent_id: &prerequisite.agent_id,
+                workspace_generation: &prerequisite.workspace_generation,
+                call_id,
+                turn: subject.turn,
+                step,
+                tool_name,
+                definition_id: &prerequisite.definition_id,
+            },
         ) {
             return Ok(Outcome::block(group));
         }

--- a/crates/agent-hook/src/model.rs
+++ b/crates/agent-hook/src/model.rs
@@ -277,6 +277,15 @@ pub struct DshSubject {
     pub session_start_source: Option<String>,
     pub agent_docs_state_home: PathBuf,
     pub agent_docs_home: Option<PathBuf>,
+    pub prerequisite: Option<DshPrerequisite>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DshPrerequisite {
+    pub agent_id: String,
+    pub workspace_generation: String,
+    pub definition_id: String,
+    pub receipt: String,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/agent-hook/tests/dsh_ingress.rs
+++ b/crates/agent-hook/tests/dsh_ingress.rs
@@ -63,11 +63,126 @@ fn dsh_pre_execute_is_normalized_and_evaluated_by_the_shared_policy_engine() {
 }
 
 #[test]
+fn dsh_v5_pre_execute_accepts_only_the_exact_prerequisite_ingress_shape() {
+    let fixture = Fixture::new(POLICY);
+    let value = json!({
+        "schema_version": "agent-hook.dsh-ingress.v5",
+        "event": "tools/pre-execute",
+        "call_id": "dsh-call-1",
+        "cwd": fixture.root,
+        "subject": {
+            "session_id": "session-1",
+            "turn": 1,
+            "step": 2,
+            "agent_id": "agent-1",
+            "workspace_generation": "workspace-generation-1",
+            "agent_docs_state_home": fixture.home.join("state"),
+        },
+        "tool": {
+            "name": "runtime_kit_plus_one",
+            "arguments": {"value": 41},
+            "definition_id": "definition-1",
+            "prerequisite_receipt": "{}",
+        },
+    });
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&value.to_string()),
+    );
+    assert_eq!(output.code, 1, "envelope={}", output.stdout_text());
+    assert_eq!(output.stdout_json()["data"]["action"], "block");
+    assert_eq!(
+        output.stdout_json()["data"]["reasons"][0]["code"],
+        "plus-one-blocked"
+    );
+
+    for (scope, field) in [
+        ("subject", "agent_id"),
+        ("subject", "workspace_generation"),
+        ("tool", "definition_id"),
+        ("tool", "prerequisite_receipt"),
+    ] {
+        let mut missing = value.clone();
+        missing[scope].as_object_mut().unwrap().remove(field);
+        let rejected = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&missing.to_string()),
+        );
+        assert_eq!(rejected.code, 65, "missing={scope}.{field}");
+        assert_eq!(
+            rejected.stdout_json()["error"]["code"],
+            "dsh-ingress-invalid"
+        );
+    }
+
+    for (scope, field, replacement) in [
+        ("subject", "agent_id", json!("")),
+        ("subject", "agent_id", json!("a".repeat(257))),
+        ("subject", "agent_id", json!("agent\n1")),
+        ("subject", "workspace_generation", json!("")),
+        ("subject", "workspace_generation", json!("w".repeat(257))),
+        ("tool", "definition_id", json!("")),
+        ("tool", "definition_id", json!("d".repeat(257))),
+        ("tool", "prerequisite_receipt", json!("")),
+        ("tool", "prerequisite_receipt", json!("r".repeat(4097))),
+        ("tool", "prerequisite_receipt", json!("receipt\nvalue")),
+    ] {
+        let mut invalid = value.clone();
+        invalid[scope][field] = replacement;
+        let rejected = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&invalid.to_string()),
+        );
+        assert_eq!(rejected.code, 65, "invalid={scope}.{field}");
+        assert_eq!(
+            rejected.stdout_json()["error"]["code"],
+            "dsh-ingress-invalid"
+        );
+    }
+
+    for (scope, field) in [("subject", "unknown"), ("tool", "unknown")] {
+        let mut unknown = value.clone();
+        unknown[scope][field] = json!(true);
+        let rejected = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&unknown.to_string()),
+        );
+        assert_eq!(rejected.code, 65, "unknown={scope}.{field}");
+        assert_eq!(
+            rejected.stdout_json()["error"]["code"],
+            "dsh-ingress-invalid"
+        );
+    }
+
+    let mut wrong_event = value.clone();
+    wrong_event["event"] = json!("tools/post-execute");
+    let rejected = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&wrong_event.to_string()),
+    );
+    assert_eq!(rejected.code, 65, "input={wrong_event}");
+
+    for version in 1..=4 {
+        let mut older = value.clone();
+        older["schema_version"] = json!(format!("agent-hook.dsh-ingress.v{version}"));
+        let rejected = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&older.to_string()),
+        );
+        assert_eq!(rejected.code, 65, "version={version}");
+        assert_eq!(
+            rejected.stdout_json()["error"]["code"],
+            "dsh-ingress-invalid"
+        );
+    }
+}
+
+#[test]
 fn dsh_ingress_rejects_unknown_versions_and_fields() {
     let fixture = Fixture::new(POLICY);
 
     let wrong_version =
-        request(&fixture).replace("agent-hook.dsh-ingress.v1", "agent-hook.dsh-ingress.v5");
+        request(&fixture).replace("agent-hook.dsh-ingress.v1", "agent-hook.dsh-ingress.v6");
     let output = fixture.run(
         &["dispatch", "--product", "dsh", "--format", "json"],
         Some(&wrong_version),

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -153,6 +153,29 @@ fn git(fixture: &Fixture, args: &[&str]) {
     );
 }
 
+fn session_json_records(state_home: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let root = state_home.join("agent-docs/sessions");
+    if !root.exists() {
+        return Vec::new();
+    }
+    let mut pending = vec![root];
+    let mut records = Vec::new();
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(directory).expect("session state directory") {
+            let path = entry.expect("session state entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path
+                .extension()
+                .is_some_and(|extension| extension == "json")
+            {
+                records.push(path);
+            }
+        }
+    }
+    records
+}
+
 fn dispatch_with_release_binary(fixture: &Fixture, binary: &std::path::Path, input: &str) -> Value {
     dispatch_with_release_binary_env(fixture, binary, input, &[])
 }
@@ -2540,6 +2563,153 @@ phase = "edit"
     );
     assert_eq!(output.code, 0, "envelope={}", output.stdout_text());
     assert_eq!(output.stdout_json()["data"]["action"], "allow");
+}
+
+#[test]
+fn dsh_pre_edit_accepts_only_an_exact_current_pending_prerequisite_without_committing_it() {
+    let Some(agent_docs) = nils_test_support::bin::sibling_or_skip("agent-docs", "nils-agent-docs")
+    else {
+        return;
+    };
+    let fixture = Fixture::new(&policy("pre-edit-intent-gate", "dsh"));
+    fs::write(
+        fixture.root.join("AGENT_DOCS.toml"),
+        r#"
+[[document]]
+context = "project-dev"
+scope = "project"
+path = "README.md"
+required = true
+phase = "edit"
+"#,
+    )
+    .expect("catalog");
+    fs::write(fixture.root.join("README.md"), "pending DSH policy\n").expect("policy doc");
+    let state_home = fixture.state_home.join("dsh-runtime-kit");
+    let begin = Command::new(&agent_docs)
+        .args([
+            "--docs-home",
+            fixture.home.to_str().unwrap(),
+            "--project-path",
+            fixture.root.to_str().unwrap(),
+            "session",
+            "prerequisite",
+            "--session-id",
+            "dsh-session-1",
+            "--product",
+            "dsh",
+            "--state-home",
+            state_home.to_str().unwrap(),
+            "--intent",
+            "project-dev",
+            "--phase",
+            "edit",
+            "--request-id",
+            "pending-pre-edit-test",
+            "--agent-id",
+            "agent-1",
+            "--workspace-generation",
+            "workspace-generation-1",
+            "--call-id",
+            "dsh-task-3-2-call",
+            "--turn",
+            "1",
+            "--step",
+            "2",
+            "--tool-name",
+            "bash",
+            "--definition-id",
+            "definition-1",
+            "--format",
+            "json",
+        ])
+        .env_clear()
+        .env("HOME", &fixture.home)
+        .env("PATH", "/usr/bin:/bin")
+        .output()
+        .expect("agent-docs prerequisite begin");
+    assert!(
+        begin.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&begin.stderr)
+    );
+    let begin_json: Value = serde_json::from_slice(&begin.stdout).expect("begin JSON");
+    let receipt = begin_json["data"]["decision"]["receipt"]
+        .as_str()
+        .expect("pending receipt");
+    assert!(session_json_records(&state_home).is_empty());
+
+    let mut input: Value = serde_json::from_str(&request(
+        &fixture,
+        "bash",
+        json!({"command": "printf owned > owned.txt"}),
+    ))
+    .expect("request JSON");
+    input["schema_version"] = json!("agent-hook.dsh-ingress.v5");
+    input["subject"]["agent_docs_home"] =
+        Value::String(fixture.home.to_string_lossy().into_owned());
+    input["subject"]["agent_id"] = json!("agent-1");
+    input["subject"]["workspace_generation"] = json!("workspace-generation-1");
+    input["tool"]["definition_id"] = json!("definition-1");
+    input["tool"]["prerequisite_receipt"] = json!(receipt);
+
+    let accepted = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&input.to_string()),
+    );
+    assert_eq!(accepted.code, 0, "envelope={}", accepted.stdout_text());
+    assert_eq!(accepted.stdout_json()["data"]["action"], "allow");
+    assert!(session_json_records(&state_home).is_empty());
+
+    for (scope, field, replacement) in [
+        ("subject", "agent_id", json!("agent-2")),
+        (
+            "subject",
+            "workspace_generation",
+            json!("workspace-generation-2"),
+        ),
+        ("subject", "turn", json!(2)),
+        ("subject", "step", json!(3)),
+        (
+            "subject",
+            "agent_docs_state_home",
+            json!(fixture.state_home.join("other-runtime")),
+        ),
+        ("tool", "definition_id", json!("definition-2")),
+        ("tool", "prerequisite_receipt", json!("{}")),
+    ] {
+        let mut substituted = input.clone();
+        substituted[scope][field] = replacement;
+        let denied = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&substituted.to_string()),
+        );
+        assert_eq!(denied.code, 1, "substitution={scope}.{field}");
+        assert_eq!(denied.stdout_json()["data"]["action"], "block");
+    }
+
+    let mut other_call = input.clone();
+    other_call["call_id"] = json!("other-call");
+    let denied = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&other_call.to_string()),
+    );
+    assert_eq!(denied.code, 1, "envelope={}", denied.stdout_text());
+    assert_eq!(denied.stdout_json()["data"]["action"], "block");
+
+    let mut cross_intent_receipt: Value =
+        serde_json::from_str(receipt).expect("prerequisite receipt JSON");
+    cross_intent_receipt["intent"] = json!("other-dev");
+    let mut cross_intent = input.clone();
+    cross_intent["tool"]["prerequisite_receipt"] =
+        json!(serde_json::to_string(&cross_intent_receipt).unwrap());
+    let denied = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&cross_intent.to_string()),
+    );
+    assert_eq!(denied.code, 1, "envelope={}", denied.stdout_text());
+    assert_eq!(denied.stdout_json()["data"]["action"], "block");
+    assert!(session_json_records(&state_home).is_empty());
 }
 
 #[test]

--- a/crates/agent-hook/tests/policy_parity.rs
+++ b/crates/agent-hook/tests/policy_parity.rs
@@ -54,6 +54,7 @@ fn canonical_spec_names_the_strict_dsh_ingress_and_policy_contracts() {
         "`agent-hook.dsh-ingress.v2`",
         "`agent-hook.dsh-ingress.v3`",
         "`agent-hook.dsh-ingress.v4`",
+        "`agent-hook.dsh-ingress.v5`",
         "`dsh.policy.v1`",
     ] {
         assert!(


### PR DESCRIPTION
## Summary

- add side-effect-free `agent-docs session prerequisite` decisions bound to an exact DSH execution
- add fresh compare-and-set `commit-prerequisite` verification, including reused activations after approval waits
- add strict DSH ingress v5 fields for agent, workspace generation, tool definition, and prerequisite receipt
- keep the existing session activation path compatible while allowing pre-edit admission from an exact pending receipt

## Test plan

- `TMPDIR=/var/tmp bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- 8,633 workspace tests passed, plus all-target clippy, formatting, documentation checks, and doctests
- focused stale-reuse, concurrent commit, cross-scope replay, malformed ingress, and policy parity regressions
- security, API-contract, maintainability, testing, and adversarial red-team review converged with no remaining findings

Refs sympoies/dsh-runtime-kit#57
