### PR TITLE
feat(agent-session): deliver safe coordination checkpoints

### DIFF
--- a/crates/agent-session/docs/provider-turn-signal-evidence.md
+++ b/crates/agent-session/docs/provider-turn-signal-evidence.md
@@ -41,7 +41,7 @@ created.
   structured turn failures and server requests. The audited 0.144.1/0.144.3
   schemas and live Unix
   WebSocket probe expose `Turn.status`, `Turn.error.codexErrorInfo`, the
-  `error` notification, `account/rateLimits/read`, `turn/start`, typed
+  `error` notification, `account/rateLimits/read`, `turn/start`, `turn/steer`, typed
   `RequestId` (`string | int64`), five admitted blocking request methods, and
   `serverRequest/resolved`.
 - [Claude Code hooks](https://code.claude.com/docs/en/hooks) documents parallel
@@ -139,8 +139,11 @@ terminal failed Turn carrying the same structured error, maps
 `usageLimitExceeded` to `usage_exhausted`. Wrong threads, wrong turns,
 non-terminal statuses, retrying errors, reordered partial envelopes, unknown
 values, malformed usage snapshots, and monitor gaps cannot arm or submit. Raw
-thread/turn ids are runtime-scoped SHA-256 projections before persistence;
-human error text, prompts, output, and auth/account payloads are discarded.
+thread/turn ids are runtime-scoped SHA-256 projections before persistence. For
+same-turn mailbox steering, the exact control incarnation retains the raw
+active turn id only in memory and sends it back to Codex after its projection
+matches durable activity; human error text, prompts, output, and auth/account
+payloads are discarded.
 
 The persisted rollout history is not used to recover failures because the live
 probe demonstrated that a failed quota turn can later appear as completed with

--- a/crates/agent-session/docs/specs/serve-api-v1.md
+++ b/crates/agent-session/docs/specs/serve-api-v1.md
@@ -225,7 +225,13 @@ recorded in `sympoies/nils-cli#1409`.
   and it exposes no mailbox body, receipt key, capability, incarnation, or
   provider turn identifier. The full state, adapter, and privacy contract is in
   [Session coordination v1](session-coordination-v1.md#notification-ownership).
-  Codex app-server runtimes use acknowledged structured submission.
+  Codex app-server runtimes use acknowledged structured submission: idle turns
+  use `turn/start`, while an authoritative active turn uses `turn/steer` with
+  its exact `expectedTurnId`. The control connection transiently maps the
+  durable projected turn fence back to the matching raw active turn id; raw
+  ids never enter session documents or API projections. Long-running work observes the body-free prompt
+  at the provider's next model checkpoint. Both paths retain the exact
+  incarnation and no-claim/no-operation generation fence.
   Terminal-backed Codex and Claude runtimes use the same notification-generation CAS
   plus exact incarnation, idle-turn, live-runtime, and detached-session
   rechecks before one fixed body-free prompt and a single Enter. The terminal

--- a/crates/agent-session/docs/specs/session-coordination-v1.md
+++ b/crates/agent-session/docs/specs/session-coordination-v1.md
@@ -648,8 +648,10 @@ authoritative-idle, detached, live-runtime, authoritative-broker, no-claim, and
 no-operation checks. The short `queued -> attempting` CAS is a per-session
 submission fence: claim and operation admission returns
 `coordination-notification-submission-in-progress` with typed retry guidance
-until the terminal submission boundary completes, while unrelated coordination
-registry work remains available. Claude additionally requires a `Stop` hook
+until the submission boundary completes. Stop, delete, resume, runtime
+replacement, and maintenance mutations for the exact incarnation share this
+admission fence, while account refresh and unrelated coordination registry
+work remain available. Claude additionally requires a `Stop` hook
 that survived a no-reactivation debounce. Terminal acceptance requires the
 byte-exact prompt as the content of a newer transcript-observed turn. A later
 provider observation reconciles `attempting` or `attempt_unknown`: an exact prompt proves

--- a/crates/agent-session/docs/specs/session-coordination-v1.md
+++ b/crates/agent-session/docs/specs/session-coordination-v1.md
@@ -631,8 +631,18 @@ restores the encoded generation and state; an acknowledged generation remains
 submitted, while an in-flight generation becomes `attempt_unknown` rather than
 being retried.
 
-App-server Codex uses prompt-v2 control and counts only an acknowledged turn
-submission. Terminal-backed Codex and Claude use the controller-owned
+App-server Codex uses prompt-v2 control. An authoritatively idle turn receives
+one acknowledged `turn/start`; an authoritative `working` or `needs_input`
+turn with an exact active provider turn id receives `turn/steer` fenced by
+`expectedTurnId`. Durable activity keeps only the runtime-scoped projection;
+the matching control incarnation retains the raw id transiently, proves its
+projection still equals that durable fence, and sends only the raw id back to
+Codex. The latter queues the body-free prompt for the provider's
+next in-turn model checkpoint instead of waiting for the whole task to become
+idle. Both paths count only the matching acknowledged turn id and require the
+same exact incarnation, authoritative broker, no active claim, and no active
+or uncertain operation before their generation CAS. Terminal-backed Codex and
+Claude use the controller-owned
 private-buffer paste plus a separate Enter after exact-incarnation,
 authoritative-idle, detached, live-runtime, authoritative-broker, no-claim, and
 no-operation checks. The short `queued -> attempting` CAS is a per-session
@@ -646,8 +656,11 @@ provider observation reconciles `attempting` or `attempt_unknown`: an exact prom
 `prompt_submitted`, a current transcript without it safely requeues, and
 unavailable observation leaves the attempt parked.
 
-Busy, attached, rate-limited, controller-unavailable, and provider-not-ready
-targets remain queued with a bounded safe reason. Replaced incarnations,
+Busy app-server Codex without an authoritative steerable turn, attached or
+busy terminal runtimes, rate-limited, controller-unavailable, and
+provider-not-ready targets remain queued with a bounded safe reason. A
+rejected or outcome-unknown `turn/steer` is retained as `attempt_unknown` for
+the same transcript-based reconciliation used by idle submission. Replaced incarnations,
 coordination-off sessions, Hermes, unmanaged sessions, and other unsupported
 providers are explicitly undeliverable. A non-app-server Codex generation
 previously marked `undeliverable` only for `provider-unsupported` may be re-queued by the

--- a/crates/agent-session/src/activity.rs
+++ b/crates/agent-session/src/activity.rs
@@ -1116,6 +1116,13 @@ fn projected_provider_identifier(
     Ok(format!("local:v1:{}", hex_digest(digest.finalize())))
 }
 
+pub(crate) fn projected_codex_turn_identifier(
+    runtime_id: &str,
+    value: &str,
+) -> Result<String, CliError> {
+    projected_provider_identifier(runtime_id, AgentKind::Codex, "turn", value)
+}
+
 fn hermes_approval_correlation_id(runtime_id: &str, raw: &Value) -> Result<String, CliError> {
     fn required_string<'a>(raw: &'a Value, field: &str) -> Result<&'a str, CliError> {
         raw.get(field).and_then(Value::as_str).ok_or_else(|| {

--- a/crates/agent-session/src/codex_app_server.rs
+++ b/crates/agent-session/src/codex_app_server.rs
@@ -10740,6 +10740,12 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
 
     #[tokio::test]
     async fn unix_control_projects_live_failure_and_acknowledges_exact_turn_without_content() {
+        let env_lock = GlobalStateLock::new();
+        let _broker = EnvGuard::set(
+            &env_lock,
+            "AGENT_SESSION_CODEX_ACCOUNT_BROKER",
+            r#"["/configured/broker"]"#,
+        );
         let tmp = tempfile::TempDir::new().unwrap();
         let socket = tmp.path().join("codex.sock");
         let listener = tokio::net::UnixListener::bind(&socket).unwrap();

--- a/crates/agent-session/src/codex_app_server.rs
+++ b/crates/agent-session/src/codex_app_server.rs
@@ -1464,6 +1464,7 @@ pub(crate) struct StructuredFailure {
 #[derive(Debug)]
 pub(crate) struct FailureReducer {
     thread_id: String,
+    active_turn_id: Option<String>,
     pending_turns: BTreeMap<String, Option<StructuredFailureKind>>,
     pending_order: VecDeque<String>,
     completed_turns: BTreeSet<String>,
@@ -1474,6 +1475,7 @@ impl FailureReducer {
     pub(crate) fn new(thread_id: impl Into<String>) -> Self {
         Self {
             thread_id: thread_id.into(),
+            active_turn_id: None,
             pending_turns: BTreeMap::new(),
             pending_order: VecDeque::new(),
             completed_turns: BTreeSet::new(),
@@ -1482,6 +1484,7 @@ impl FailureReducer {
     }
 
     pub(crate) fn ingest(&mut self, message: &Value) -> Option<StructuredFailure> {
+        self.observe_turn_lifecycle(message);
         match message.get("method").and_then(Value::as_str) {
             Some("error") => {
                 let params = message.get("params")?;
@@ -1543,6 +1546,50 @@ impl FailureReducer {
             }
             _ => None,
         }
+    }
+
+    fn observe_turn_lifecycle(&mut self, message: &Value) {
+        let method = message.get("method").and_then(Value::as_str);
+        let thread_id = message.pointer("/params/threadId").and_then(Value::as_str);
+        let turn_id = message
+            .pointer("/params/turn/id")
+            .and_then(Value::as_str)
+            .filter(|turn_id| protocol_id_is_valid(turn_id));
+        if thread_id != Some(self.thread_id.as_str()) {
+            return;
+        }
+        match (method, turn_id) {
+            (Some("turn/started"), Some(turn_id)) => self.note_started(turn_id),
+            (Some("turn/completed"), Some(turn_id))
+                if self.active_turn_id.as_deref() == Some(turn_id) =>
+            {
+                self.active_turn_id = None;
+            }
+            _ => {}
+        }
+    }
+
+    fn note_started(&mut self, turn_id: &str) {
+        if protocol_id_is_valid(turn_id) {
+            self.active_turn_id = Some(turn_id.to_string());
+        }
+    }
+
+    fn raw_turn_for_projection(
+        &self,
+        runtime_id: &str,
+        expected_projected_turn_id: &str,
+    ) -> Result<String, String> {
+        let raw_turn_id = self
+            .active_turn_id
+            .as_deref()
+            .ok_or_else(|| "Codex active turn identity is unavailable".to_string())?;
+        let projected = crate::activity::projected_codex_turn_identifier(runtime_id, raw_turn_id)
+            .map_err(|_| "Codex active turn identity is invalid".to_string())?;
+        if projected != expected_projected_turn_id {
+            return Err("Codex active turn changed before steering".to_string());
+        }
+        Ok(raw_turn_id.to_string())
     }
 }
 
@@ -1676,6 +1723,47 @@ pub(crate) fn continuation_request(id: u64, thread_id: &str, message: &str) -> V
     })
 }
 
+pub(crate) fn steering_request(
+    id: u64,
+    thread_id: &str,
+    expected_turn_id: &str,
+    message: &str,
+) -> Value {
+    json!({
+        "id": id,
+        "method": "turn/steer",
+        "params": {
+            "threadId": thread_id,
+            "expectedTurnId": expected_turn_id,
+            "input": [{ "type": "text", "text": message, "text_elements": [] }]
+        }
+    })
+}
+
+pub(crate) fn latest_turn_request(id: u64, thread_id: &str) -> Value {
+    json!({
+        "id": id,
+        "method": "thread/turns/list",
+        "params": {
+            "threadId": thread_id,
+            "limit": 1,
+            "sortDirection": "desc",
+            "itemsView": "notLoaded"
+        }
+    })
+}
+
+fn latest_in_progress_turn_id(result: &Value) -> Option<&str> {
+    let turn = result.get("data")?.as_array()?.first()?;
+    (turn.get("status").and_then(Value::as_str) == Some("inProgress"))
+        .then(|| {
+            turn.get("id")
+                .and_then(Value::as_str)
+                .filter(|id| protocol_id_is_valid(id))
+        })
+        .flatten()
+}
+
 pub(crate) fn loaded_thread_ids(result: &Value) -> Option<Vec<String>> {
     let data = result.get("data")?.as_array()?;
     data.iter()
@@ -1768,6 +1856,11 @@ pub(crate) enum ControlCommand {
         message: String,
         response: oneshot::Sender<Result<String, String>>,
     },
+    Steer {
+        message: String,
+        expected_turn_id: String,
+        response: oneshot::Sender<Result<String, String>>,
+    },
     Continue {
         message: String,
         response: oneshot::Sender<Result<String, String>>,
@@ -1834,6 +1927,32 @@ impl ControlHandle {
         })
         .await
         .map_err(|_| "codex turn submission timed out".to_string())?
+    }
+
+    pub(crate) async fn steer_prompt(
+        &self,
+        message: &str,
+        expected_turn_id: &str,
+    ) -> Result<String, String> {
+        let (response, receive) = oneshot::channel();
+        tokio::time::timeout(
+            CONTROL_RESPONSE_TIMEOUT,
+            self.sender.send(ControlCommand::Steer {
+                message: message.to_string(),
+                expected_turn_id: expected_turn_id.to_string(),
+                response,
+            }),
+        )
+        .await
+        .map_err(|_| "codex turn steering enqueue timed out".to_string())?
+        .map_err(|_| "codex control connection unavailable".to_string())?;
+        // Once the command is queued, the caller's durable notification fence
+        // must remain held until the bounded control handler answers or the
+        // connection closes. Timing out here would let a late provider write
+        // outlive that fence and overlap a newly admitted atomic operation.
+        receive
+            .await
+            .map_err(|_| "codex control connection closed".to_string())?
     }
 
     pub(crate) async fn bind_account(
@@ -2065,6 +2184,23 @@ async fn control_account_ready(
     record: &SessionRecord,
     external_auth_account: Option<&str>,
 ) -> Result<(), String> {
+    control_account_ready_with(context, record, external_auth_account, false).await
+}
+
+async fn control_terminal_account_ready(
+    context: &CliContext,
+    record: &SessionRecord,
+    external_auth_account: Option<&str>,
+) -> Result<(), String> {
+    control_account_ready_with(context, record, external_auth_account, true).await
+}
+
+async fn control_account_ready_with(
+    context: &CliContext,
+    record: &SessionRecord,
+    external_auth_account: Option<&str>,
+    allow_pending_next: bool,
+) -> Result<(), String> {
     let check_context = context.clone();
     let id = record.id.clone();
     let launch_id = record
@@ -2085,7 +2221,11 @@ async fn control_account_ready(
                 Some(json!({ "id": current.id })),
             ));
         }
-        crate::codex_account::ensure_input_allowed(&current)?;
+        if allow_pending_next {
+            crate::codex_account::ensure_terminal_input_allowed(&current)?;
+        } else {
+            crate::codex_account::ensure_input_allowed(&current)?;
+        }
         Ok::<_, CliError>(crate::codex_account::selected_account(&current))
     })
     .await
@@ -2194,6 +2334,7 @@ pub(crate) async fn run_control(
                     ));
                 }
                 ControlCommand::Prompt { response, .. }
+                | ControlCommand::Steer { response, .. }
                 | ControlCommand::Continue { response, .. } => {
                     let _ = response.send(Err(
                         "Codex account binding is not ready; retry the account switch".to_string(),
@@ -2355,6 +2496,117 @@ pub(crate) async fn run_control(
                                 .map(str::to_string)
                                 .ok_or_else(|| "Codex turn/start response omitted the acknowledged turn id".to_string())
                         });
+                        if let Ok(turn_id) = result.as_deref() {
+                            reducer.note_started(turn_id);
+                        }
+                        let _ = response.send(result);
+                    }
+                    ControlCommand::Steer {
+                        message,
+                        expected_turn_id,
+                        response,
+                    } => {
+                        if let Err(error) = control_terminal_account_ready(
+                            &context,
+                            &record,
+                            external_auth_account.as_deref(),
+                        )
+                        .await
+                        {
+                            let _ = response.send(Err(error));
+                            continue;
+                        }
+                        if reducer.active_turn_id.is_none() {
+                            request_id = request_id.saturating_add(1);
+                            if let Err(error) = send_json(
+                                &mut websocket,
+                                latest_turn_request(request_id, &thread_id),
+                            )
+                            .await
+                            {
+                                let _ = response.send(Err(error));
+                                return Err("Codex active turn recovery write failed".to_string());
+                            }
+                            let recovered = receive_response_with_timeout(
+                                &mut websocket,
+                                request_id,
+                                Some((&context, &record, &mut reducer)),
+                                external_auth_account
+                                    .as_deref()
+                                    .map(|account| (&context, &record, account)),
+                                CONTROL_RESPONSE_TIMEOUT,
+                            )
+                            .await
+                            .and_then(|value| {
+                                latest_in_progress_turn_id(&value)
+                                    .map(str::to_string)
+                                    .ok_or_else(|| {
+                                        "Codex active turn identity is unavailable".to_string()
+                                    })
+                            });
+                            match recovered {
+                                Ok(turn_id) => reducer.note_started(&turn_id),
+                                Err(error) => {
+                                    let _ = response.send(Err(error));
+                                    continue;
+                                }
+                            }
+                        }
+                        let runtime_id = record
+                            .runtime
+                            .as_ref()
+                            .map(|runtime| runtime.launch_id.as_str())
+                            .ok_or_else(|| "Codex runtime identity is missing".to_string())?;
+                        let raw_turn_id = match reducer
+                            .raw_turn_for_projection(runtime_id, &expected_turn_id)
+                        {
+                            Ok(turn_id) => turn_id,
+                            Err(error) => {
+                                let _ = response.send(Err(error));
+                                continue;
+                            }
+                        };
+                        request_id = request_id.saturating_add(1);
+                        if let Err(err) = send_json(
+                            &mut websocket,
+                            steering_request(
+                                request_id,
+                                &thread_id,
+                                &raw_turn_id,
+                                &message,
+                            ),
+                        )
+                        .await
+                        {
+                            let _ = response.send(Err(err));
+                            return Err("Codex turn steering request write failed".to_string());
+                        }
+                        let result = receive_response_with_timeout(
+                            &mut websocket,
+                            request_id,
+                            Some((&context, &record, &mut reducer)),
+                            external_auth_account
+                                .as_deref()
+                                .map(|account| (&context, &record, account)),
+                            CONTROL_SUBMISSION_TIMEOUT,
+                        )
+                        .await
+                        .and_then(|value| {
+                            let acknowledged = value
+                                .get("turnId")
+                                .and_then(Value::as_str)
+                                .ok_or_else(|| {
+                                    "Codex turn/steer response omitted the acknowledged turn id"
+                                        .to_string()
+                                })?;
+                            if acknowledged != raw_turn_id {
+                                return Err(
+                                    "Codex turn/steer response acknowledged a different turn id"
+                                        .to_string(),
+                                );
+                            }
+                            Ok(expected_turn_id)
+                        });
                         let _ = response.send(result);
                     }
                     ControlCommand::Continue { message, response } => {
@@ -2413,6 +2665,9 @@ pub(crate) async fn run_control(
                                 .map(str::to_string)
                                 .ok_or_else(|| "Codex turn/start response omitted the acknowledged turn id".to_string())
                         });
+                        if let Ok(turn_id) = result.as_deref() {
+                            reducer.note_started(turn_id);
+                        }
                         let _ = response.send(result);
                     }
                     ControlCommand::BindAccount { account, revision, response } => {
@@ -4258,6 +4513,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn steering_request_fences_the_exact_active_turn() {
+        assert_eq!(
+            steering_request(9, "thread-fixture", "turn-fixture", "mailbox checkpoint"),
+            json!({
+                "id": 9,
+                "method": "turn/steer",
+                "params": {
+                    "threadId": "thread-fixture",
+                    "expectedTurnId": "turn-fixture",
+                    "input": [{
+                        "type": "text",
+                        "text": "mailbox checkpoint",
+                        "text_elements": []
+                    }]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn latest_turn_recovery_requests_metadata_only_and_accepts_only_in_progress() {
+        assert_eq!(
+            latest_turn_request(10, "thread-fixture"),
+            json!({
+                "id": 10,
+                "method": "thread/turns/list",
+                "params": {
+                    "threadId": "thread-fixture",
+                    "limit": 1,
+                    "sortDirection": "desc",
+                    "itemsView": "notLoaded"
+                }
+            })
+        );
+        assert_eq!(
+            latest_in_progress_turn_id(&json!({
+                "data": [{"id": "raw-active-turn", "status": "inProgress", "items": []}],
+                "nextCursor": null
+            })),
+            Some("raw-active-turn")
+        );
+        assert_eq!(
+            latest_in_progress_turn_id(&json!({
+                "data": [{"id": "raw-completed-turn", "status": "completed", "items": []}],
+                "nextCursor": null
+            })),
+            None
+        );
+    }
+
     struct PendingMessageSink;
 
     impl futures_util::Sink<Message> for PendingMessageSink {
@@ -5651,6 +5957,30 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
     }
 
     #[tokio::test(start_paused = true)]
+    async fn queued_steer_waits_for_handler_so_its_durable_fence_cannot_expire_early() {
+        let (handle, mut commands) = control_channel();
+        let task = tokio::spawn(async move {
+            handle
+                .steer_prompt("mailbox checkpoint", "projected-active-turn")
+                .await
+        });
+        let command = commands.recv().await.expect("queued steer");
+        let ControlCommand::Steer { response, .. } = command else {
+            panic!("expected steer command");
+        };
+
+        tokio::time::advance(CONTROL_SUBMIT_TOTAL_TIMEOUT + Duration::from_secs(1)).await;
+        assert!(
+            !task.is_finished(),
+            "an enqueued steer must keep its caller-side fence until the handler answers"
+        );
+        response
+            .send(Ok("projected-active-turn".to_string()))
+            .expect("complete steer");
+        assert_eq!(task.await.unwrap().unwrap(), "projected-active-turn");
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn submit_timeout_covers_resume_plus_turn_acknowledgement_budget() {
         let (handle, mut commands) = control_channel();
         let responder = tokio::spawn(async move {
@@ -5710,6 +6040,45 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
             reducer.ingest(&error),
             None,
             "a completed turn cannot be re-armed"
+        );
+    }
+
+    #[test]
+    fn reducer_keeps_raw_active_turn_transient_and_matches_only_its_projection() {
+        let mut reducer = FailureReducer::new("thread-a");
+        reducer.ingest(&json!({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-a",
+                "turn": { "id": "raw-turn-a", "status": "inProgress" }
+            }
+        }));
+        let projected = crate::activity::projected_codex_turn_identifier("runtime-a", "raw-turn-a")
+            .expect("project raw active turn");
+        assert_eq!(
+            reducer
+                .raw_turn_for_projection("runtime-a", &projected)
+                .expect("match exact projection"),
+            "raw-turn-a"
+        );
+        assert!(
+            reducer
+                .raw_turn_for_projection("runtime-a", "local:v1:stale")
+                .is_err()
+        );
+
+        reducer.ingest(&json!({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-a",
+                "turn": { "id": "raw-turn-a", "status": "completed" }
+            }
+        }));
+        assert!(
+            reducer
+                .raw_turn_for_projection("runtime-a", &projected)
+                .is_err(),
+            "completed turns must no longer accept steering"
         );
     }
 
@@ -10271,6 +10640,105 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
     }
 
     #[tokio::test]
+    async fn unix_control_recovers_raw_active_turn_after_reconnect_before_steering() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let socket = tmp.path().join("reconnect.sock");
+        let listener = tokio::net::UnixListener::bind(&socket).unwrap();
+        let context = CliContext {
+            state_dir: tmp.path().join("state"),
+            host: None,
+        };
+        let record = record_with_runtime("reconnect-control", &socket);
+        fs::create_dir_all(crate::session_dir(&context, &record.id)).unwrap();
+        crate::write_session_record(&context, &record).unwrap();
+        crate::activity::activate_runtime(&context, &record).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let initialize = receive_json(&mut socket).await;
+            respond(&mut socket, &initialize, json!({})).await;
+            assert_eq!(receive_json(&mut socket).await["method"], "initialized");
+            let loaded = receive_json(&mut socket).await;
+            assert_eq!(loaded["method"], "thread/loaded/list");
+            respond(
+                &mut socket,
+                &loaded,
+                json!({"data": ["raw-reconnect-thread"], "nextCursor": null}),
+            )
+            .await;
+            let usage = receive_json(&mut socket).await;
+            assert_eq!(usage["method"], "account/rateLimits/read");
+            respond(
+                &mut socket,
+                &usage,
+                json!({
+                    "rateLimits": {
+                        "primary": {"usedPercent": 0.0, "resetsAt": null},
+                        "secondary": null
+                    }
+                }),
+            )
+            .await;
+
+            let recovery = receive_json(&mut socket).await;
+            assert_eq!(recovery["method"], "thread/turns/list");
+            assert_eq!(recovery["params"]["threadId"], "raw-reconnect-thread");
+            assert_eq!(recovery["params"]["itemsView"], "notLoaded");
+            respond(
+                &mut socket,
+                &recovery,
+                json!({
+                    "data": [{
+                        "id": "raw-recovered-active-turn",
+                        "status": "inProgress",
+                        "items": []
+                    }],
+                    "nextCursor": null,
+                    "backwardsCursor": null
+                }),
+            )
+            .await;
+            let steering = receive_json(&mut socket).await;
+            assert_eq!(steering["method"], "turn/steer");
+            assert_eq!(
+                steering["params"]["expectedTurnId"],
+                "raw-recovered-active-turn"
+            );
+            respond(
+                &mut socket,
+                &steering,
+                json!({"turnId": "raw-recovered-active-turn"}),
+            )
+            .await;
+        });
+
+        let (handle, commands) = control_channel();
+        let control_context = context.clone();
+        let control_record = record.clone();
+        let control =
+            tokio::spawn(
+                async move { run_control(control_context, control_record, commands).await },
+            );
+        let projected_turn_id = crate::activity::projected_codex_turn_identifier(
+            "runtime-reconnect-control",
+            "raw-recovered-active-turn",
+        )
+        .expect("project recovered active turn");
+        assert_eq!(
+            handle
+                .steer_prompt("mailbox checkpoint", &projected_turn_id)
+                .await
+                .unwrap(),
+            projected_turn_id
+        );
+        server.await.unwrap();
+        drop(handle);
+        control.abort();
+        let _ = control.await;
+    }
+
+    #[tokio::test]
     async fn unix_control_projects_live_failure_and_acknowledges_exact_turn_without_content() {
         let tmp = tempfile::TempDir::new().unwrap();
         let socket = tmp.path().join("codex.sock");
@@ -10423,6 +10891,17 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
                 json!({ "turn": { "id": "acknowledged-turn", "status": "inProgress" } }),
             )
             .await;
+            let steering = receive_json(&mut socket).await;
+            assert_eq!(steering["method"], "turn/steer");
+            assert_eq!(steering["params"]["threadId"], "raw-thread-a");
+            assert_eq!(steering["params"]["expectedTurnId"], "acknowledged-turn");
+            assert_eq!(steering["params"]["input"][0]["text"], "mailbox checkpoint");
+            respond(
+                &mut socket,
+                &steering,
+                json!({ "turnId": "acknowledged-turn" }),
+            )
+            .await;
         });
 
         let (handle, commands) = control_channel();
@@ -10439,6 +10918,31 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
         assert_eq!(
             handle.submit("private continuation").await.unwrap(),
             "acknowledged-turn"
+        );
+        assert_eq!(
+            crate::auto_resume::pending_sessions(&context, 1_893_456_000)
+                .unwrap()
+                .usage_ids,
+            vec![id.to_string()]
+        );
+        crate::codex_account::queue_next_account_with_unbound(
+            &context,
+            id,
+            "runtime-control",
+            "sym",
+        )
+        .expect("queue the next account during the active turn");
+        let projected_turn_id = crate::activity::projected_codex_turn_identifier(
+            "runtime-control",
+            "acknowledged-turn",
+        )
+        .expect("project active turn id");
+        assert_eq!(
+            handle
+                .steer_prompt("mailbox checkpoint", &projected_turn_id)
+                .await
+                .unwrap(),
+            projected_turn_id
         );
         server.await.unwrap();
         drop(handle);
@@ -10461,11 +10965,5 @@ printf '%s\n' "{\"schema_version\":\"agent-session.codex-auth-broker.v1\",\"acco
         ] {
             assert!(!activity.contains(secret));
         }
-        assert_eq!(
-            crate::auto_resume::pending_sessions(&context, 1_893_456_000)
-                .unwrap()
-                .usage_ids,
-            vec![id.to_string()]
-        );
     }
 }

