### PR TITLE
fix(test-support): isolate non-Git temp fixtures

### DIFF
--- a/crates/agent-hook/tests/workspace_lease.rs
+++ b/crates/agent-hook/tests/workspace_lease.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use pretty_assertions::{assert_eq, assert_ne};
 use serde_json::{Value, json};
 
+use nils_test_support::tempdir::ScopedTempDir;
 use support::Fixture;
 
 const POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
@@ -393,7 +394,7 @@ fn read_only_tools_need_no_operation_and_copied_fences_fail_closed() {
 #[test]
 fn renew_is_exact_and_non_git_directories_remain_unmanaged() {
     let fixture = fixture();
-    let non_git = tempfile::TempDir::new().expect("non-Git cwd");
+    let non_git = ScopedTempDir::outside_git_ancestry("agent-hook-non-git-");
     let binding = bind(
         &fixture,
         "unmanaged-session",

--- a/crates/api-testing-core/src/suite/resolve.rs
+++ b/crates/api-testing-core/src/suite/resolve.rs
@@ -283,7 +283,7 @@ pub fn write_file(path: &Path, contents: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nils_test_support::{EnvGuard, GlobalStateLock};
+    use nils_test_support::{EnvGuard, GlobalStateLock, tempdir::ScopedTempDir};
 
     use tempfile::TempDir;
 
@@ -302,7 +302,7 @@ mod tests {
         let found = find_repo_root(&root.join("a/b/c")).unwrap();
         assert_eq!(found, root);
 
-        let tmp2 = TempDir::new().unwrap();
+        let tmp2 = ScopedTempDir::outside_git_ancestry("api-testing-core-non-git-");
         let err = find_repo_root(tmp2.path()).unwrap_err();
         assert!(format!("{err:#}").contains("Must run inside a git work tree"));
     }

--- a/crates/api-testing-core/tests/integration/cli_report.rs
+++ b/crates/api-testing-core/tests/integration/cli_report.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use api_testing_core::cli_report::{ReportMetadataConfig, build_report_metadata, endpoint_note};
-use nils_test_support::{EnvGuard, GlobalStateLock};
+use nils_test_support::{EnvGuard, GlobalStateLock, tempdir::ScopedTempDir};
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
@@ -34,7 +34,7 @@ fn assert_stamp_prefix(name: &str) {
 fn build_report_metadata_defaults_to_docs_dir() {
     let lock = GlobalStateLock::new();
     let _guard = EnvGuard::remove(&lock, "TEST_REPORT_DIR");
-    let tmp = TempDir::new().unwrap();
+    let tmp = ScopedTempDir::outside_git_ancestry("api-testing-core-report-non-git-");
     let metadata = build_report_metadata(report_config(
         "Hello World",
         None,

--- a/crates/nils-test-support/src/tempdir.rs
+++ b/crates/nils-test-support/src/tempdir.rs
@@ -10,6 +10,7 @@
 //! `ScopedTempDir` uses `TempDir::close`, which surfaces that error, and fails
 //! the test that produced it.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
@@ -37,6 +38,28 @@ impl ScopedTempDir {
         }
     }
 
+    /// Create a temporary directory whose canonical ancestry contains no Git
+    /// marker. Use this only when the fixture contract specifically requires a
+    /// non-repository path: the process temp root may itself be a Git checkout.
+    pub fn outside_git_ancestry(prefix: &str) -> Self {
+        // Keep the process temp root first. The full test gate points TMPDIR at
+        // a private leak-probe directory and must retain visibility into every
+        // fixture that can safely live there. Fall back only when that root is
+        // itself inside Git ancestry or cannot create the fixture.
+        let mut candidates = vec![std::env::temp_dir()];
+        if let Some(runtime_dir) = std::env::var_os("XDG_RUNTIME_DIR") {
+            candidates.push(PathBuf::from(runtime_dir));
+        }
+        #[cfg(unix)]
+        candidates.extend([PathBuf::from("/dev/shm"), PathBuf::from("/var/tmp")]);
+
+        let tempdir = tempdir_outside_git_ancestry(prefix, candidates)
+            .unwrap_or_else(|| panic!("no writable temporary root outside Git ancestry"));
+        Self {
+            inner: Some(tempdir),
+        }
+    }
+
     pub fn path(&self) -> &Path {
         self.inner
             .as_ref()
@@ -56,6 +79,35 @@ impl ScopedTempDir {
             None => Ok(()),
         }
     }
+}
+
+fn tempdir_outside_git_ancestry(
+    prefix: &str,
+    candidates: impl IntoIterator<Item = PathBuf>,
+) -> Option<TempDir> {
+    for candidate in candidates {
+        let Ok(candidate) = fs::canonicalize(candidate) else {
+            continue;
+        };
+        if has_git_ancestry(&candidate) {
+            continue;
+        }
+        let Ok(tempdir) = tempfile::Builder::new()
+            .prefix(prefix)
+            .tempdir_in(candidate)
+        else {
+            continue;
+        };
+        if !has_git_ancestry(tempdir.path()) {
+            return Some(tempdir);
+        }
+    }
+    None
+}
+
+fn has_git_ancestry(path: &Path) -> bool {
+    path.ancestors()
+        .any(|ancestor| fs::symlink_metadata(ancestor.join(".git")).is_ok())
 }
 
 impl Default for ScopedTempDir {
@@ -182,7 +234,30 @@ impl Drop for RestoredMode {
 
 #[cfg(test)]
 mod tests {
-    use super::{RestoredMode, ScopedTempDir};
+    use super::{RestoredMode, ScopedTempDir, has_git_ancestry, tempdir_outside_git_ancestry};
+
+    #[test]
+    fn outside_git_ancestry_never_inherits_a_repository_marker() {
+        let dir = ScopedTempDir::outside_git_ancestry("nils-test-support-non-git-");
+        assert!(!has_git_ancestry(dir.path()));
+    }
+
+    #[test]
+    fn outside_git_ancestry_skips_a_contaminated_candidate() {
+        let root = ScopedTempDir::outside_git_ancestry("nils-test-support-candidates-");
+        let contaminated = root.path().join("contaminated");
+        let clean = root.path().join("clean");
+        std::fs::create_dir_all(contaminated.join(".git")).expect("create Git marker");
+        std::fs::create_dir_all(&clean).expect("create clean candidate");
+
+        let selected = tempdir_outside_git_ancestry(
+            "nils-test-support-selected-",
+            [contaminated, clean.clone()],
+        )
+        .expect("clean fallback candidate");
+
+        assert!(selected.path().starts_with(clean));
+    }
 
     #[test]
     fn close_removes_the_directory() {

--- a/scripts/ci/tempdir-leak-probe.sh
+++ b/scripts/ci/tempdir-leak-probe.sh
@@ -20,10 +20,10 @@
 # before/after diff reports their entries as leaks. It also hides the real ones
 # — temp directories are dotfiles, and a plain `ls` does not list them.
 #
-# Do NOT point TMPDIR inside the repository work tree. Many tests assert that a
+# Do NOT point TMPDIR inside any repository work tree. Many tests assert that a
 # path is outside a git repository (`*_outside_git_repo`, `not_a_repo`), and a
-# TMPDIR under the checkout fails 131 of them across ~25 crates. The probe root
-# therefore defaults to the system temp directory.
+# TMPDIR with Git marker ancestry invalidates those fixtures. The probe therefore
+# selects the first writable system temp root outside Git marker ancestry.
 #
 # Compatibility: must run on macOS (system bash 3.2) and Linux runners. Avoid
 # associative arrays, mapfile, and `${var,,}` lowercasing.
@@ -43,8 +43,9 @@ nextest arguments are given.
   --runs <n>         repeat the run <n> times before checking (default: 1).
                      Several leaks are races that only lose sometimes; repeat
                      to raise the odds of catching one.
-  --probe-root <dir> where to create the private TMPDIR (default: the system
-                     temp directory). Must not be inside the repository.
+  --probe-root <dir> where to create the private TMPDIR (default: the first
+                     writable system temp root outside Git marker ancestry).
+                     Must not have Git marker ancestry.
   --allow <glob>     tolerate a surviving entry whose name matches <glob>.
                      Repeatable. Only for state a test deliberately reuses
                      across runs under a fixed name — such state is bounded, so
@@ -57,7 +58,8 @@ USAGE
 }
 
 runs=1
-probe_root="${TMPDIR:-/tmp}"
+probe_root=""
+probe_root_explicit=0
 allow_globs=()
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -90,6 +92,7 @@ while [ $# -gt 0 ]; do
         exit 2
       fi
       probe_root="$1"
+      probe_root_explicit=1
       shift
       ;;
     --)
@@ -115,20 +118,56 @@ if [ "$runs" -lt 1 ]; then
   echo "tempdir-leak-probe: --runs must be at least 1" >&2
   exit 2
 fi
+
+has_git_marker_ancestry() {
+  local cursor="$1"
+  local parent
+  while :; do
+    if [ -e "$cursor/.git" ] || [ -L "$cursor/.git" ]; then
+      return 0
+    fi
+    parent="$(dirname "$cursor")"
+    if [ "$parent" = "$cursor" ]; then
+      return 1
+    fi
+    cursor="$parent"
+  done
+}
+
+select_default_probe_root() {
+  local candidate
+  local candidate_abs
+  for candidate in "${TMPDIR:-}" "${XDG_RUNTIME_DIR:-}" /var/tmp /dev/shm /tmp; do
+    [ -n "$candidate" ] || continue
+    [ -d "$candidate" ] || continue
+    [ -w "$candidate" ] || continue
+    candidate_abs="$(cd "$candidate" && pwd -P)" || continue
+    if ! has_git_marker_ancestry "$candidate_abs"; then
+      printf '%s\n' "$candidate_abs"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [ "$probe_root_explicit" -eq 0 ]; then
+  if ! probe_root="$(select_default_probe_root)"; then
+    echo "tempdir-leak-probe: no writable system temp root outside Git marker ancestry" >&2
+    exit 2
+  fi
+fi
 if [ ! -d "$probe_root" ]; then
   echo "tempdir-leak-probe: not a directory: $probe_root" >&2
   exit 2
 fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-probe_root_abs="$(cd "$probe_root" && pwd)"
-case "$probe_root_abs/" in
-  "$repo_root"/*)
-    echo "tempdir-leak-probe: --probe-root must be outside the repository;" >&2
-    echo "  tests that assert a path is outside a git repo fail under it." >&2
-    exit 2
-    ;;
-esac
+probe_root_abs="$(cd "$probe_root" && pwd -P)"
+if has_git_marker_ancestry "$probe_root_abs"; then
+  echo "tempdir-leak-probe: --probe-root must be outside Git marker ancestry;" >&2
+  echo "  tests that assert a path is outside a git repo fail under it." >&2
+  exit 2
+fi
 
 if [ $# -eq 0 ]; then
   set -- --workspace

--- a/scripts/ci/tempdir-leak-probe.sh
+++ b/scripts/ci/tempdir-leak-probe.sh
@@ -181,6 +181,16 @@ trap cleanup EXIT
 
 cd "$repo_root"
 
+# Build before entering the disposable TMPDIR. Persistent compiler helpers such
+# as sccache retain the environment from their first request; starting one under
+# the probe directory would leave it pointing at a path cleanup removes before
+# later Rust commands run. The selected tests still execute under the private
+# directory below, which is the behavior this probe owns.
+if ! cargo nextest run --no-run "$@"; then
+  echo "tempdir-leak-probe: the test build failed" >&2
+  exit 1
+fi
+
 run_status=0
 i=1
 while [ "$i" -le "$runs" ]; do

--- a/scripts/ci/tests/tempdir-leak-probe.test.sh
+++ b/scripts/ci/tests/tempdir-leak-probe.test.sh
@@ -14,9 +14,11 @@ set -euo pipefail
 #   (c) a failing test run fails the probe even with no leak
 #   (d) a default temp root with Git ancestry is skipped without losing leak
 #       visibility
-#   (e) --probe-root with any Git ancestry is refused, because tests that
+#   (e) a cold persistent compiler helper does not retain the disposable probe
+#       TMPDIR after the run
+#   (f) --probe-root with any Git ancestry is refused, because tests that
 #       assert a path is outside a git repo break under it
-#   (f) usage errors exit 2
+#   (g) usage errors exit 2
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
@@ -69,6 +71,12 @@ write_cargo_stub() {
   local body="$1"
   {
     printf '%s\n' '#!/bin/sh'
+    printf '%s\n' 'if [ -n "${CARGO_STUB_PERSISTENT_TMPDIR_FILE:-}" ] && [ ! -e "$CARGO_STUB_PERSISTENT_TMPDIR_FILE" ]; then'
+    printf '%s\n' '  printf "%s\n" "${TMPDIR:-}" >"$CARGO_STUB_PERSISTENT_TMPDIR_FILE"'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'for arg in "$@"; do'
+    printf '%s\n' '  [ "$arg" = "--no-run" ] && exit 0'
+    printf '%s\n' 'done'
     printf '%s\n' "$body"
   } >"$work/bin/cargo"
   chmod +x "$work/bin/cargo"
@@ -185,6 +193,31 @@ if ! grep -q '.tmpDEFAULT_LEAK' "$work/out.txt"; then
   exit 1
 fi
 echo "ok: a safe fallback remains visible to the leak detector"
+
+echo "== a cold persistent helper keeps a stable TMPDIR after probe cleanup =="
+mkdir -p "$work/build-tmp"
+# The stub records the TMPDIR seen by its first invocation, like a persistent
+# compiler-cache server. Its actual test invocation and the follow-on compile
+# both require that retained directory to remain present.
+write_cargo_stub '[ -d "$(cat "$CARGO_STUB_PERSISTENT_TMPDIR_FILE")" ]'
+TMPDIR="$work/build-tmp" \
+  CARGO_STUB_PERSISTENT_TMPDIR_FILE="$work/persistent-tmpdir.txt" \
+  expect_status 0 "the probe prebuild starts persistent helpers outside its disposable TMPDIR"
+if [[ "$(cat "$work/persistent-tmpdir.txt")" != "$work/build-tmp" ]]; then
+  echo "FAIL: the persistent helper inherited the disposable probe TMPDIR"
+  cat "$work/persistent-tmpdir.txt"
+  exit 1
+fi
+status=0
+TMPDIR="$work/build-tmp" \
+  CARGO_STUB_PERSISTENT_TMPDIR_FILE="$work/persistent-tmpdir.txt" \
+  PATH="$work/bin:$PATH" \
+  cargo nextest run --workspace >/dev/null 2>&1 || status=$?
+if [[ "$status" -ne 0 ]]; then
+  echo "FAIL: a follow-on compile could not use the retained persistent-helper TMPDIR"
+  exit 1
+fi
+echo "ok: the persistent helper and follow-on compile retain a stable TMPDIR"
 
 echo "== --probe-root with Git ancestry is refused =="
 write_cargo_stub 'exit 0'

--- a/scripts/ci/tests/tempdir-leak-probe.test.sh
+++ b/scripts/ci/tests/tempdir-leak-probe.test.sh
@@ -12,9 +12,11 @@ set -euo pipefail
 #   (b) a run that leaves a directory behind fails, and names its contents —
 #       the contents are what identifies the writer
 #   (c) a failing test run fails the probe even with no leak
-#   (d) --probe-root inside the repository is refused, because tests that
+#   (d) a default temp root with Git ancestry is skipped without losing leak
+#       visibility
+#   (e) --probe-root with any Git ancestry is refused, because tests that
 #       assert a path is outside a git repo break under it
-#   (e) usage errors exit 2
+#   (f) usage errors exit 2
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
@@ -28,7 +30,36 @@ if [[ ! -f "$probe_script" ]]; then
   exit 2
 fi
 
-work="$(mktemp -d "${TMPDIR:-/tmp}/tempdir-leak-probe-test.XXXXXX")"
+has_git_marker_ancestry() {
+  local cursor="$1"
+  local parent
+  while :; do
+    if [[ -e "$cursor/.git" || -L "$cursor/.git" ]]; then
+      return 0
+    fi
+    parent="$(dirname "$cursor")"
+    if [[ "$parent" == "$cursor" ]]; then
+      return 1
+    fi
+    cursor="$parent"
+  done
+}
+
+test_root=""
+for candidate in /var/tmp /dev/shm "${TMPDIR:-}" /tmp; do
+  [[ -n "$candidate" && -d "$candidate" && -w "$candidate" ]] || continue
+  candidate="$(cd "$candidate" && pwd -P)"
+  if ! has_git_marker_ancestry "$candidate"; then
+    test_root="$candidate"
+    break
+  fi
+done
+if [[ -z "$test_root" ]]; then
+  echo "error: no writable test root outside Git marker ancestry" >&2
+  exit 2
+fi
+
+work="$(mktemp -d "$test_root/tempdir-leak-probe-test.XXXXXX")"
 trap 'rm -rf "$work"' EXIT
 mkdir -p "$work/bin" "$work/root"
 
@@ -126,7 +157,36 @@ if [[ "$(wc -l <"$work/runs.log" | tr -d ' ')" != "3" ]]; then
 fi
 echo "ok: --runs repeats the run"
 
-echo "== --probe-root inside the repository is refused =="
+echo "== a polluted default root falls back without losing leak visibility =="
+mkdir -p "$work/contaminated/.git"
+# shellcheck disable=SC2016 # the stub expands both variables at run time
+write_cargo_stub 'printf "%s\n" "$TMPDIR" >"$CARGO_STUB_LOG"; : >"$TMPDIR/.tmpDEFAULT_LEAK"'
+status=0
+CARGO_STUB_LOG="$work/selected-root.log" \
+  PATH="$work/bin:$PATH" \
+  TMPDIR="$work/contaminated" \
+  XDG_RUNTIME_DIR="$work/contaminated" \
+  bash "$probe_script" >"$work/out.txt" 2>&1 || status=$?
+if [[ "$status" -ne 1 ]]; then
+  echo "FAIL: a leak under the safe default fallback should exit 1, got $status"
+  cat "$work/out.txt"
+  exit 1
+fi
+selected_root="$(cat "$work/selected-root.log")"
+case "$selected_root/" in
+  "$work/contaminated"/*)
+    echo "FAIL: the default probe used a root with Git ancestry: $selected_root"
+    exit 1
+    ;;
+esac
+if ! grep -q '.tmpDEFAULT_LEAK' "$work/out.txt"; then
+  echo "FAIL: the fallback probe did not report the leaked entry"
+  cat "$work/out.txt"
+  exit 1
+fi
+echo "ok: a safe fallback remains visible to the leak detector"
+
+echo "== --probe-root with Git ancestry is refused =="
 write_cargo_stub 'exit 0'
 status=0
 PATH="$work/bin:$PATH" bash "$probe_script" --probe-root "$repo_root" >/dev/null 2>&1 || status=$?
@@ -134,7 +194,13 @@ if [[ "$status" -ne 2 ]]; then
   echo "FAIL: an in-repo probe root should exit 2, got $status"
   exit 1
 fi
-echo "ok: an in-repo probe root is refused"
+status=0
+PATH="$work/bin:$PATH" bash "$probe_script" --probe-root "$work/contaminated" >/dev/null 2>&1 || status=$?
+if [[ "$status" -ne 2 ]]; then
+  echo "FAIL: a probe root below an unrelated Git marker should exit 2, got $status"
+  exit 1
+fi
+echo "ok: probe roots with Git ancestry are refused"
 
 echo "== usage =="
 status=0


### PR DESCRIPTION
## Summary

Make non-repository test fixtures hermetic when the system temp root itself has Git marker ancestry, while keeping every fixture visible to the workspace temp-leak detector and keeping persistent compiler helpers outside its disposable test directory.

## Problem

- Expected: Tests that require a non-Git path remain independent of the host temp-directory ancestry, the leak probe observes every temporary fixture, and cleanup does not invalidate a persistent compiler helper.
- Actual: `tempfile::TempDir::new()` inherited `/tmp/.git`, breaking three negative fixtures; an initial fallback could escape probe observation; a cold `sccache` launched inside the probe retained its removed `TMPDIR`.
- Impact: The authoritative pre-PR gate blocked unrelated delivery, while incomplete repairs could make leak validation false-green or break the next Rust command.

## Reproduction

1. Place a `.git` marker at the system temp root.
2. Run the workspace-lease non-Git case, API repository-root negative case, or report default-root case and observe the fixture inherit that Git root.
3. Exercise the old fallback under the leak probe and observe that its fixture can escape the monitored private `TMPDIR`.
4. Start a cold persistent compiler cache while the probe owns `TMPDIR`, let cleanup remove it, then run another Rust command and observe the live helper reference the deleted path.

## Issues Found

- Refs #1505

## Fix Approach

Centralize non-Git fixture creation in `nils-test-support`, select only writable roots without Git marker ancestry, prefer the process `TMPDIR` so the leak probe retains visibility, and make the probe select or require a safe root. Prebuild the exact nextest selection before entering the disposable test `TMPDIR` so persistent compiler helpers retain a stable directory; the tests themselves still execute under the private probe root. Rust and shell regressions cover contaminated fallback, leak visibility, and the cold-helper follow-on lifecycle.

## Test-First Evidence

- RED: Unchanged v1.27.9 and v1.27.10 reproduced the workspace-lease failure with exit 69 (`workspace-git-unavailable`) under `/tmp/.git`.
- RED: Full-gate runs exposed the same invalid fixture assumption in API repository-root resolution and report metadata default-root tests.
- RED: Testing review proved the first fallback made a deliberate leak unobservable.
- RED: Current-head review reproduced a cold persistent compiler helper retaining the removed probe `TMPDIR` and breaking the next Rust compile.
- GREEN: Dedicated Rust and shell regressions pass for clean fallback, leak detection, and a cold helper followed by a second compile.

## Test plan

- `bash -n scripts/ci/tempdir-leak-probe.sh scripts/ci/tests/tempdir-leak-probe.test.sh` — passed.
- `bash scripts/ci/tests/tempdir-leak-probe.test.sh` — passed, including polluted fallback, deliberate leak detection, and cold persistent-helper follow-on compilation.
- `bash scripts/ci/tempdir-leak-probe.sh -- -p nils-test-support outside_git_ancestry` — 2/2 passed, zero leftovers.
- `cargo nextest run -p nils-agent-hook --test workspace_lease` — 13/13 passed.
- Focused API repository-root and report metadata cases — 1/1 passed each.
- `.agents/scripts/pre-pr.sh --full` — passed on signed head `00bc85b7`: audits, 8 project skill suites, formatting, all-target/all-feature clippy, 8,638 workspace tests under the safe leak probe with zero leftovers, and doctests.

## Risk / Notes

- Low production risk: production behavior is unchanged; changes affect test fixture selection and CI validation only.
- The probe fails closed when an explicit root has Git marker ancestry and exits with a usage error when no safe writable root exists.
- Testing, maintainability, security, API-contract, performance, and red-team current-head reviews found no remaining material issue after the cold-helper repair.
