### PR TITLE
fix(agent-session): gracefully stop profiled TUIs on delete

### DIFF
--- a/crates/agent-session/src/cli.rs
+++ b/crates/agent-session/src/cli.rs
@@ -171,6 +171,10 @@ pub struct StartArgs {
     #[arg(skip)]
     pub initial_profile_auto_resume_supported: Option<bool>,
 
+    /// Internal: bounded graceful shutdown mode owned by the selected profile.
+    #[arg(skip)]
+    pub initial_profile_graceful_shutdown: Option<String>,
+
     /// Internal: authoritative Codex usage account nickname for a `claude`
     /// launch profile that actually runs on a Codex/GPT backend. When set, the
     /// auto-resume loop keys off this Codex account's rate limits instead of

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -23055,7 +23055,7 @@ fi
             serde_json::json!("double-ctrl-c"),
         );
         write_session_record(&context, &record).unwrap();
-        let mut pane = TestProcessGroup::spawn();
+        let mut pane = ReapedTestProcessGroup::spawn();
         let tmux = tmp.path().join("tmux-profiled-graceful-delete-success");
         let calls = tmp
             .path()

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -79,6 +79,7 @@ const STARTUP_EXTRA_KEY: &str = "startup";
 const AGENT_PROFILE_RUNTIME_KEY: &str = "agent_profile";
 const AGENT_PROFILE_PROVIDER_CONFIG_DIR_RUNTIME_KEY: &str = "agent_profile_provider_config_dir";
 const AGENT_PROFILE_AUTO_RESUME_SUPPORTED_RUNTIME_KEY: &str = "agent_profile_auto_resume_supported";
+const AGENT_PROFILE_GRACEFUL_SHUTDOWN_RUNTIME_KEY: &str = "agent_profile_graceful_shutdown";
 const AGENT_PROFILE_CODEX_USAGE_ACCOUNT_RUNTIME_KEY: &str = "agent_profile_codex_usage_account";
 const PROVIDER_STOP_CANARY_RUNTIME_KEY: &str = "provider_stop_canary";
 const PROVIDER_STOP_CANARY_PROOF_RUNTIME_KEY: &str = "provider_stop_canary_proof";
@@ -150,6 +151,10 @@ const DELETE_TERMINATION_VERIFY_TIMEOUT: Duration = Duration::from_secs(1);
 const DELETE_TERMINATION_VERIFY_POLL_INTERVAL: Duration = Duration::from_millis(25);
 const DELETE_TERMINATION_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 const DELETE_TERMINATION_IDENTITY_RETRY_LIMIT: usize = 3;
+const DELETE_GRACEFUL_SHUTDOWN_TIMEOUT_MULTIPLIER: u32 = 8;
+const DELETE_GRACEFUL_SHUTDOWN_MAX_TIMEOUT: Duration = Duration::from_secs(8);
+const DELETE_GRACEFUL_SHUTDOWN_INPUT_INTERVAL: Duration = Duration::from_millis(500);
+const PROFILE_GRACEFUL_SHUTDOWN_DOUBLE_CTRL_C: &str = "double-ctrl-c";
 const DELETE_TMUX_PROBE_MAX_OUTPUT_BYTES: usize = 4 * 1024;
 #[cfg(target_os = "linux")]
 const SYSTEMD_SCOPE_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
