### PR TITLE
fix(ci): keep leak fixtures visible to sandboxes

### DIFF
--- a/scripts/ci/tempdir-leak-probe.sh
+++ b/scripts/ci/tempdir-leak-probe.sh
@@ -23,7 +23,8 @@
 # Do NOT point TMPDIR inside any repository work tree. Many tests assert that a
 # path is outside a git repository (`*_outside_git_repo`, `not_a_repo`), and a
 # TMPDIR with Git marker ancestry invalidates those fixtures. The probe therefore
-# selects the first writable system temp root outside Git marker ancestry.
+# selects the first writable system temp root outside Git marker ancestry and
+# outside host paths hidden by workspace sandbox mount plans.
 #
 # Compatibility: must run on macOS (system bash 3.2) and Linux runners. Avoid
 # associative arrays, mapfile, and `${var,,}` lowercasing.
@@ -45,7 +46,9 @@ nextest arguments are given.
                      to raise the odds of catching one.
   --probe-root <dir> where to create the private TMPDIR (default: the first
                      writable system temp root outside Git marker ancestry).
-                     Must not have Git marker ancestry.
+                     Must not have Git marker ancestry or live below `/run` or
+                     `/dev`, which workspace sandboxes replace with private
+                     mounts.
   --allow <glob>     tolerate a surviving entry whose name matches <glob>.
                      Repeatable. Only for state a test deliberately reuses
                      across runs under a fixed name — such state is bounded, so
@@ -134,6 +137,17 @@ has_git_marker_ancestry() {
   done
 }
 