--- a/crates/agent-session/src/coordination/mod.rs
+++ b/crates/agent-session/src/coordination/mod.rs
@@ -1950,7 +1950,7 @@ pub(crate) fn ensure_notification_submission_not_in_progress(
     if notification::submission_fences_session(registry, session_id, incarnation) {
         return Err(CliError::unavailable(
             "coordination-notification-submission-in-progress",
-            "claim or operation admission is fenced during exact terminal notification submission",
+            "claim, operation, or session lifecycle admission is fenced during exact notification submission",
             Some(serde_json::json!({
                 "retryable": true,
                 "next_action": "wait-for-notification-outcome",
@@ -1963,6 +1963,15 @@ pub(crate) fn ensure_notification_submission_not_in_progress(
         ));
     }
     Ok(())
+}
+
+pub(crate) fn ensure_notification_submission_not_in_progress_for_session(
+    context: &CliContext,
+    session_id: &str,
+    incarnation: &str,
+) -> Result<(), CliError> {
+    let locked = lock_registry(context)?;
+    ensure_notification_submission_not_in_progress(&locked.registry, session_id, incarnation)
 }
 
 pub(crate) fn mark_notification_submitted(

--- a/crates/agent-session/src/coordination/notification.rs
+++ b/crates/agent-session/src/coordination/notification.rs
@@ -725,6 +725,7 @@ fn safe_reason(reason: &str) -> String {
         | "prompt-accepted"
         | "recipient-working"
         | "recipient-attached"
+        | "recipient-coordination-not-quiescent"
         | "provider-not-ready"
         | "controller-unavailable"
         | "rate-limited"
@@ -1121,6 +1122,21 @@ mod tests {
         assert!(serialized.contains("notification-state-invalid"));
         assert!(!serialized.contains("target"));
         assert!(!serialized.contains("incarnation"));
+    }
+
+    #[test]
+    fn notification_projection_preserves_safe_checkpoint_quiescence_reason() {
+        let mut registry = Registry::default();
+        schedule(&mut registry, "target", "incarnation", 100);
+        let receipt = registry.notifications.values_mut().next().expect("receipt");
+        receipt.last_reason = Some("recipient-coordination-not-quiescent".to_string());
+
+        let projection =
+            projection_for(&mut registry, "target", "incarnation", false).expect("projection");
+        assert_eq!(
+            projection.last_reason.as_deref(),
+            Some("recipient-coordination-not-quiescent")
+        );
     }
 
     #[test]

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -2581,6 +2581,25 @@ fn persist_initial_profile_context(
     Ok(())
 }
 
+pub(crate) fn ensure_session_lifecycle_mutation_allowed(
+    context: &CliContext,
+    record: &SessionRecord,
+) -> Result<(), CliError> {
+    let Some(incarnation) = record
+        .runtime
+        .as_ref()
+        .map(|runtime| runtime.launch_id.as_str())
+        .filter(|incarnation| !incarnation.is_empty())
+    else {
+        return Ok(());
+    };
+    coordination::ensure_notification_submission_not_in_progress_for_session(
+        context,
+        &record.id,
+        incarnation,
+    )
+}
+
 struct CreatedRecord {
     record: SessionRecord,
     prompt_file: Option<PathBuf>,
@@ -9740,6 +9759,7 @@ fn resume_session_locked(
     mut record: SessionRecord,
     tmux_bin: &Path,
 ) -> Result<ResumeSessionOutcome, CliError> {
+    ensure_session_lifecycle_mutation_allowed(context, &record)?;
     orchestration::ensure_session_not_quarantined(context, &record)?;
     match session_status(context, tmux_bin, &record).as_str() {
         "running" => {
@@ -12207,6 +12227,7 @@ fn delete_session_locked_with_timeouts(
     kill_timeout: Duration,
     verify_timeout: Duration,
 ) -> Result<DeleteResult, CliError> {
+    ensure_session_lifecycle_mutation_allowed(context, &record)?;
     if dsh_external::is_external_record(&record) {
         // There is no tmux runtime to terminate, so deletion is admitted only
         // on positive evidence: the external runtime never attached, or the
@@ -12276,6 +12297,7 @@ fn delete_session_locked_after_failed_canary_proof(
     tmux_bin: &Path,
     proof: ProviderStopCanaryFailedStartupQuiescenceProof,
 ) -> Result<DeleteResult, CliError> {
+    ensure_session_lifecycle_mutation_allowed(context, &record)?;
     if !proof.matches(&record) || session_status(context, tmux_bin, &record) != "stopped" {
         return Err(session_termination_error(
             &record,
@@ -12293,6 +12315,7 @@ fn finish_session_delete(
     session_dir: PathBuf,
     registry_fence: SessionRegistryFence,
 ) -> Result<DeleteResult, CliError> {
+    ensure_session_lifecycle_mutation_allowed(context, &record)?;
     coordination::revoke(context, &record)?;
     codex_app_server::cleanup_runtime_files(context, &record)?;
     let cleanup_pending = commit_session_directory_delete(context, &record.id, &session_dir)?;
@@ -12449,6 +12472,7 @@ pub(crate) fn stop_session_runtime_locked(
     record: &mut SessionRecord,
     tmux_bin: &Path,
 ) -> Result<(), CliError> {
+    ensure_session_lifecycle_mutation_allowed(context, record)?;
     if dsh_external::is_external_record(record) {
         return Err(CliError::usage(
             "dsh-runtime-plugin-owned",

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -760,6 +760,8 @@ fn execute_inner(
         return Err(stale_preview_error(&record));
     }
 
+    crate::ensure_session_lifecycle_mutation_allowed(context, &record)?;
+
     if matches!(
         request.action,
         MaintenanceActionId::RetryResume | MaintenanceActionId::TerminateRuntimeThenResume

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -92,6 +92,10 @@ impl MaintenanceActionId {
         )
     }
 
+    fn mutates_session_state(self) -> bool {
+        !matches!(self, Self::RetryAttach | Self::Inspect)
+    }
+
     /// Whether this action signals a process or tmux runtime.
     ///
     /// Record-only removal deliberately signals nothing, so it must never claim
@@ -760,7 +764,9 @@ fn execute_inner(
         return Err(stale_preview_error(&record));
     }
 
-    crate::ensure_session_lifecycle_mutation_allowed(context, &record)?;
+    if request.action.mutates_session_state() {
+        crate::ensure_session_lifecycle_mutation_allowed(context, &record)?;
+    }
 
     if matches!(
         request.action,

--- a/crates/agent-session/src/maintenance.rs
+++ b/crates/agent-session/src/maintenance.rs
@@ -1055,6 +1055,7 @@ fn sanitize_maintenance_error(
             | "invalid-maintenance-preview-digest"
             | "maintenance-confirmation-required"
             | "session-maintenance-failed"
+            | "coordination-notification-submission-in-progress"
             | "agent-profile-unavailable"
             | "worker-quarantined"
     ) {

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -5118,8 +5118,28 @@ async fn dispatch_coordination_notification(
             .await;
         return;
     }
-    let waiting = activity::state_for_view(&state.context, &record)
+    let turn = activity::state_for_view(&state.context, &record);
+    let waiting = turn
+        .as_ref()
         .is_some_and(|turn| turn.phase == activity::TurnPhase::Waiting);
+    if codex_app_server::runtime_is_supported(&record)
+        && let Some(active_turn_id) = turn.as_ref().and_then(|turn| {
+            (matches!(
+                turn.phase,
+                activity::TurnPhase::Working | activity::TurnPhase::NeedsInput
+            ) && turn.source.confidence == activity::Confidence::Authoritative)
+                .then(|| {
+                    turn.current_turn
+                        .as_ref()
+                        .and_then(|current| current.provider_turn_id.clone())
+                })
+                .flatten()
+        })
+    {
+        dispatch_codex_in_turn_coordination_checkpoint(state, record, candidate, active_turn_id)
+            .await;
+        return;
+    }
     if !waiting {
         update_notification_deferred(
             &state,
@@ -5169,6 +5189,138 @@ async fn dispatch_coordination_notification(
             "provider-not-ready",
             COORDINATION_NOTIFICATION_RETRY,
         )
+        .await;
+    }
+}
+
+async fn dispatch_codex_in_turn_coordination_checkpoint(
+    state: Arc<ServeState>,
+    record: SessionRecord,
+    candidate: crate::coordination::NotificationCandidate,
+    expected_turn_id: String,
+) {
+    let launch_id = candidate.target_incarnation.clone();
+    let handle = match wait_for_structured_prompt_control(
+        &state,
+        &record.id,
+        &launch_id,
+        Some(&launch_id),
+        STRUCTURED_PROMPT_CONTROL_WAIT,
+    )
+    .await
+    {
+        Ok(handle) => handle,
+        Err(_) => {
+            update_notification_deferred(
+                &state,
+                &candidate,
+                "provider-not-ready",
+                COORDINATION_NOTIFICATION_RETRY,
+            )
+            .await;
+            return;
+        }
+    };
+    let prompt = crate::coordination::notification_prompt("", &candidate.target_session_id);
+    let lock_context = state.context.clone();
+    let lock_id = record.id.clone();
+    let lock_launch_id = launch_id.clone();
+    let lock_turn_id = expected_turn_id.clone();
+    let fence = candidate.clone();
+    let locked = tokio::task::spawn_blocking(move || {
+        let record_lock = crate::acquire_session_record_lock(&lock_context, &lock_id)?;
+        let mut current = load_session_record(&lock_context, &lock_id)?;
+        if current
+            .runtime
+            .as_ref()
+            .map(|runtime| runtime.launch_id.as_str())
+            != Some(lock_launch_id.as_str())
+            || !codex_app_server::runtime_is_supported(&current)
+        {
+            return Err(structured_prompt_incarnation_conflict(
+                &current.id,
+                &lock_launch_id,
+                current
+                    .runtime
+                    .as_ref()
+                    .map(|runtime| runtime.launch_id.as_str()),
+            ));
+        }
+        let eligible = activity::state_for_view(&lock_context, &current).is_some_and(|turn| {
+            matches!(
+                turn.phase,
+                activity::TurnPhase::Working | activity::TurnPhase::NeedsInput
+            ) && turn.source.confidence == activity::Confidence::Authoritative
+                && turn
+                    .current_turn
+                    .as_ref()
+                    .and_then(|active| active.provider_turn_id.as_deref())
+                    == Some(lock_turn_id.as_str())
+        });
+        if !eligible {
+            return Err(CliError::unavailable(
+                "coordination-checkpoint-turn-changed",
+                "the active turn changed before the coordination checkpoint",
+                None,
+            ));
+        }
+        crate::codex_account::authorize_terminal_input_locked(&lock_context, &mut current)?;
+        crate::codex_account::ensure_terminal_input_allowed(&current)?;
+        let mut quiescence = crate::coordination::lock_session_quiescence(
+            &lock_context,
+            &fence.target_session_id,
+            &fence.target_incarnation,
+        )?;
+        if !quiescence.begin_notification_attempt(&fence)? {
+            return Err(CliError::unavailable(
+                "coordination-checkpoint-not-quiescent",
+                "the recipient has an active claim or operation",
+                None,
+            ));
+        }
+        Ok::<_, CliError>(record_lock)
+    })
+    .await;
+    let record_lock = match locked {
+        Ok(Ok(record_lock)) => record_lock,
+        Ok(Err(err)) if err.code() == "coordination-checkpoint-not-quiescent" => {
+            update_notification_deferred(
+                &state,
+                &candidate,
+                "recipient-coordination-not-quiescent",
+                COORDINATION_NOTIFICATION_RETRY,
+            )
+            .await;
+            return;
+        }
+        Ok(Err(_)) | Err(_) => {
+            update_notification_deferred(
+                &state,
+                &candidate,
+                "recipient-working",
+                COORDINATION_NOTIFICATION_RETRY,
+            )
+            .await;
+            return;
+        }
+    };
+
+    let response = handle.steer_prompt(&prompt, &expected_turn_id).await;
+    drop(record_lock);
+    let context = state.context.clone();
+    if response.as_deref() == Ok(expected_turn_id.as_str()) {
+        let _ = tokio::task::spawn_blocking(move || {
+            crate::coordination::mark_notification_submitted(&context, &candidate)
+        })
+        .await;
+    } else {
+        let _ = tokio::task::spawn_blocking(move || {
+            crate::coordination::mark_notification_unknown(
+                &context,
+                &candidate,
+                "submission-outcome-unknown",
+            )
+        })
         .await;
     }
 }
@@ -25284,6 +25436,289 @@ exit 0
             "untrusted_peer_data"
         );
         assert_eq!(shown["data"]["coordination"]["body"]["text"], canary);
+    }
+
+    #[tokio::test]
+    async fn coordination_notification_working_codex_uses_safe_in_turn_checkpoint() {
+        let lock = GlobalStateLock::new();
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let codex_home = tmp.path().join("codex-home");
+        let transcript = codex_home.join("sessions/2030/01/active.jsonl");
+        fs::create_dir_all(transcript.parent().expect("transcript parent"))
+            .expect("transcript dir");
+        let provider_id = "notification-active-provider";
+        let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
+        seed_session_with_runtime(tmp.path(), "alpha", "codex", "hs-codex-alpha");
+        let launch_id = seed_codex_app_server_session(tmp.path(), "beta");
+        let record_path = tmp.path().join("sessions/beta/session.json");
+        let mut record: Value =
+            serde_json::from_slice(&fs::read(&record_path).expect("beta record"))
+                .expect("beta json");
+        record["provider_resume"] = json!({
+            "provider": "codex",
+            "session_id": provider_id,
+            "captured_at": "2030-01-01T00:00:00Z",
+            "capture_method": "fixture",
+            "resume_args": []
+        });
+        fs::write(
+            &record_path,
+            serde_json::to_vec_pretty(&record).expect("beta record json"),
+        )
+        .expect("write beta provider resume");
+        let state = state(tmp.path(), Some(TOKEN), minimal_tmux(tmp.path()));
+        let alpha = load_session_record(&state.context, "alpha").expect("alpha");
+        let beta = load_session_record(&state.context, "beta").expect("beta");
+        let alpha_capability = provision_ready_coordination_fixture(&state.context, &alpha);
+        provision_ready_coordination_fixture(&state.context, &beta);
+        crate::activity::activate_runtime(&state.context, &beta).expect("activate beta");
+        let turn = serde_json::from_value(json!({
+            "schema_version": crate::activity::TURN_EVENT_VERSION,
+            "event_id": "notification-active-turn-start",
+            "runtime_id": launch_id,
+            "provider": "codex",
+            "provider_session_id": provider_id,
+            "provider_turn_id": "notification-active-turn",
+            "kind": "turn_started",
+            "confidence": "authoritative"
+        }))
+        .expect("activity event");
+        crate::activity::ingest_event(&state.context, &beta.id, turn).expect("ingest");
+        let projected_turn_id = crate::activity::state_for_view(&state.context, &beta)
+            .and_then(|turn| turn.current_turn)
+            .and_then(|turn| turn.provider_turn_id)
+            .expect("projected active turn id");
+        assert_ne!(projected_turn_id, "notification-active-turn");
+        crate::codex_account::queue_next_account_with_unbound(
+            &state.context,
+            &beta.id,
+            &launch_id,
+            "sym",
+        )
+        .expect("queue next account during the active turn");
+
+        let canary = "ACTIVE-TURN-MAILBOX-BODY-MUST-NOT-REACH-CHECKPOINT";
+        let (status, sent) = call(
+            router(state.clone()),
+            post_coordination(
+                "/sessions/beta/messages/v1",
+                alpha_capability.trim(),
+                json!({
+                    "body": canary,
+                    "idempotency_key": "notification-active-turn-0001",
+                    "reply_to": null,
+                    "expires_in": null
+                }),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{sent}");
+
+        let (handle, mut commands) = codex_app_server::control_channel();
+        state.codex_controls.lock().unwrap().insert(
+            beta.id.clone(),
+            CodexControlEntry {
+                launch_id: launch_id.clone(),
+                handle,
+            },
+        );
+
+        let registry_path = tmp.path().join("coordination/registry.json");
+        let mut registry: Value =
+            serde_json::from_slice(&fs::read(&registry_path).expect("registry"))
+                .expect("registry json");
+        registry["operations"]
+            .as_array_mut()
+            .expect("operations")
+            .push(json!({
+                "schema_version": "agent-session.operation-lease.v1",
+                "lease_id": "active-turn-checkpoint-operation",
+                "session_id": "beta",
+                "session_incarnation": launch_id,
+                "claim_id": "active-turn-checkpoint-claim",
+                "claim_revision": 1,
+                "operation": "atomic mutation",
+                "targets": [],
+                "provider_targets": [],
+                "state": "active",
+                "revision": 1,
+                "started_at": "2030-01-01T00:00:00Z",
+                "expires_at": "9999-12-31T23:59:59Z",
+                "expires_at_epoch": i64::MAX,
+                "terminal_at_epoch": null,
+                "execution_token_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "activity_revision": 1,
+                "activity_identity_digest": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "runtime_identity_digest": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "descendant": null,
+                "reconcile_observed_at_epoch": null,
+                "outcome": null
+            }));
+        fs::write(
+            &registry_path,
+            serde_json::to_vec_pretty(&registry).expect("registry json"),
+        )
+        .expect("write active operation");
+        drain_coordination_notifications(state.clone()).await;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), commands.recv())
+                .await
+                .is_err(),
+            "an active atomic operation must defer the in-turn checkpoint"
+        );
+        assert_eq!(
+            notification_fixture(tmp.path())["last_reason"],
+            "recipient-coordination-not-quiescent"
+        );
+
+        let mut registry: Value =
+            serde_json::from_slice(&fs::read(&registry_path).expect("registry"))
+                .expect("registry json");
+        registry["operations"] = json!([]);
+        registry["notifications"]
+            .as_object_mut()
+            .expect("notifications")
+            .values_mut()
+            .next()
+            .expect("notification")["next_attempt_at_epoch"] = json!(0);
+        fs::write(
+            &registry_path,
+            serde_json::to_vec_pretty(&registry).expect("registry json"),
+        )
+        .expect("clear active operation");
+        let responder = tokio::spawn(async move {
+            let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
+                .await
+                .expect("working Codex notification must reach an in-turn checkpoint")
+                .expect("Codex control command");
+            let codex_app_server::ControlCommand::Steer {
+                message,
+                expected_turn_id,
+                response,
+            } = command
+            else {
+                panic!("working Codex notification must use turn/steer");
+            };
+            assert_eq!(expected_turn_id, projected_turn_id);
+            assert_eq!(
+                message,
+                crate::coordination::notification_prompt("", "beta")
+            );
+            assert!(!message.contains(canary));
+            response
+                .send(Ok(expected_turn_id))
+                .expect("acknowledge checkpoint");
+        });
+
+        drain_coordination_notifications(state.clone()).await;
+        responder.await.expect("checkpoint responder");
+
+        let notification = notification_fixture(tmp.path());
+        assert_eq!(notification["state"], "prompt_submitted");
+        assert_eq!(notification["generation"], 1);
+        assert_eq!(notification["notified_generation"], 1);
+        let registry: Value = serde_json::from_slice(
+            &fs::read(tmp.path().join("coordination/registry.json")).expect("registry"),
+        )
+        .expect("registry json");
+        assert_eq!(registry["messages"][0]["state"], "unread");
+
+        send_notification_fixture(
+            &state,
+            &alpha_capability,
+            "notification-active-turn-unknown-0002",
+        )
+        .await;
+        let (handle, mut commands) = codex_app_server::control_channel();
+        state.codex_controls.lock().unwrap().insert(
+            beta.id.clone(),
+            CodexControlEntry {
+                launch_id: launch_id.clone(),
+                handle,
+            },
+        );
+
+        let drain = tokio::spawn(drain_coordination_notifications(state.clone()));
+        let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
+            .await
+            .expect("unknown steer attempt")
+            .expect("steer command");
+        let codex_app_server::ControlCommand::Steer {
+            expected_turn_id,
+            response,
+            ..
+        } = command
+        else {
+            panic!("active notification retry must use turn/steer");
+        };
+        assert_eq!(
+            expected_turn_id,
+            crate::activity::state_for_view(&state.context, &beta)
+                .and_then(|turn| turn.current_turn)
+                .and_then(|turn| turn.provider_turn_id)
+                .expect("same projected active turn")
+        );
+        response
+            .send(Err("provider rejected stale turn".to_string()))
+            .expect("reject steer");
+        drain.await.expect("unknown steer drain");
+        assert_eq!(notification_fixture(tmp.path())["state"], "attempt_unknown");
+
+        assert!(
+            crate::coordination::pending_notifications(&state.context)
+                .expect("pending notifications")
+                .is_empty(),
+            "an unresolved steer must not become a pending retry"
+        );
+        let duplicate_drain = tokio::spawn(drain_coordination_notifications(state.clone()));
+        match tokio::time::timeout(Duration::from_millis(100), commands.recv()).await {
+            Err(_) => {
+                tokio::time::timeout(Duration::from_secs(2), duplicate_drain)
+                    .await
+                    .expect("empty notification drain must finish")
+                    .expect("empty notification drain");
+            }
+            Ok(Some(codex_app_server::ControlCommand::Steer { response, .. })) => {
+                let _ = response.send(Err("duplicate test steer".to_string()));
+                let _ = duplicate_drain.await;
+                panic!("an unresolved steer must not be submitted twice");
+            }
+            Ok(Some(_)) => panic!("an unresolved steer emitted another control command"),
+            Ok(None) => panic!("the active control channel closed unexpectedly"),
+        }
+        write_codex_notification_transcript(&transcript, provider_id, &[]);
+        reconcile_coordination_notifications(state.clone()).await;
+        assert_eq!(
+            notification_fixture(tmp.path())["state"],
+            "queued",
+            "an absent transcript observation permits a bounded retry"
+        );
+
+        let drain = tokio::spawn(drain_coordination_notifications(state.clone()));
+        let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
+            .await
+            .expect("reconciled steer retry")
+            .expect("steer retry command");
+        let codex_app_server::ControlCommand::Steer { response, .. } = command else {
+            panic!("reconciled active notification must use turn/steer");
+        };
+        response
+            .send(Err("steer acknowledgement lost".to_string()))
+            .expect("lose steer acknowledgement");
+        drain.await.expect("ambiguous steer drain");
+        assert_eq!(notification_fixture(tmp.path())["state"], "attempt_unknown");
+        write_codex_notification_transcript(
+            &transcript,
+            provider_id,
+            &[(
+                "9999-01-01T00:00:00Z",
+                crate::coordination::notification_prompt("", "beta"),
+            )],
+        );
+        reconcile_coordination_notifications(state.clone()).await;
+        let notification = notification_fixture(tmp.path());
+        assert_eq!(notification["state"], "prompt_submitted");
+        assert_eq!(notification["notified_generation"], 2);
     }
 
     #[tokio::test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -25594,6 +25594,16 @@ exit 0
         let lock_probe_context = state.context.clone();
         let lifecycle_context = state.context.clone();
         let lifecycle_tmux = state.tmux_bin.clone();
+        let maintenance_context = state.context.clone();
+        let maintenance_tmux = state.tmux_bin.clone();
+        let maintenance_preview = crate::maintenance::preview(
+            &maintenance_context,
+            "beta",
+            &maintenance_tmux,
+            crate::maintenance::MaintenanceOperation::Delete,
+            crate::maintenance::MaintenanceContract::V1,
+        )
+        .expect("maintenance preview before notification submission");
         let responder = tokio::spawn(async move {
             let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
                 .await
@@ -25632,6 +25642,43 @@ exit 0
             assert_eq!(
                 error.code(),
                 "coordination-notification-submission-in-progress"
+            );
+            let maintenance = tokio::task::spawn_blocking(move || {
+                crate::maintenance::execute_with_resume_guard(
+                    &maintenance_context,
+                    "beta",
+                    &maintenance_tmux,
+                    crate::maintenance::MaintenanceActionRequest {
+                        schema_version: crate::maintenance::MaintenanceContract::V1,
+                        operation: crate::maintenance::MaintenanceOperation::Delete,
+                        action: crate::maintenance::MaintenanceActionId::RetryDelete,
+                        expected_session_incarnation: maintenance_preview
+                            .session_incarnation
+                            .clone(),
+                        expected_session_generation: maintenance_preview.session_generation,
+                        expected_preview_digest: maintenance_preview.preview_digest.clone(),
+                        confirmed: true,
+                    },
+                    |_| Ok(()),
+                )
+            });
+            let maintenance_error = tokio::time::timeout(Duration::from_millis(250), maintenance)
+                .await
+                .expect("maintenance admission must remain bounded during checkpoint provider I/O")
+                .expect("maintenance probe worker")
+                .expect_err("maintenance mutation must preserve the checkpoint retry contract");
+            assert_eq!(
+                maintenance_error.code(),
+                "coordination-notification-submission-in-progress"
+            );
+            let maintenance_details = maintenance_error
+                .0
+                .details
+                .expect("notification submission retry details");
+            assert_eq!(maintenance_details["retryable"], true);
+            assert_eq!(
+                maintenance_details["next_action"],
+                "wait-for-notification-outcome"
             );
             response
                 .send(Ok(expected_turn_id))

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -5278,11 +5278,12 @@ async fn dispatch_codex_in_turn_coordination_checkpoint(
                 None,
             ));
         }
-        Ok::<_, CliError>(record_lock)
+        drop(record_lock);
+        Ok::<_, CliError>(())
     })
     .await;
-    let record_lock = match locked {
-        Ok(Ok(record_lock)) => record_lock,
+    match locked {
+        Ok(Ok(())) => {}
         Ok(Err(err)) if err.code() == "coordination-checkpoint-not-quiescent" => {
             update_notification_deferred(
                 &state,
@@ -5306,7 +5307,6 @@ async fn dispatch_codex_in_turn_coordination_checkpoint(
     };
 
     let response = handle.steer_prompt(&prompt, &expected_turn_id).await;
-    drop(record_lock);
     let context = state.context.clone();
     if response.as_deref() == Ok(expected_turn_id.as_str()) {
         let _ = tokio::task::spawn_blocking(move || {
@@ -25591,6 +25591,7 @@ exit 0
             serde_json::to_vec_pretty(&registry).expect("registry json"),
         )
         .expect("clear active operation");
+        let lock_probe_context = state.context.clone();
         let responder = tokio::spawn(async move {
             let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
                 .await
@@ -25610,6 +25611,14 @@ exit 0
                 crate::coordination::notification_prompt("", "beta")
             );
             assert!(!message.contains(canary));
+            let lock_probe = tokio::task::spawn_blocking(move || {
+                let _record_lock = crate::acquire_session_record_lock(&lock_probe_context, "beta")
+                    .expect("checkpoint record lock must be reacquirable");
+            });
+            tokio::time::timeout(Duration::from_millis(250), lock_probe)
+                .await
+                .expect("checkpoint must release the record lock before provider I/O")
+                .expect("record-lock probe worker");
             response
                 .send(Ok(expected_turn_id))
                 .expect("acknowledge checkpoint");

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -25592,6 +25592,8 @@ exit 0
         )
         .expect("clear active operation");
         let lock_probe_context = state.context.clone();
+        let lifecycle_context = state.context.clone();
+        let lifecycle_tmux = state.tmux_bin.clone();
         let responder = tokio::spawn(async move {
             let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
                 .await
@@ -25619,6 +25621,18 @@ exit 0
                 .await
                 .expect("checkpoint must release the record lock before provider I/O")
                 .expect("record-lock probe worker");
+            let lifecycle = tokio::task::spawn_blocking(move || {
+                crate::resume_session_by_id(&lifecycle_context, "beta", &lifecycle_tmux)
+            });
+            let error = tokio::time::timeout(Duration::from_millis(250), lifecycle)
+                .await
+                .expect("lifecycle admission must remain bounded during checkpoint provider I/O")
+                .expect("lifecycle probe worker")
+                .expect_err("lifecycle mutation must be fenced while checkpoint steer is pending");
+            assert_eq!(
+                error.code(),
+                "coordination-notification-submission-in-progress"
+            );
             response
                 .send(Ok(expected_turn_id))
                 .expect("acknowledge checkpoint");

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -25604,6 +25604,22 @@ exit 0
             crate::maintenance::MaintenanceContract::V1,
         )
         .expect("maintenance preview before notification submission");
+        let inspect_preview = crate::maintenance::preview(
+            &maintenance_context,
+            "beta",
+            &maintenance_tmux,
+            crate::maintenance::MaintenanceOperation::Inspect,
+            crate::maintenance::MaintenanceContract::V1,
+        )
+        .expect("inspect preview before notification submission");
+        let attach_preview = crate::maintenance::preview(
+            &maintenance_context,
+            "beta",
+            &maintenance_tmux,
+            crate::maintenance::MaintenanceOperation::Attach,
+            crate::maintenance::MaintenanceContract::V1,
+        )
+        .expect("attach preview before notification submission");
         let responder = tokio::spawn(async move {
             let command = tokio::time::timeout(Duration::from_secs(2), commands.recv())
                 .await
@@ -25644,7 +25660,37 @@ exit 0
                 "coordination-notification-submission-in-progress"
             );
             let maintenance = tokio::task::spawn_blocking(move || {
-                crate::maintenance::execute_with_resume_guard(
+                let inspect = crate::maintenance::execute_with_resume_guard(
+                    &maintenance_context,
+                    "beta",
+                    &maintenance_tmux,
+                    crate::maintenance::MaintenanceActionRequest {
+                        schema_version: crate::maintenance::MaintenanceContract::V1,
+                        operation: crate::maintenance::MaintenanceOperation::Inspect,
+                        action: crate::maintenance::MaintenanceActionId::Inspect,
+                        expected_session_incarnation: inspect_preview.session_incarnation.clone(),
+                        expected_session_generation: inspect_preview.session_generation,
+                        expected_preview_digest: inspect_preview.preview_digest.clone(),
+                        confirmed: false,
+                    },
+                    |_| Ok(()),
+                );
+                let attach = crate::maintenance::execute_with_resume_guard(
+                    &maintenance_context,
+                    "beta",
+                    &maintenance_tmux,
+                    crate::maintenance::MaintenanceActionRequest {
+                        schema_version: crate::maintenance::MaintenanceContract::V1,
+                        operation: crate::maintenance::MaintenanceOperation::Attach,
+                        action: crate::maintenance::MaintenanceActionId::RetryAttach,
+                        expected_session_incarnation: attach_preview.session_incarnation.clone(),
+                        expected_session_generation: attach_preview.session_generation,
+                        expected_preview_digest: attach_preview.preview_digest.clone(),
+                        confirmed: false,
+                    },
+                    |_| Ok(()),
+                );
+                let delete = crate::maintenance::execute_with_resume_guard(
                     &maintenance_context,
                     "beta",
                     &maintenance_tmux,
@@ -25660,12 +25706,27 @@ exit 0
                         confirmed: true,
                     },
                     |_| Ok(()),
-                )
+                );
+                (inspect, attach, delete)
             });
-            let maintenance_error = tokio::time::timeout(Duration::from_millis(250), maintenance)
-                .await
-                .expect("maintenance admission must remain bounded during checkpoint provider I/O")
-                .expect("maintenance probe worker")
+            let (inspect, attach, delete) =
+                tokio::time::timeout(Duration::from_millis(250), maintenance)
+                    .await
+                    .expect(
+                        "maintenance admission must remain bounded during checkpoint provider I/O",
+                    )
+                    .expect("maintenance probe worker");
+            let inspect = serde_json::to_value(
+                inspect.expect("read-only inspect must remain available during checkpoint steer"),
+            )
+            .expect("inspect result json");
+            assert_eq!(inspect["outcome"], "inspected");
+            let attach = serde_json::to_value(
+                attach.expect("read-only attach must remain available during checkpoint steer"),
+            )
+            .expect("attach result json");
+            assert_eq!(attach["outcome"], "inspected");
+            let maintenance_error = delete
                 .expect_err("maintenance mutation must preserve the checkpoint retry contract");
             assert_eq!(
                 maintenance_error.code(),

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -25448,6 +25448,11 @@ exit 0
             .expect("transcript dir");
         let provider_id = "notification-active-provider";
         let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
+        let _broker = EnvGuard::set(
+            &lock,
+            "AGENT_SESSION_CODEX_ACCOUNT_BROKER",
+            r#"["/configured/broker"]"#,
+        );
         seed_session_with_runtime(tmp.path(), "alpha", "codex", "hs-codex-alpha");
         let launch_id = seed_codex_app_server_session(tmp.path(), "beta");
         let record_path = tmp.path().join("sessions/beta/session.json");


### PR DESCRIPTION
## Summary

Enable authenticated coordination notifications to reach an active Codex turn at a bounded safe checkpoint, so long-running work can reorder itself promptly without cancelling an in-flight atomic operation or exposing peer message bodies.

## Changes

- Add an exact projected-to-raw active-turn fence and metadata-only recovery for the Codex app-server control channel.
- Dispatch body-free coordination steering only while the recipient is authoritative, terminal-account-safe, and free of claims or operations.
- Preserve durable notification reconciliation across rejection, acknowledgement loss, reconnect, and transcript recovery.
- Release the session-record lock before provider I/O so an in-band authentication refresh cannot recursively block checkpoint delivery.
- Fence exact-incarnation stop, delete, resume, replacement, and maintenance admission while a checkpoint provider request is unresolved.
- Preserve the typed retryable checkpoint fence through maintenance error sanitization.
- Keep read-only maintenance inspect/attach actions available while mutating actions share the checkpoint fence.
- Document the safe in-turn delivery contract and extend focused and integration regression coverage.

## Test-First Evidence

- Red: `cargo test -p nils-agent-session coordination_notification_working_codex_uses_safe_in_turn_checkpoint -- --nocapture` failed by timing out before the active-turn checkpoint existed.
- Review red: the same regression's lock probe failed with `checkpoint must release the record lock before provider I/O` before the concurrency repair.
- Lifecycle red: a resume probe succeeded while steer acknowledgement was pending before lifecycle admission shared the durable notification fence.
- API-contract red: a maintenance action returned generic non-retryable `session-maintenance-failed` before sanitization preserved the typed checkpoint error.
- Red-team red: read-only maintenance `Inspect` was rejected before the lifecycle guard was narrowed to mutating actions.
- Green: the focused active-turn, reconnect, enqueue-fence, notification reconciliation, and projection tests pass.

## Test plan

- `env -u AGENT_SESSION_CODEX_ACCOUNT_BROKER bash .agents/scripts/pre-pr.sh` — passed on final head `16af2c45`, including formatting, clippy, documentation audits, 1,180 nextest cases, and doctests.
- `cargo nextest run -p nils-agent-session -E 'test(/(queued_steer|unix_control_recovers|coordination_notification_working|unix_control_projects_live_failure)/)'` — 4 passed.
- Focused lifecycle, runtime-stop, mutating maintenance admission, typed-error, and read-only maintenance selection — 5 passed.
- Affected notification regression suite — 5 passed.

## Risk / Notes

- The new path can steer only the exact currently projected Codex turn and carries a fixed body-free checkpoint prompt.
- Provider rejection or ambiguous acknowledgement fails closed into durable reconciliation; terminal delivery behavior is unchanged.
