### PR TITLE
fix(agent-scope-lock): trust system Git under PrivateUsers

### DIFF
--- a/crates/agent-scope-lock/src/lib.rs
+++ b/crates/agent-scope-lock/src/lib.rs
@@ -448,14 +448,7 @@ fn trusted_git_executable() -> Result<PathBuf, CliError> {
         let Ok(canonical) = fs::canonicalize(&candidate) else {
             continue;
         };
-        let Ok(metadata) = fs::metadata(&canonical) else {
-            continue;
-        };
-        if metadata.is_file()
-            && (metadata.uid() == 0 || metadata.uid() == unsafe { libc::geteuid() })
-            && metadata.permissions().mode() & 0o022 == 0
-            && metadata.permissions().mode() & 0o111 != 0
-        {
+        if trusted_git_path(&canonical) {
             return Ok(canonical);
         }
     }
@@ -464,6 +457,90 @@ fn trusted_git_executable() -> Result<PathBuf, CliError> {
         "a trusted system Git executable is unavailable",
         None,
     ))
+}
+
+fn trusted_git_path(path: &Path) -> bool {
+    let effective_uid = unsafe { libc::geteuid() };
+    let overflow_uid = fs::read_to_string("/proc/sys/kernel/overflowuid").ok();
+    let uid_map = fs::read_to_string("/proc/self/uid_map").ok();
+
+    for (index, component) in path.ancestors().enumerate() {
+        let Ok(metadata) = fs::symlink_metadata(component) else {
+            return false;
+        };
+        let expected_type = if index == 0 {
+            metadata.is_file() && metadata.permissions().mode() & 0o111 != 0
+        } else {
+            metadata.is_dir()
+        };
+        if !expected_type
+            || metadata.file_type().is_symlink()
+            || metadata.permissions().mode() & 0o022 != 0
+            || !trusted_system_owner_for_namespace(
+                metadata.uid(),
+                effective_uid,
+                overflow_uid.as_deref(),
+                uid_map.as_deref(),
+            )
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn trusted_system_owner_for_namespace(
+    owner_uid: u32,
+    effective_uid: u32,
+    overflow_uid: Option<&str>,
+    uid_map: Option<&str>,
+) -> bool {
+    if owner_uid == 0 {
+        return true;
+    }
+
+    let parsed_overflow_uid = overflow_uid.and_then(|value| value.trim().parse::<u32>().ok());
+    if owner_uid == effective_uid {
+        return parsed_overflow_uid != Some(owner_uid);
+    }
+
+    let Some(overflow_uid) =
+        parsed_overflow_uid.filter(|value| *value == owner_uid && *value != effective_uid)
+    else {
+        return false;
+    };
+    let Some(uid_map) = uid_map else {
+        return false;
+    };
+
+    let mut rows = 0usize;
+    for line in uid_map.lines().filter(|line| !line.trim().is_empty()) {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.len() != 3 {
+            return false;
+        }
+        let Ok(inner) = fields[0].parse::<u64>() else {
+            return false;
+        };
+        let Ok(_outer) = fields[1].parse::<u64>() else {
+            return false;
+        };
+        let Ok(length) = fields[2].parse::<u64>() else {
+            return false;
+        };
+        let Some(end) = inner.checked_add(length) else {
+            return false;
+        };
+        if length == 0 {
+            return false;
+        }
+        rows += 1;
+        let overflow_uid = u64::from(overflow_uid);
+        if inner <= overflow_uid && overflow_uid < end {
+            return false;
+        }
+    }
+    rows > 0
 }
 
 fn absolute_path(path: &Path) -> Result<PathBuf, CliError> {
@@ -742,7 +819,10 @@ struct ErrorBody<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_allowed_path, normalize_absolute_path, repo_relative_path};
+    use super::{
+        is_allowed_path, normalize_absolute_path, repo_relative_path,
+        trusted_system_owner_for_namespace,
+    };
     use std::path::Path;
 
     #[test]
@@ -771,5 +851,49 @@ mod tests {
     #[test]
     fn empty_repo_relative_path_becomes_dot() {
         assert_eq!(repo_relative_path(Path::new("")).expect("path"), ".");
+    }
+
+    #[test]
+    fn trusted_system_owner_accepts_only_genuinely_unmapped_overflow_uid() {
+        assert!(trusted_system_owner_for_namespace(
+            65_534,
+            1_000,
+            Some("65534\n"),
+            Some("0 1000 1\n"),
+        ));
+        assert!(!trusted_system_owner_for_namespace(
+            65_534,
+            1_000,
+            Some("65534\n"),
+            Some("0 1000 1\n65534 65534 1\n"),
+        ));
+        assert!(!trusted_system_owner_for_namespace(
+            65_534,
+            65_534,
+            Some("65534\n"),
+            Some("0 1000 1\n"),
+        ));
+    }
+
+    #[test]
+    fn trusted_system_owner_rejects_invalid_namespace_evidence() {
+        assert!(!trusted_system_owner_for_namespace(
+            65_534,
+            1_000,
+            Some("not-a-uid\n"),
+            Some("0 1000 1\n"),
+        ));
+        assert!(!trusted_system_owner_for_namespace(
+            65_534,
+            1_000,
+            Some("65534\n"),
+            Some("0 1000 0\n"),
+        ));
+        assert!(!trusted_system_owner_for_namespace(
+            65_534,
+            1_000,
+            Some("65534\n"),
+            Some("0 1000 1 extra\n"),
+        ));
     }
 }

--- a/crates/agent-scope-lock/src/lib.rs
+++ b/crates/agent-scope-lock/src/lib.rs
@@ -461,8 +461,14 @@ fn trusted_git_executable() -> Result<PathBuf, CliError> {
 
 fn trusted_git_path(path: &Path) -> bool {
     let effective_uid = unsafe { libc::geteuid() };
-    let overflow_uid = fs::read_to_string("/proc/sys/kernel/overflowuid").ok();
-    let uid_map = fs::read_to_string("/proc/self/uid_map").ok();
+    let (overflow_uid, uid_map) = if allows_namespace_overflow_for_git_path(path) {
+        (
+            fs::read_to_string("/proc/sys/kernel/overflowuid").ok(),
+            fs::read_to_string("/proc/self/uid_map").ok(),
+        )
+    } else {
+        (None, None)
+    };
 
     for (index, component) in path.ancestors().enumerate() {
         let Ok(metadata) = fs::symlink_metadata(component) else {
@@ -487,6 +493,10 @@ fn trusted_git_path(path: &Path) -> bool {
         }
     }
     true
+}
+
+fn allows_namespace_overflow_for_git_path(path: &Path) -> bool {
+    path == Path::new("/usr/bin/git") || path == Path::new("/bin/git")
 }
 
 fn trusted_system_owner_for_namespace(
@@ -820,8 +830,8 @@ struct ErrorBody<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_allowed_path, normalize_absolute_path, repo_relative_path,
-        trusted_system_owner_for_namespace,
+        allows_namespace_overflow_for_git_path, is_allowed_path, normalize_absolute_path,
+        repo_relative_path, trusted_system_owner_for_namespace,
     };
     use std::path::Path;
 
@@ -895,5 +905,24 @@ mod tests {
             Some("65534\n"),
             Some("0 1000 1 extra\n"),
         ));
+    }
+
+    #[test]
+    fn namespace_overflow_is_limited_to_the_fixed_system_git_family() {
+        assert!(allows_namespace_overflow_for_git_path(Path::new(
+            "/usr/bin/git"
+        )));
+        assert!(allows_namespace_overflow_for_git_path(Path::new(
+            "/bin/git"
+        )));
+        assert!(!allows_namespace_overflow_for_git_path(Path::new(
+            "/usr/local/bin/git"
+        )));
+        assert!(!allows_namespace_overflow_for_git_path(Path::new(
+            "/opt/homebrew/bin/git"
+        )));
+        assert!(!allows_namespace_overflow_for_git_path(Path::new(
+            "/usr/bin/git-wrapper"
+        )));
     }
 }


### PR DESCRIPTION
## Summary

Keep `agent-scope-lock` able to invoke the trusted system Git executable inside the Linux `PrivateUsers=yes` containment used by `agent-hook finish-line`, without widening executable discovery or relaxing path trust.

## Problem

- Expected: a root-owned, non-writable `/usr/bin/git` remains trusted inside a user namespace.
- Actual: an unmapped host owner is rendered as Linux `overflowuid`, so the released binary reports `git-spawn-failed` before Git starts.
- Impact: contained repository validations using `agent-scope-lock` fail even though the fixed system Git path is intact.

## Reproduction

1. Create a Git repository visible to the user systemd manager.
2. Run released `agent-scope-lock create` through `systemd-run --user --property=PrivateUsers=yes`.
3. Observe exit 1 with `git-spawn-failed: a trusted system Git executable is unavailable`.

## Issues Found

- Refs serenvia/sympoies-infra#213.

## Fix Approach

- Accept `overflowuid` only when `/proc/self/uid_map` is valid, non-empty, proves the value is unmapped, and the effective UID is distinct.
- Continue accepting root and the ordinary effective owner outside that special case.
- Verify the canonical Git executable and every ancestor are the expected file/directory type, are not symlinks, are owned by a trusted identity, and are not group/world writable.

## Test-First Evidence

- RED: the new namespace-owner unit test initially failed to compile because the trust helper did not exist.
- RED: released 1.27.9 under `PrivateUsers=yes` exited 1 with `git-spawn-failed`.
- GREEN: the fixed binary under the same `PrivateUsers=yes` probe created the scope lock successfully.

## Test plan

- `cargo test -p nils-agent-scope-lock --lib` — 6 passed.
- `cargo test -p nils-agent-scope-lock` — 34 passed.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — passed.
- Live `systemd-run --user --wait --pipe --collect --property=PrivateUsers=yes` probe — passed with the fixed binary.

## Risk / Notes

- Linux namespace parsing remains fail closed on missing, malformed, empty, zero-length, overflowing, or mapped UID ranges.
- No PATH expansion, environment allowlist, sandbox removal, or repository policy bypass is introduced.