+has_sandbox_masked_ancestry() {
+  case "$1/" in
+    /run/* | /dev/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 select_default_probe_root() {
   local candidate
   local candidate_abs
@@ -142,7 +156,8 @@ select_default_probe_root() {
     [ -d "$candidate" ] || continue
     [ -w "$candidate" ] || continue
     candidate_abs="$(cd "$candidate" && pwd -P)" || continue
-    if ! has_git_marker_ancestry "$candidate_abs"; then
+    if ! has_git_marker_ancestry "$candidate_abs" &&
+      ! has_sandbox_masked_ancestry "$candidate_abs"; then
       printf '%s\n' "$candidate_abs"
       return 0
     fi
@@ -166,6 +181,11 @@ probe_root_abs="$(cd "$probe_root" && pwd -P)"
 if has_git_marker_ancestry "$probe_root_abs"; then
   echo "tempdir-leak-probe: --probe-root must be outside Git marker ancestry;" >&2
   echo "  tests that assert a path is outside a git repo fail under it." >&2
+  exit 2
+fi
+if has_sandbox_masked_ancestry "$probe_root_abs"; then
+  echo "tempdir-leak-probe: --probe-root must remain visible to sandboxed tests;" >&2
+  echo "  /run and /dev are replaced by private mounts." >&2
   exit 2
 fi
 

--- a/scripts/ci/tempdir-leak-probe.sh
+++ b/scripts/ci/tempdir-leak-probe.sh
@@ -137,15 +137,19 @@ has_git_marker_ancestry() {
   done
 }
 
+SANDBOX_MASKED_ROOTS="/run /proc /dev"
+
 has_sandbox_masked_ancestry() {
-  case "$1/" in
-    /run/* | /dev/*)
-      return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  local path="$1"
+  local root
+  for root in $SANDBOX_MASKED_ROOTS; do
+    case "$path/" in
+      "$root"/*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
 }
 
 select_default_probe_root() {

--- a/scripts/ci/tests/tempdir-leak-probe.test.sh
+++ b/scripts/ci/tests/tempdir-leak-probe.test.sh
@@ -34,6 +34,49 @@ if [[ ! -f "$probe_script" ]]; then
   exit 2
 fi
 
+echo "== sandbox-masked root policy matches the Rust sandbox owner =="
+rust_sandbox_source="$repo_root/crates/agent-workflow-primitives/src/agent_run/inspect.rs"
+shell_masked_roots="$(sed -n 's/^SANDBOX_MASKED_ROOTS="\([^"]*\)"$/\1/p' "$probe_script")"
+if [[ -z "$shell_masked_roots" ]]; then
+  echo "FAIL: the probe does not declare SANDBOX_MASKED_ROOTS" >&2
+  exit 1
+fi
+rust_masked_roots="$({
+  sed -n '/^fn is_private_mount(/,/^}/p' "$rust_sandbox_source" |
+    awk '
+      {
+        line = $0
+        while (match(line, /Path::new\("[^"]+"\)/)) {
+          root = substr(line, RSTART, RLENGTH)
+          sub(/^Path::new\("/, "", root)
+          sub(/"\)$/, "", root)
+          print root
+          line = substr(line, RSTART + RLENGTH)
+        }
+      }
+    '
+} | sort)"
+normalized_shell_masked_roots="$(printf '%s\n' $shell_masked_roots | sort)"
+if [[ "$normalized_shell_masked_roots" != "$rust_masked_roots" ]]; then
+  echo "FAIL: shell sandbox-masked roots differ from the Rust sandbox owner" >&2
+  printf 'shell:\n%s\nrust:\n%s\n' "$normalized_shell_masked_roots" "$rust_masked_roots" >&2
+  exit 1
+fi
+echo "ok: shell and Rust sandbox-masked roots match"
+
+has_sandbox_masked_ancestry() {
+  local path="$1"
+  local root
+  for root in $shell_masked_roots; do
+    case "$path/" in
+      "$root"/*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
 has_git_marker_ancestry() {
   local cursor="$1"
   local parent
@@ -239,17 +282,14 @@ echo "ok: probe roots with Git ancestry are refused"
 
 echo "== sandbox-masked probe roots are refused and skipped =="
 masked_root=""
-for candidate in "${XDG_RUNTIME_DIR:-}" /dev/shm /run; do
+for candidate in "${XDG_RUNTIME_DIR:-}" $shell_masked_roots; do
   [[ -n "$candidate" && -d "$candidate" && -w "$candidate" ]] || continue
   candidate="$(cd "$candidate" && pwd -P)"
-  case "$candidate/" in
-    /run/* | /dev/*)
-      if ! has_git_marker_ancestry "$candidate"; then
-        masked_root="$candidate"
-        break
-      fi
-      ;;
-  esac
+  if has_sandbox_masked_ancestry "$candidate" &&
+    ! has_git_marker_ancestry "$candidate"; then
+    masked_root="$candidate"
+    break
+  fi
 done
 if [[ -n "$masked_root" ]]; then
   write_cargo_stub 'printf "%s\n" "$TMPDIR" >"$CARGO_STUB_LOG"'
@@ -259,12 +299,10 @@ if [[ -n "$masked_root" ]]; then
     XDG_RUNTIME_DIR="$masked_root" \
     bash "$probe_script" >/dev/null 2>&1
   selected_root="$(cat "$work/sandbox-visible-root.log")"
-  case "$selected_root/" in
-    /run/* | /dev/*)
-      echo "FAIL: the default probe used a sandbox-masked root: $selected_root"
-      exit 1
-      ;;
-  esac
+  if has_sandbox_masked_ancestry "$selected_root"; then
+    echo "FAIL: the default probe used a sandbox-masked root: $selected_root"
+    exit 1
+  fi
   status=0
   PATH="$work/bin:$PATH" bash "$probe_script" --probe-root "$masked_root" >/dev/null 2>&1 || status=$?
   if [[ "$status" -ne 2 ]]; then

--- a/scripts/ci/tests/tempdir-leak-probe.test.sh
+++ b/scripts/ci/tests/tempdir-leak-probe.test.sh
@@ -18,7 +18,9 @@ set -euo pipefail
 #       TMPDIR after the run
 #   (f) --probe-root with any Git ancestry is refused, because tests that
 #       assert a path is outside a git repo break under it
-#   (g) usage errors exit 2
+#   (g) roots hidden by the workspace's sandbox mount plan are skipped by
+#       default and refused when explicit
+#   (h) usage errors exit 2
 
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 if [[ -z "$repo_root" || ! -d "$repo_root" ]]; then
@@ -234,6 +236,45 @@ if [[ "$status" -ne 2 ]]; then
   exit 1
 fi
 echo "ok: probe roots with Git ancestry are refused"
+
+echo "== sandbox-masked probe roots are refused and skipped =="
+masked_root=""
+for candidate in "${XDG_RUNTIME_DIR:-}" /dev/shm /run; do
+  [[ -n "$candidate" && -d "$candidate" && -w "$candidate" ]] || continue
+  candidate="$(cd "$candidate" && pwd -P)"
+  case "$candidate/" in
+    /run/* | /dev/*)
+      if ! has_git_marker_ancestry "$candidate"; then
+        masked_root="$candidate"
+        break
+      fi
+      ;;
+  esac
+done
+if [[ -n "$masked_root" ]]; then
+  write_cargo_stub 'printf "%s\n" "$TMPDIR" >"$CARGO_STUB_LOG"'
+  CARGO_STUB_LOG="$work/sandbox-visible-root.log" \
+    PATH="$work/bin:$PATH" \
+    TMPDIR="$masked_root" \
+    XDG_RUNTIME_DIR="$masked_root" \
+    bash "$probe_script" >/dev/null 2>&1
+  selected_root="$(cat "$work/sandbox-visible-root.log")"
+  case "$selected_root/" in
+    /run/* | /dev/*)
+      echo "FAIL: the default probe used a sandbox-masked root: $selected_root"
+      exit 1
+      ;;
+  esac
+  status=0
+  PATH="$work/bin:$PATH" bash "$probe_script" --probe-root "$masked_root" >/dev/null 2>&1 || status=$?
+  if [[ "$status" -ne 2 ]]; then
+    echo "FAIL: an explicit sandbox-masked probe root should exit 2, got $status"
+    exit 1
+  fi
+  echo "ok: sandbox-masked roots are skipped by default and refused when explicit"
+else
+  echo "ok: no writable sandbox-masked root is present on this platform"
+fi
 
 echo "== usage =="
 status=0


### PR DESCRIPTION
## Summary

Keep the workspace leak probe's private fixtures visible to sandboxed test consumers by skipping and refusing roots below host paths that workspace sandboxes replace. A cross-surface assertion now also keeps that shell policy identical to the Rust inspection sandbox owner. The change is limited to CI/test infrastructure and does not alter production runtime behavior.

## Issues

- Refs #1505

## Test-First Evidence

- RED on the post-#1506 baseline: with `XDG_RUNTIME_DIR` below `/run`, the leak probe selected that root and the `agent_run_inspect` suite passed 1/13 and failed 12/13 because Bubblewrap could not see the fixture after replacing `/run`.
- Added a shell regression proving sandbox-masked roots are skipped by default and rejected when passed explicitly; it failed before the selection repair and passes afterward.
- Review RED: the new cross-surface parity assertion failed because the probe had no declared `SANDBOX_MASKED_ROOTS` policy to compare with Rust's `is_private_mount` owner.
- Evidence record: complete v2, delivery attempt 4, bound to exact head `9b3a9ed23f50ac8787476e70cdde8f64eabba7bd`.

## Test plan

- `bash -n scripts/ci/tempdir-leak-probe.sh scripts/ci/tests/tempdir-leak-probe.test.sh` — passed.
- `bash scripts/ci/tests/tempdir-leak-probe.test.sh` — passed without warnings, including sandbox visibility and exact shell/Rust private-root parity.
- `env -u TMPDIR XDG_RUNTIME_DIR=/run/user/$(id -u) bash scripts/ci/tempdir-leak-probe.sh -- -p nils-agent-workflow-primitives -E 'test(/agent_run_inspect::inspect_/)'` — 13/13 passed; zero leftovers.
- `.agents/scripts/pre-pr.sh --full` — all audits and eight project skill suites passed; formatting and clippy passed; 8,638/8,638 workspace tests and doctests passed; zero probe leftovers.

## Risk / Notes

- Low CI-only risk. `/run`, `/proc`, and `/dev` cannot host this probe because the authoritative inspection sandbox replaces them; parity now fails if the Rust owner or shell policy changes alone. `/var/tmp` remains the first portable fallback before the Git-contaminated `/tmp` on the affected host.
