### PR TITLE
Honor advisory DSH coordination on macOS

### DIFF
--- a/crates/agent-hook/src/dsh_coordination_unsupported.rs
+++ b/crates/agent-hook/src/dsh_coordination_unsupported.rs
@@ -27,6 +27,12 @@ pub(crate) fn run(
             message: None,
         });
     }
+    if crate::liveness::coordination_failure_mode().is_some() {
+        return Ok(Outcome {
+            status: Status::NotRun,
+            message: None,
+        });
+    }
     Ok(Outcome {
         status: Status::Unavailable,
         message: Some(

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -863,7 +863,6 @@ fn dsh_operation_lifecycle_is_optional_when_unmanaged_and_closed_when_partial() 
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn dsh_operation_lifecycle_requires_a_claim_only_in_authenticated_enforce_mode() {
     for (durable_mode, runtime_hint, expected_action, expected_helper_calls) in [
         (Some("advisory"), "advisory", "allow", 0),
@@ -933,6 +932,11 @@ fn dsh_operation_lifecycle_requires_a_claim_only_in_authenticated_enforce_mode()
             .unwrap_or_default()
             .lines()
             .count();
+        let expected_helper_calls = if cfg!(target_os = "linux") {
+            expected_helper_calls
+        } else {
+            0
+        };
         assert_eq!(
             helper_calls, expected_helper_calls,
             "durable_mode={durable_mode:?} runtime_hint={runtime_hint}"


### PR DESCRIPTION
## Summary

- Give the non-Linux DSH operation-lifecycle backend parity with Linux for authenticated durable `advisory` and `off` coordination modes.
- Keep partial, unauthenticated, and enforce-mode managed selectors blocked when Linux finish-line containment is unavailable.
- Exercise the existing contract test on both Linux and macOS.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (all gates passed except one unrelated workspace-lease test that fails identically on clean `origin/main` with `workspace-git-unavailable`)
- `cargo test -p agent-hook --test dsh_policy dsh_operation_lifecycle_requires_a_claim_only_in_authenticated_enforce_mode` on Linux
- The same focused test on m4/macOS
- Public repository CI is required before merge.

Refs serenvia/sympoies-infra#213