@@ -1547,6 +1552,7 @@ pub(crate) struct ProviderResumeImportArgs {
     pub(crate) agent_profile: Option<String>,
     pub(crate) provider_config_dir: Option<PathBuf>,
     pub(crate) profile_auto_resume_supported: Option<bool>,
+    pub(crate) profile_graceful_shutdown: Option<String>,
     pub(crate) codex_usage_account: Option<String>,
     pub(crate) agent_args: Vec<String>,
     pub(crate) format: OutputFormat,
@@ -1898,6 +1904,7 @@ fn start_session_with_create_guard(
         args.initial_agent_profile.as_deref(),
         args.initial_provider_config_dir.as_deref(),
         args.initial_profile_auto_resume_supported,
+        args.initial_profile_graceful_shutdown.as_deref(),
         args.initial_codex_usage_account.as_deref(),
     )?;
     if let Err(err) = codex_account::set_initial_binding(
@@ -2412,6 +2419,7 @@ pub(crate) fn start_provider_resume_session(
         args.agent_profile.as_deref(),
         args.provider_config_dir.as_deref(),
         args.profile_auto_resume_supported,
+        args.profile_graceful_shutdown.as_deref(),
         args.codex_usage_account.as_deref(),
     )?;
 
@@ -2518,11 +2526,13 @@ fn persist_initial_profile_context(
     agent_profile: Option<&str>,
     provider_config_dir: Option<&Path>,
     profile_auto_resume_supported: Option<bool>,
+    profile_graceful_shutdown: Option<&str>,
     codex_usage_account: Option<&str>,
 ) -> Result<(), CliError> {
     if agent_profile.is_none()
         && provider_config_dir.is_none()
         && profile_auto_resume_supported.is_none()
+        && profile_graceful_shutdown.is_none()
         && codex_usage_account.is_none()
     {
         return Ok(());
@@ -2550,6 +2560,12 @@ fn persist_initial_profile_context(
         runtime.extra.insert(
             AGENT_PROFILE_AUTO_RESUME_SUPPORTED_RUNTIME_KEY.to_string(),
             json!(supported),
+        );
+    }
+    if let Some(mode) = profile_graceful_shutdown {
+        runtime.extra.insert(
+            AGENT_PROFILE_GRACEFUL_SHUTDOWN_RUNTIME_KEY.to_string(),
+            json!(mode),
         );
     }
     if let Some(account) = codex_usage_account {
@@ -11761,6 +11777,27 @@ pub(crate) fn session_profile_auto_resume_supported(record: &SessionRecord) -> b
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProfileGracefulShutdown {
+    DoubleCtrlC,
+}
+
+fn session_profile_graceful_shutdown(
+    record: &SessionRecord,
+) -> Result<Option<ProfileGracefulShutdown>, SessionTerminationFailure> {
+    let Some(mode) = runtime_extra_string(record, AGENT_PROFILE_GRACEFUL_SHUTDOWN_RUNTIME_KEY)
+    else {
+        return Ok(None);
+    };
+    if session_agent_profile(record).is_none() {
+        return Err(SessionTerminationFailure::RuntimeIdentityUnavailable);
+    }
+    match mode {
+        PROFILE_GRACEFUL_SHUTDOWN_DOUBLE_CTRL_C => Ok(Some(ProfileGracefulShutdown::DoubleCtrlC)),
+        _ => Err(SessionTerminationFailure::RuntimeIdentityUnavailable),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct DurableProfileResumeContext {
     profile_id: String,
@@ -12213,6 +12250,10 @@ fn delete_session_locked_with_timeouts(
         return finish_session_delete(context, record, session_dir, registry_fence);
     }
     let registry_fence = SessionRegistryFence::from_record(&record);
+    gracefully_shutdown_profiled_tmux_session(context, &mut record, tmux_bin, verify_timeout)
+        .map_err(|reason| {
+            session_termination_error(&record, reason, SessionTerminationOperation::Delete)
+        })?;
     terminate_tmux_session_with_timeouts(
         context,
         &mut record,
@@ -12373,6 +12414,7 @@ fn cleanup_session_delete_tombstones(context: &CliContext, limit: usize) -> io::
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum SessionTerminationFailure {
+    GracefulShutdownIncomplete,
     KillFailed,
     KillTimeout,
     KillError,
@@ -12431,6 +12473,7 @@ pub(crate) fn stop_session_runtime_locked(
 impl SessionTerminationFailure {
     fn reason(self) -> &'static str {
         match self {
+            Self::GracefulShutdownIncomplete => "graceful-shutdown-incomplete",
             Self::KillFailed => "kill-failed",
             Self::KillTimeout => "kill-timeout",
             Self::KillError => "kill-error",
@@ -12445,6 +12488,9 @@ impl SessionTerminationFailure {
 
     fn message(self) -> &'static str {
         match self {
+            Self::GracefulShutdownIncomplete => {
+                "the launch profile's graceful shutdown did not reach a verified stop"
+            }
             Self::KillFailed => "tmux kill-session failed",
             Self::KillTimeout => "tmux kill-session timed out",
             Self::KillError => "tmux kill-session could not be executed",
@@ -12888,6 +12934,126 @@ fn terminate_tmux_session_with_timeouts(
                     .map_err(|_| SessionTerminationFailure::RuntimeIdentityUnavailable)?;
                 return Ok(());
             }
+        }
+    }
+}
+
+fn gracefully_shutdown_profiled_tmux_session(
+    context: &CliContext,
+    record: &mut SessionRecord,
+    tmux_bin: &Path,
+    verify_timeout: Duration,
+) -> Result<(), SessionTerminationFailure> {
+    let Some(mode) = session_profile_graceful_shutdown(record)? else {
+        return Ok(());
+    };
+    if persisted_tmux_termination_state(record)?.is_some() {
+        return Ok(());
+    }
+    recover_interrupted_tmux_termination_locked(context, record)?;
+    let identity = match capture_tmux_runtime_identity(
+        context,
+        record,
+        tmux_bin,
+        verify_timeout.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+    )? {
+        TmuxRuntimeProbe::Stopped => return Ok(()),
+        TmuxRuntimeProbe::Running(identity) => *identity,
+    };
+    persist_tmux_runtime_identities(record, &identity, &[])?;
+    write_session_record(context, record)
+        .map_err(|_| SessionTerminationFailure::RuntimeIdentityUnavailable)?;
+
+    let graceful_timeout = verify_timeout
+        .saturating_mul(DELETE_GRACEFUL_SHUTDOWN_TIMEOUT_MULTIPLIER)
+        .min(DELETE_GRACEFUL_SHUTDOWN_MAX_TIMEOUT);
+    let started_at = Instant::now();
+    loop {
+        let remaining = graceful_timeout.saturating_sub(started_at.elapsed());
+        if remaining.is_zero() {
+            return Err(SessionTerminationFailure::GracefulShutdownIncomplete);
+        }
+        match mode {
+            ProfileGracefulShutdown::DoubleCtrlC => {
+                match tmux_send_ctrl_c_if_identity_matches(
+                    tmux_bin,
+                    &identity,
+                    remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+                ) {
+                    Ok(TmuxGracefulInputOutcome::Delivered) => {}
+                    Ok(TmuxGracefulInputOutcome::IdentityChanged) => {
+                        if verified_tmux_status_with_timeout(
+                            tmux_bin,
+                            &identity.session_id,
+                            remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+                        ) == "stopped"
+                        {
+                            return verify_stopped_tmux_runtime(tmux_bin, &identity, remaining)
+                                .map_err(|_| {
+                                    SessionTerminationFailure::GracefulShutdownIncomplete
+                                });
+                        }
+                        return Err(SessionTerminationFailure::RuntimeIdentityChanged);
+                    }
+                    Err(reason) => {
+                        if verified_tmux_status_with_timeout(
+                            tmux_bin,
+                            &identity.session_id,
+                            remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+                        ) == "stopped"
+                        {
+                            return verify_stopped_tmux_runtime(tmux_bin, &identity, remaining)
+                                .map_err(|_| {
+                                    SessionTerminationFailure::GracefulShutdownIncomplete
+                                });
+                        }
+                        return Err(reason);
+                    }
+                }
+            }
+        }
+        thread::sleep(
+            DELETE_GRACEFUL_SHUTDOWN_INPUT_INTERVAL
+                .min(graceful_timeout.saturating_sub(started_at.elapsed())),
+        );
+        let remaining = graceful_timeout.saturating_sub(started_at.elapsed());
+        if remaining.is_zero() {
+            return Err(SessionTerminationFailure::GracefulShutdownIncomplete);
+        }
+        match verified_tmux_status_with_timeout(
+            tmux_bin,
+            &identity.session_id,
+            remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+        )
+        .as_str()
+        {
+            "stopped" => {
+                return verify_stopped_tmux_runtime(tmux_bin, &identity, remaining)
+                    .map_err(|_| SessionTerminationFailure::GracefulShutdownIncomplete);
+            }
+            "running"
+                if !tmux_pane_identity_matches(
+                    tmux_bin,
+                    record,
+                    &identity.session_id,
+                    &identity.pane_id,
+                    identity.pane_pid,
+                    remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+                ) =>
+            {
+                if verified_tmux_status_with_timeout(
+                    tmux_bin,
+                    &identity.session_id,
+                    remaining.min(DELETE_TERMINATION_PROBE_TIMEOUT),
+                ) == "stopped"
+                {
+                    return verify_stopped_tmux_runtime(tmux_bin, &identity, remaining)
+                        .map_err(|_| SessionTerminationFailure::GracefulShutdownIncomplete);
+                }
+                return Err(SessionTerminationFailure::RuntimeIdentityChanged);
+            }
+            "running" | "unknown" => {}
+            _ => return Err(SessionTerminationFailure::VerificationFailed),
         }
     }
 }
@@ -15777,6 +15943,46 @@ fn tmux_output_reports_absent(output: &std::process::Output) -> bool {
     }
     let stderr = String::from_utf8_lossy(&output.stderr).to_ascii_lowercase();
     stderr.contains("can't find session:") || stderr.contains("no server running on")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TmuxGracefulInputOutcome {
+    Delivered,
+    IdentityChanged,
+}
+
+fn tmux_send_ctrl_c_if_identity_matches(
+    tmux_bin: &Path,
+    identity: &TmuxRuntimeIdentity,
+    timeout: Duration,
+) -> Result<TmuxGracefulInputOutcome, SessionTerminationFailure> {
+    let condition = format!(
+        "#{{&&:#{{==:#{{session_id}},{}}},#{{&&:#{{==:#{{pane_id}},{}}},#{{==:#{{pane_pid}},{}}}}}}}",
+        identity.session_id, identity.pane_id, identity.pane_pid
+    );
+    let mut command = ProcessCommand::new(tmux_bin);
+    command
+        .arg("if-shell")
+        .arg("-F")
+        .arg("-t")
+        .arg(&identity.pane_id)
+        .arg(condition)
+        .arg(format!("send-keys -t {} C-c", identity.pane_id))
+        .arg(format!(
+            "display-message -p {TMUX_RUNTIME_IDENTITY_CHANGED_OUTPUT}"
+        ));
+    let output = run_output_with_timeout(command, timeout)
+        .map_err(|_| SessionTerminationFailure::GracefulShutdownIncomplete)?;
+    if !output.status.success() {
+        return Err(SessionTerminationFailure::GracefulShutdownIncomplete);
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .map_err(|_| SessionTerminationFailure::VerificationFailed)?;
+    match stdout.trim() {
+        "" => Ok(TmuxGracefulInputOutcome::Delivered),
+        TMUX_RUNTIME_IDENTITY_CHANGED_OUTPUT => Ok(TmuxGracefulInputOutcome::IdentityChanged),
+        _ => Err(SessionTerminationFailure::VerificationFailed),
+    }
 }
 
 fn tmux_kill_identity_with_timeout(
@@ -22759,6 +22965,152 @@ fi
             "tmux must remain untouched without a cgroup"
         );
         assert_eq!(unsafe { libc::kill(descendant_pid, 0) }, 0);
+    }
+
+    #[test]
+    fn profiled_graceful_delete_sends_ctrl_c_and_never_falls_through_to_kill_session() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = test_context(tmp.path());
+        let id = create_test_record_id(
+            &context,
+            AgentKind::Hermes,
+            None,
+            Some("profiled-graceful-delete"),
+        );
+        let mut record = load_session_record(&context, &id).unwrap();
+        record
+            .runtime
+            .as_mut()
+            .unwrap()
+            .extra
+            .insert("agent_profile".to_string(), serde_json::json!("dsh-tui"));
+        record.runtime.as_mut().unwrap().extra.insert(
+            "agent_profile_graceful_shutdown".to_string(),
+            serde_json::json!("double-ctrl-c"),
+        );
+        write_session_record(&context, &record).unwrap();
+        let mut pane = TestProcessGroup::spawn();
+        let tmux = tmp.path().join("tmux-profiled-graceful-delete");
+        let calls = tmp.path().join("tmux-profiled-graceful-delete.calls");
+        fs::write(
+            &tmux,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {calls}\n{identity}if [ \"$1\" = has-session ]; then exit 0; fi\nif [ \"$1\" = if-shell ]; then exit 0; fi\nexit 42\n",
+                calls = calls.display(),
+                identity = deletion_identity_script(&context, &record, pane.pid()),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&tmux, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let error = delete_session_with_timeouts(
+            &context,
+            &id,
+            tmux,
+            Duration::from_millis(50),
+            Duration::from_millis(75),
+        )
+        .unwrap_err()
+        .into_inner();
+
+        assert_eq!(
+            error.details.unwrap()["reason"],
+            "graceful-shutdown-incomplete"
+        );
+        assert!(session_dir(&context, &id).exists());
+        let calls = fs::read_to_string(calls).unwrap();
+        assert!(
+            calls
+                .lines()
+                .any(|line| line.contains("send-keys") && line.contains("C-c")),
+            "profiled delete must first request the TUI's own disposal path: {calls}",
+        );
+        assert!(
+            !calls.contains("kill-session"),
+            "an incomplete graceful shutdown must retain the session instead of orphaning mutation state: {calls}",
+        );
+        assert_eq!(unsafe { libc::kill(pane.pid() as libc::pid_t, 0) }, 0);
+        pane.stop();
+    }
+
+    #[test]
+    fn profiled_graceful_delete_removes_the_record_after_verified_tui_exit() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = test_context(tmp.path());
+        let id = create_test_record_id(
+            &context,
+            AgentKind::Hermes,
+            None,
+            Some("profiled-graceful-delete-success"),
+        );
+        let mut record = load_session_record(&context, &id).unwrap();
+        record
+            .runtime
+            .as_mut()
+            .unwrap()
+            .extra
+            .insert("agent_profile".to_string(), serde_json::json!("dsh-tui"));
+        record.runtime.as_mut().unwrap().extra.insert(
+            "agent_profile_graceful_shutdown".to_string(),
+            serde_json::json!("double-ctrl-c"),
+        );
+        write_session_record(&context, &record).unwrap();
+        let mut pane = TestProcessGroup::spawn();
+        let tmux = tmp.path().join("tmux-profiled-graceful-delete-success");
+        let calls = tmp
+            .path()
+            .join("tmux-profiled-graceful-delete-success.calls");
+        let stopped = tmp.path().join("tmux-profiled-graceful-delete-stopped");
+        fs::write(
+            &tmux,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> {calls}
+if [ -f {stopped} ] && {{ [ "$1" = display-message ] || [ "$1" = has-session ]; }}; then
+  printf "%s\n" "can't find session: $91" >&2
+  exit 1
+fi
+{identity}if [ "$1" = has-session ]; then exit 0; fi
+if [ "$1" = if-shell ]; then
+  case "$*" in
+    *send-keys*)
+      count=$(grep -c send-keys {calls})
+      if [ "$count" -ge 3 ]; then
+        kill -TERM {pane_pid}
+        : > {stopped}
+        exit 1
+      fi
+      exit 0
+      ;;
+    *kill-session*) exit 42 ;;
+  esac
+fi
+exit 42
+"#,
+                calls = calls.display(),
+                stopped = stopped.display(),
+                identity = deletion_identity_script(&context, &record, pane.pid()),
+                pane_pid = pane.pid(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&tmux, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let result = delete_session_with_timeouts(
+            &context,
+            &id,
+            tmux,
+            Duration::from_millis(50),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        assert!(result.deleted);
+        assert!(!session_dir(&context, &id).exists());
+        let calls = fs::read_to_string(calls).unwrap();
+        assert!(calls.matches("send-keys").count() >= 3, "{calls}");
+        assert!(!calls.contains("kill-session"), "{calls}");
+        pane.stop();
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/agent-session/src/main_agent.rs
+++ b/crates/agent-session/src/main_agent.rs
@@ -4268,6 +4268,7 @@ fn run_worker_start_single_input(
                 initial_agent_profile: None,
                 initial_provider_config_dir: launch_provider_config_dir.clone(),
                 initial_profile_auto_resume_supported: None,
+                initial_profile_graceful_shutdown: None,
                 initial_codex_usage_account: None,
                 agent,
                 cwd: Some(PathBuf::from(&launch_input.launch.cwd)),

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -1006,7 +1006,8 @@ fn maintenance_failure_error(
     operation: MaintenanceOperation,
 ) -> CliError {
     let kind = match reason {
-        SessionTerminationFailure::StillRunning => "session_still_running",
+        SessionTerminationFailure::GracefulShutdownIncomplete
+        | SessionTerminationFailure::StillRunning => "session_still_running",
         SessionTerminationFailure::ProcessStillRunning => "process_boundary_live",
         SessionTerminationFailure::RuntimeIdentityChanged
         | SessionTerminationFailure::RuntimeIdentityMismatch => "runtime_identity_changed",

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -282,7 +282,22 @@ struct AgentLaunchProfile {
     provider_config_dir: Option<PathBuf>,
     readiness_args: Vec<String>,
     auto_resume_supported: bool,
+    graceful_shutdown: Option<AgentLaunchProfileGracefulShutdown>,
     codex_usage_account: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum AgentLaunchProfileGracefulShutdown {
+    DoubleCtrlC,
+}
+
+impl AgentLaunchProfileGracefulShutdown {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::DoubleCtrlC => "double-ctrl-c",
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -297,6 +312,8 @@ struct AgentLaunchProfileConfig {
     readiness_args: Vec<String>,
     #[serde(default)]
     auto_resume_supported: bool,
+    #[serde(default)]
+    graceful_shutdown: Option<AgentLaunchProfileGracefulShutdown>,
     /// Optional authoritative Codex usage account nickname for a `claude`
     /// profile that runs on a Codex/GPT backend. Absent leaves behavior
     /// unchanged (auto-resume keys off native Claude usage).
@@ -395,6 +412,7 @@ impl AgentLaunchProfiles {
                 provider_config_dir: config.provider_config_dir,
                 readiness_args: config.readiness_args,
                 auto_resume_supported: config.auto_resume_supported,
+                graceful_shutdown: config.graceful_shutdown,
                 codex_usage_account: config
                     .codex_usage_account
                     .map(|nick| nick.trim().to_string()),
@@ -3914,6 +3932,10 @@ async fn create_handler(
             profile_auto_resume_supported: launch_profile
                 .as_ref()
                 .map(|profile| profile.auto_resume_supported),
+            profile_graceful_shutdown: launch_profile
+                .as_ref()
+                .and_then(|profile| profile.graceful_shutdown)
+                .map(|mode| mode.as_str().to_string()),
             codex_usage_account: launch_profile
                 .as_ref()
                 .and_then(|profile| profile.codex_usage_account.clone()),
@@ -3952,6 +3974,10 @@ async fn create_handler(
         initial_profile_auto_resume_supported: launch_profile
             .as_ref()
             .map(|profile| profile.auto_resume_supported),
+        initial_profile_graceful_shutdown: launch_profile
+            .as_ref()
+            .and_then(|profile| profile.graceful_shutdown)
+            .map(|mode| mode.as_str().to_string()),
         initial_codex_usage_account: launch_profile
             .as_ref()
             .and_then(|profile| profile.codex_usage_account.clone()),
@@ -8416,6 +8442,52 @@ mod tests {
 
         fs::write(&launcher, "#!/usr/bin/env sh\nexit 1\n").unwrap();
         assert!(profiles.probe_ready_summaries().is_empty());
+    }
+
+    #[test]
+    fn launch_profiles_accept_a_bounded_double_ctrl_c_graceful_shutdown_contract() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let launcher = executable(
+            &tmp.path().join("dsh-tui-launcher"),
+            "#!/usr/bin/env sh\nexit 0\n",
+        );
+
+        let profiles = AgentLaunchProfiles::from_json(
+            &json!([{
+                "id": "dsh-tui",
+                "label": "DSH TUI",
+                "agent": "hermes",
+                "agent_bin": launcher,
+                "graceful_shutdown": "double-ctrl-c",
+            }])
+            .to_string(),
+        )
+        .expect("the fixed graceful-shutdown mode is valid server-owned profile metadata");
+
+        assert_eq!(profiles.entries.len(), 1);
+    }
+
+    #[test]
+    fn launch_profiles_reject_unknown_graceful_shutdown_contracts() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let launcher = executable(
+            &tmp.path().join("dsh-tui-launcher"),
+            "#!/usr/bin/env sh\nexit 0\n",
+        );
+
+        let error = AgentLaunchProfiles::from_json(
+            &json!([{
+                "id": "dsh-tui",
+                "label": "DSH TUI",
+                "agent": "hermes",
+                "agent_bin": launcher,
+                "graceful_shutdown": "force-kill",
+            }])
+            .to_string(),
+        )
+        .expect_err("unknown shutdown behavior must fail the server-owned profile parser closed");
+
+        assert_eq!(error.code(), "invalid-agent-launch-profiles");
     }
 
     #[test]
@@ -14710,6 +14782,7 @@ esac
                 "provider_config_dir":config_dir,
                 "readiness_args":["--check"],
                 "auto_resume_supported":false,
+                "graceful_shutdown":"double-ctrl-c",
             }])
             .to_string(),
         )
@@ -14773,6 +14846,14 @@ esac
             Some(config_dir)
         );
         assert!(!crate::session_profile_auto_resume_supported(&record));
+        assert_eq!(
+            record
+                .runtime
+                .as_ref()
+                .and_then(|runtime| runtime.extra.get("agent_profile_graceful_shutdown"))
+                .and_then(Value::as_str),
+            Some("double-ctrl-c")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Make tmux-backed launch profiles able to request a bounded, fail-closed graceful shutdown before session deletion so DSH can finish provider disposal and workspace-lease completion instead of being hard-killed.

## Problem

- Expected: deleting a trusted DSH launch profile asks the TUI to exit through its own disposal path, then removes metadata only after exact runtime-stop verification.
- Actual: deletion immediately killed the tmux/process boundary, so an in-flight workspace operation could remain active with no durable terminal outcome.
- Impact: a later fresh DSH session failed closed with `WORKSPACE_OPERATION_UNCERTAIN` until the exact orphan was reconciled.

## Reproduction

1. Start a tmux-backed DSH TUI launch profile and begin a workspace mutation.
2. Delete the owning Agent Console session while the mutation is active.
3. Observe that force termination can preempt provider disposal and leave the durable workspace operation active.

## Issues Found

- Supports [sympoies-infra Issue #213](https://github.com/serenvia/sympoies-infra/issues/213); this PR does not close that delivery plan.

## Fix Approach

- Add the strict server-owned `graceful_shutdown: "double-ctrl-c"` launch-profile contract.
- Persist the selected contract with session runtime metadata for create and provider-import paths.
- On delete, capture and persist exact tmux/process identity, send bounded Ctrl+C input only to that pane, and require verified natural exit.
- If graceful shutdown does not converge, retain the session and never fall through to `kill-session`; profiles without the contract keep existing behavior.

## Test-First Evidence

- RED: the strict launch-profile parser rejected `graceful_shutdown`.
- RED: profiled deletion returned `runtime-identity-unavailable` before any graceful input and could not satisfy the fail-closed contract.
- GREEN: parser, persistence, incomplete-shutdown, natural-exit, and exit-race coverage pass.
- The verified test-first record is supplied to the delivery gate.

## Test plan

- `cargo test -p nils-agent-session launch_profiles_`
- `cargo test -p nils-agent-session graceful_delete`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — 1,173/1,173 nextest cases plus fmt, all-target/all-feature clippy, docs hygiene, tempdir audits, and doctests passed.
- `.agents/scripts/pre-pr.sh` through the repository dispatcher — passed the same canonical package gate after commit.

## Risk / Notes

- The graceful mode is opt-in and fixed by the server profile parser; unknown modes fail closed.
- Input is bound to exact tmux session, pane, pid, launch identity, process group/session, and control-group evidence.
- The eight-second bound fits within Agent Console's ten-second daemon control deadline and covers the DSH disposer budget.
- Live Agent Console/DSH acceptance remains required after release promotion; this PR alone is not final Issue #213 acceptance.
