### PR TITLE
fix(macos-agent): keep SSH journal history and classify v4 refusals

### DIFF
--- a/crates/macos-agent/docs/specs/macos-agent-journal-v2.md
+++ b/crates/macos-agent/docs/specs/macos-agent-journal-v2.md
@@ -67,6 +67,25 @@ from validated steps under the journal lock before appending. Summary
 generation validates the full log at session close or on an explicit
 summarize/review operation.
 
+## Remote transfer merge
+
+A remote session journal is per-call scratch. The endpoint allocates a fresh
+session root for every request, so a transferred `steps.jsonl` always restarts
+at sequence 1 with its own `run_id`. The controller therefore merges a transfer
+into the durable journal in `--out-dir` instead of installing it: artifact
+payloads are written directly, while `manifest.json`, `steps.jsonl`,
+`summary.json`, `redaction.json`, `review.json`, and `artifacts/index.json` are
+verified, parsed, and merged under the journal lock.
+
+Merging reassigns each transferred step a local sequence, id, and correlation
+id, remaps a parent named inside the same transfer, rewrites the producing step
+of each merged artifact row, and rebuilds the summary and redaction report from
+the merged log. The local manifest keeps its own `run_id` and `started_at`; a
+transfer may only continue a session whose `schema_version`, `backend_digest`,
+`runtime`, `transport`, `evidence_mode`, and `tool_profile` are unchanged, and
+a drifted tuple fails closed without losing the steps already recorded. The
+512-step rotation bound applies to the merged log.
+
 ## Replay
 
 - `safe`: read-only observation/setup with retained sanitized argv.
@@ -91,9 +110,16 @@ so both planning and execution fail closed.
 
 Repeated normalized failures and mandatory significant classes become review
 candidates. Significant classes include privacy/redaction, wrong target, false
-success, unknown mutation, held input, remote cleanup, journal/replay integrity,
-backend drift, and permission drift. Proposed ownership is one of adapter,
-Peekaboo/adapter, runtime skill policy, or the TCC environment. Review does not
-create a provider issue by itself.
+success, unknown mutation, refused mutation, held input, remote cleanup,
+journal/replay integrity, backend drift, and permission drift. Proposed
+ownership is one of adapter, Peekaboo/adapter, runtime skill policy, or the TCC
+environment. Review does not create a provider issue by itself.
+
+When the upstream result publishes a v4 outcome envelope, classification reads
+it rather than inferring from the process exit code alone. A refusal becomes
+`upstream_refused` and is always significant; an upstream that reports its own
+failure at exit zero becomes `false_success`; and an envelope proving no
+mutation dispatched resolves an otherwise unknown mutation. An upstream result
+without an envelope keeps the exit-code rules unchanged.
 
 Raw upstream payloads and screenshots are never promoted automatically.

--- a/crates/macos-agent/src/commands/exec.rs
+++ b/crates/macos-agent/src/commands/exec.rs
@@ -136,6 +136,25 @@ pub fn run_local(
         status = StepStatus::Failed;
         failure_class = Some("upstream_malformed_json".into());
     }
+    // Peekaboo v4 publishes a structured outcome envelope beside its data.
+    // Classify from it when present: a refusal is not a generic upstream
+    // failure, and an upstream that reports its own failure at exit zero is a
+    // false success rather than a pass.
+    if let Some(outcome) = parsed.as_ref().and_then(upstream_outcome) {
+        // An envelope proving nothing dispatched resolves the conservative
+        // unknown-mutation classification into an ordinary failure.
+        let resolved_unknown = unknown_mutation && outcome.mutation_dispatched == Some(false);
+        if outcome.refused {
+            status = StepStatus::Failed;
+            failure_class = Some("upstream_refused".into());
+        } else if resolved_unknown {
+            status = StepStatus::Failed;
+            failure_class = Some("upstream".into());
+        } else if outcome.success == Some(false) && status == StepStatus::Passed {
+            status = StepStatus::Failed;
+            failure_class = Some("false_success".into());
+        }
+    }
     let debug_artifact = if args.evidence_mode == crate::cli::EvidenceMode::Debug {
         Some(write_debug_artifact(
             &args.out_dir,
@@ -216,6 +235,35 @@ pub fn run_local(
     })
 }
 
+/// The parts of the Peekaboo v4 result envelope the adapter classifies on.
+/// Every field is optional, so an upstream result without an envelope keeps the
+/// exit-code rules unchanged.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct UpstreamOutcome {
+    success: Option<bool>,
+    refused: bool,
+    mutation_dispatched: Option<bool>,
+}
+
+fn upstream_outcome(value: &serde_json::Value) -> Option<UpstreamOutcome> {
+    let object = value.as_object()?;
+    let outcome = object.get("outcome").and_then(|value| value.as_object());
+    let refusal_reason = outcome
+        .and_then(|outcome| outcome.get("refusal_reason"))
+        .is_some_and(|reason| !reason.is_null());
+    let refused_effect = outcome
+        .and_then(|outcome| outcome.get("effect"))
+        .and_then(|effect| effect.as_str())
+        == Some("refused");
+    Some(UpstreamOutcome {
+        success: object.get("success").and_then(|value| value.as_bool()),
+        refused: refusal_reason || refused_effect,
+        mutation_dispatched: outcome
+            .and_then(|outcome| outcome.get("mutation_dispatched"))
+            .and_then(|value| value.as_bool()),
+    })
+}
+
 fn validate(args: &ExecArgs) -> Result<(), CliError> {
     policy::validate_exec_argv(&args.argv)?;
     if policy::mutating_invocation(&args.argv)
@@ -260,4 +308,52 @@ fn write_debug_artifact(
     write_atomic(&root.join(&filename), &body, SECRET_FILE_MODE)
         .map_err(|_| CliError::journal("failed to write debug upstream artifact"))?;
     Ok(filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{UpstreamOutcome, upstream_outcome};
+
+    #[test]
+    fn the_v4_outcome_envelope_is_read_instead_of_guessed_from_the_exit_code() {
+        let refused = serde_json::json!({
+            "success": false,
+            "outcome": {
+                "effect": "refused",
+                "refusal_reason": "target_unavailable",
+                "mutation_dispatched": false
+            }
+        });
+        assert_eq!(
+            upstream_outcome(&refused),
+            Some(UpstreamOutcome {
+                success: Some(false),
+                refused: true,
+                mutation_dispatched: Some(false),
+            })
+        );
+
+        // A dispatched but unverifiable delivery is the ordinary background
+        // accessibility-action result; it must never read as a refusal.
+        let unverifiable = serde_json::json!({
+            "success": true,
+            "outcome": {"effect": "unverifiable", "mutation_dispatched": true}
+        });
+        assert_eq!(
+            upstream_outcome(&unverifiable),
+            Some(UpstreamOutcome {
+                success: Some(true),
+                refused: false,
+                mutation_dispatched: Some(true),
+            })
+        );
+
+        // An upstream result without an envelope leaves classification to the
+        // existing exit-code rules.
+        assert_eq!(
+            upstream_outcome(&serde_json::json!({"data": {"ok": true}})),
+            Some(UpstreamOutcome::default())
+        );
+        assert_eq!(upstream_outcome(&serde_json::json!([])), None);
+    }
 }

--- a/crates/macos-agent/src/journal/mod.rs
+++ b/crates/macos-agent/src/journal/mod.rs
@@ -563,6 +563,136 @@ pub fn record_system_failure(root: &Path, class: &str) -> Result<(), CliError> {
     Ok(())
 }
 
+/// One remote exec or MCP journal transferred back from an SSH target.
+pub struct TransferredJournal {
+    pub manifest: Manifest,
+    pub steps: Vec<StepRecord>,
+    pub index: Option<ArtifactIndex>,
+}
+
+/// Merge a transferred remote journal into the durable local journal.
+///
+/// A remote session journal is per-call scratch: the endpoint allocates a fresh
+/// session root for every request, so the transferred log always restarts at
+/// sequence 1. Installing it verbatim would replace every step already recorded
+/// in this output directory. Merge it instead, reassigning local sequences and
+/// identifiers, and return the assigned ids in transferred order.
+pub fn ingest_transfer(root: &Path, transfer: TransferredJournal) -> Result<Vec<String>, CliError> {
+    validate_root(root)?;
+    create_private_dir(root)?;
+    let _lock = JournalLock::acquire(root)?;
+    create_private_dir(&root.join("artifacts"))?;
+
+    if transfer.manifest.schema_version != JOURNAL_SCHEMA {
+        return Err(journal_error("unsupported journal schema"));
+    }
+
+    // The local manifest owns run identity. A transferred manifest may only
+    // continue a session whose execution tuple is unchanged, matching the
+    // homogeneity rule `open_with_digest` enforces for local runs.
+    let manifest_path = root.join("manifest.json");
+    let manifest = if manifest_path.exists() {
+        let local: Manifest = read_json(&manifest_path)?;
+        if local.schema_version != transfer.manifest.schema_version
+            || local.backend_digest != transfer.manifest.backend_digest
+            || local.runtime != transfer.manifest.runtime
+            || local.transport != transfer.manifest.transport
+            || local.evidence_mode != transfer.manifest.evidence_mode
+            || local.tool_profile != transfer.manifest.tool_profile
+        {
+            return Err(journal_error(
+                "journal manifest does not match this execution session",
+            ));
+        }
+        local
+    } else {
+        Manifest {
+            state: "open".into(),
+            closed_at: None,
+            ..transfer.manifest
+        }
+    };
+    write_json(&manifest_path, &manifest)?;
+    ensure_index(root)?;
+
+    recover_sequence_transaction(root)?;
+    let (existing, recovered_tail) = read_steps_recover(root)?;
+    write_sequence(root, existing.len() as u64)?;
+
+    let mut assigned = Vec::new();
+    let mut remapped = BTreeMap::<String, String>::new();
+    for step in transfer.steps {
+        let committed = read_sequence(root)?;
+        if committed >= MAX_JOURNAL_STEPS {
+            return Err(journal_error(
+                "journal rotation is required at the 512-step bound; use a new output directory",
+            ));
+        }
+        let sequence = committed + 1;
+        let id = format!("step-{sequence:06}");
+        let remote_id = step.id.clone();
+        // A parent inside this same transfer follows it to its new id; one that
+        // named an earlier local step is kept as an opaque reference.
+        let parent_id = step.parent_id.as_ref().map(|parent| {
+            remapped
+                .get(parent)
+                .cloned()
+                .unwrap_or_else(|| safe_reference(parent))
+        });
+        let record = StepRecord {
+            sequence,
+            id: id.clone(),
+            correlation_id: format!("{}-{id}", manifest.run_id),
+            parent_id,
+            ..step
+        };
+        write_atomic(
+            &root.join(SEQUENCE_TRANSACTION_FILE),
+            sequence.to_string().as_bytes(),
+            SECRET_FILE_MODE,
+        )
+        .map_err(|_| journal_error("failed to begin journal sequence transaction"))?;
+        if let Err(error) = append_step(root, &record) {
+            let _ = remove_sequence_transaction(root);
+            return Err(error);
+        }
+        write_sequence(root, sequence)?;
+        remove_sequence_transaction(root)?;
+        remapped.insert(remote_id, id.clone());
+        assigned.push(id);
+    }
+
+    if let Some(remote_index) = transfer.index {
+        if remote_index.schema_version != "macos-agent.artifact-index.v1" {
+            return Err(journal_error("unsupported artifact index schema"));
+        }
+        let mut index: ArtifactIndex = read_json(&root.join("artifacts/index.json"))?;
+        for mut row in remote_index.artifacts {
+            row.producing_step = remapped
+                .get(&row.producing_step)
+                .cloned()
+                .unwrap_or_else(|| safe_reference(&row.producing_step));
+            if !index
+                .artifacts
+                .iter()
+                .any(|present| present.relative_path == row.relative_path)
+            {
+                index.artifacts.push(row);
+            }
+        }
+        index
+            .artifacts
+            .sort_by(|left, right| left.relative_path.cmp(&right.relative_path));
+        write_json(&root.join("artifacts/index.json"), &index)?;
+    }
+
+    let (merged, recovered) = read_steps_recover(root)?;
+    let summary = build_summary(&merged, recovered_tail || recovered);
+    write_json(&root.join("summary.json"), &summary)?;
+    write_redaction_report(root)?;
+    Ok(assigned)
+}
+
 pub fn replay_plan(root: &Path, selected: Option<&str>) -> Result<ReplayPlan, CliError> {
     let _lock = JournalLock::acquire(root)?;
     let manifest: Manifest = read_json(&root.join("manifest.json"))?;
@@ -1023,6 +1153,7 @@ fn significant_failure(step: &StepRecord) -> bool {
             | "wrong_target"
             | "false_success"
             | "unknown_mutation"
+            | "upstream_refused"
             | "held_input"
             | "remote_cleanup"
             | "journal_integrity"
@@ -1066,6 +1197,7 @@ fn normalize_failure(value: &str) -> String {
         | "permission_drift"
         | "upstream"
         | "upstream_malformed_json"
+        | "upstream_refused"
         | "upstream_mcp"
         | "upstream_signal"
         | "upstream_timeout"
@@ -1370,6 +1502,46 @@ mod tests {
 
     fn open(root: &std::path::Path, mode: EvidenceMode) -> Journal {
         Journal::open(root, RuntimeMode::App, "local", mode, None).expect("journal")
+    }
+
+    #[test]
+    fn a_refused_mutation_is_a_significant_review_candidate() {
+        let root = TempDir::new().expect("root");
+        let mut journal = open(root.path(), EvidenceMode::Minimal);
+        journal
+            .record_step(StepInput {
+                parent_id: None,
+                intent: Some("return the fixture to its baseline".into()),
+                expected: Some("the fixture is no longer running".into()),
+                argv: vec![
+                    "app".into(),
+                    "quit".into(),
+                    "--app".into(),
+                    "Fixture".into(),
+                ],
+                status: StepStatus::Failed,
+                failure_class: Some("upstream_refused".into()),
+                duration_ms: 1,
+                retries: 0,
+                precondition_refs: Vec::new(),
+                postcondition_refs: Vec::new(),
+                snapshot_lineage: None,
+                artifact_refs: Vec::new(),
+            })
+            .expect("step");
+
+        let review = review(root.path()).expect("review");
+        assert!(
+            !review.clean,
+            "a mutation the backend refused must not review as clean"
+        );
+        let candidate = review
+            .candidates
+            .iter()
+            .find(|candidate| candidate.signature == "app:upstream_refused")
+            .expect("refusal keeps its own signature instead of collapsing to other");
+        assert!(candidate.significant);
+        assert_eq!(candidate.proposed_owner, "peekaboo_or_adapter");
     }
 
     #[test]

--- a/crates/macos-agent/src/journal/mod.rs
+++ b/crates/macos-agent/src/journal/mod.rs
@@ -616,18 +616,21 @@ pub fn ingest_transfer(root: &Path, transfer: TransferredJournal) -> Result<Vec<
     ensure_index(root)?;
 
     recover_sequence_transaction(root)?;
-    let (existing, recovered_tail) = read_steps_recover(root)?;
-    write_sequence(root, existing.len() as u64)?;
+    let (mut merged, recovered_tail) = read_steps_recover(root)?;
+    write_sequence(root, merged.len() as u64)?;
+
+    // Refuse a transfer that cannot fit whole. Appending until the bound is hit
+    // would leave a partially merged transfer behind an error.
+    if merged.len().saturating_add(transfer.steps.len()) as u64 > MAX_JOURNAL_STEPS {
+        return Err(journal_error(
+            "journal rotation is required at the 512-step bound; use a new output directory",
+        ));
+    }
 
     let mut assigned = Vec::new();
     let mut remapped = BTreeMap::<String, String>::new();
     for step in transfer.steps {
         let committed = read_sequence(root)?;
-        if committed >= MAX_JOURNAL_STEPS {
-            return Err(journal_error(
-                "journal rotation is required at the 512-step bound; use a new output directory",
-            ));
-        }
         let sequence = committed + 1;
         let id = format!("step-{sequence:06}");
         let remote_id = step.id.clone();
@@ -660,6 +663,7 @@ pub fn ingest_transfer(root: &Path, transfer: TransferredJournal) -> Result<Vec<
         remove_sequence_transaction(root)?;
         remapped.insert(remote_id, id.clone());
         assigned.push(id);
+        merged.push(record);
     }
 
     if let Some(remote_index) = transfer.index {
@@ -686,8 +690,9 @@ pub fn ingest_transfer(root: &Path, transfer: TransferredJournal) -> Result<Vec<
         write_json(&root.join("artifacts/index.json"), &index)?;
     }
 
-    let (merged, recovered) = read_steps_recover(root)?;
-    let summary = build_summary(&merged, recovered_tail || recovered);
+    // The merged log is already in hand, so the summary is rebuilt without a
+    // second full rescan of the journal on every transfer.
+    let summary = build_summary(&merged, recovered_tail);
     write_json(&root.join("summary.json"), &summary)?;
     write_redaction_report(root)?;
     Ok(assigned)

--- a/crates/macos-agent/src/transport/mod.rs
+++ b/crates/macos-agent/src/transport/mod.rs
@@ -1574,6 +1574,77 @@ mod tests {
     }
 
     #[test]
+    fn merged_artifact_rows_follow_their_step_to_its_new_id() {
+        let root = TempDir::new().expect("root");
+        let out = root.path().join("journal");
+        install_transferred_journal(
+            &out,
+            &remote_exec_bundle("run-a", "first", "sha256:fixture"),
+        )
+        .expect("first transfer");
+
+        // A second transfer carries an artifact produced by its own step-000001,
+        // which becomes step-000002 locally.
+        let payload = b"{\"sanitized\":true}";
+        let mut bundle = remote_exec_bundle("run-b", "second", "sha256:fixture");
+        let index = crate::journal::ArtifactIndex {
+            schema_version: "macos-agent.artifact-index.v1".into(),
+            artifacts: vec![crate::journal::ArtifactRecord {
+                sha256: format!("sha256:{}", super::hex(&sha2::Sha256::digest(payload))),
+                mime: "application/json".into(),
+                kind: "upstream_result".into(),
+                producing_step: "step-000001".into(),
+                sensitivity: "private".into(),
+                redaction: "sanitized".into(),
+                retention: "debug".into(),
+                relative_path: "artifacts/result.json".into(),
+            }],
+        };
+        bundle.push(transferred(
+            "artifacts/index.json",
+            &serde_json::to_vec(&index).expect("index"),
+        ));
+        bundle.push(transferred("artifacts/result.json", payload));
+        install_transferred_journal(&out, &bundle).expect("second transfer");
+
+        let merged: crate::journal::ArtifactIndex =
+            serde_json::from_slice(&fs::read(out.join("artifacts/index.json")).expect("index"))
+                .expect("parse index");
+        let row = merged
+            .artifacts
+            .iter()
+            .find(|row| row.relative_path == "artifacts/result.json")
+            .expect("merged row");
+        assert_eq!(
+            row.producing_step, "step-000002",
+            "an artifact must follow its step to the id the local journal assigned"
+        );
+        assert_eq!(
+            fs::read(out.join("artifacts/result.json")).expect("payload"),
+            payload,
+            "the artifact payload still installs directly"
+        );
+    }
+
+    #[test]
+    fn a_bundle_without_a_journal_installs_verbatim_as_before() {
+        let root = TempDir::new().expect("root");
+        let out = root.path().join("journal");
+        let body = b"{\"collected\":true}";
+        let assigned = install_transferred_journal(&out, &[transferred("summary.json", body)])
+            .expect("install");
+        assert_eq!(
+            assigned, None,
+            "a response with no journal to merge assigns no step"
+        );
+        assert_eq!(
+            fs::read(out.join("summary.json")).expect("summary"),
+            body,
+            "a bundle this path does not recognize keeps the prior behavior"
+        );
+    }
+
+    #[test]
     fn ssh_transfers_append_to_one_journal_instead_of_replacing_it() {
         let root = TempDir::new().expect("root");
         let out = root.path().join("journal");

--- a/crates/macos-agent/src/transport/mod.rs
+++ b/crates/macos-agent/src/transport/mod.rs
@@ -19,7 +19,7 @@ use crate::backend;
 use crate::cli::{EvidenceMode, ExecArgs, McpArgs, OutputFormat, RuntimeMode, ToolProfile};
 use crate::commands;
 use crate::error::{CliError, ErrorClass};
-use crate::journal::ArtifactIndex;
+use crate::journal::{ArtifactIndex, StepRecord};
 use crate::lock::PeekabooLock;
 use crate::model::SuccessEnvelope;
 use crate::{process, test_mode};
@@ -162,7 +162,7 @@ pub fn run_remote_exec(args: &ExecArgs, format: OutputFormat) -> Result<u8, CliE
         .host
         .as_deref()
         .ok_or_else(|| transport_error("SSH host is required"))?;
-    let response = request(
+    let mut response = request(
         host,
         RemoteCommand::Exec {
             argv: args.argv.clone(),
@@ -174,7 +174,8 @@ pub fn run_remote_exec(args: &ExecArgs, format: OutputFormat) -> Result<u8, CliE
         },
         Duration::from_secs(args.timeout_seconds.clamp(1, 3600) + 30),
     )?;
-    install_transferred_files(&args.out_dir, &response.artifacts)?;
+    let assigned = install_transferred_journal(&args.out_dir, &response.artifacts)?;
+    rebind_journal_step(&mut response.result, assigned);
     emit_remote(format, "exec", response)
 }
 
@@ -287,7 +288,7 @@ pub fn run_remote_mcp(args: &McpArgs) -> Result<u8, CliError> {
         Duration::from_secs(30),
     );
     let collect_result = collected.and_then(|response| {
-        install_transferred_files(&args.out_dir, &response.artifacts)?;
+        install_transferred_journal(&args.out_dir, &response.artifacts)?;
         if response.ok {
             Ok(())
         } else {
@@ -862,6 +863,106 @@ fn collect_files(root: &Path) -> Result<Vec<TransferredFile>, CliError> {
     Ok(files)
 }
 
+/// Journal-control files a remote session emits. They describe the scratch
+/// session rather than the durable local journal, so they are merged rather
+/// than installed.
+const JOURNAL_CONTROL_FILES: [&str; 6] = [
+    "manifest.json",
+    "steps.jsonl",
+    "summary.json",
+    "redaction.json",
+    "review.json",
+    "artifacts/index.json",
+];
+
+/// Install one transferred bundle into the durable local journal.
+///
+/// Writing the control files verbatim would replace every step already
+/// recorded in this output directory, because the endpoint allocates a fresh
+/// session root per request and its journal always restarts at sequence 1.
+/// Artifact payloads still install directly. Returns the local step id
+/// assigned to the last ingested step.
+fn install_transferred_journal(
+    root: &Path,
+    files: &[TransferredFile],
+) -> Result<Option<String>, CliError> {
+    let has = |name: &str| files.iter().any(|file| file.relative_path == name);
+    if !has("manifest.json") || !has("steps.jsonl") {
+        install_transferred_files(root, files)?;
+        return Ok(None);
+    }
+
+    let mut payload = Vec::new();
+    let mut manifest_body = Vec::new();
+    let mut steps_body = Vec::new();
+    let mut index_body = None;
+    for file in files {
+        match file.relative_path.as_str() {
+            "manifest.json" => manifest_body = decode_transferred(file)?,
+            "steps.jsonl" => steps_body = decode_transferred(file)?,
+            "artifacts/index.json" => index_body = Some(decode_transferred(file)?),
+            other if JOURNAL_CONTROL_FILES.contains(&other) => {}
+            _ => payload.push(file.clone()),
+        }
+    }
+    install_transferred_files(root, &payload)?;
+
+    let manifest = serde_json::from_slice(&manifest_body)
+        .map_err(|_| transport_error("remote journal manifest is malformed"))?;
+    let steps = parse_transferred_steps(&steps_body)?;
+    let index = index_body
+        .map(|body| {
+            serde_json::from_slice::<ArtifactIndex>(&body)
+                .map_err(|_| transport_error("remote artifact index is malformed"))
+        })
+        .transpose()?;
+    let assigned = crate::journal::ingest_transfer(
+        root,
+        crate::journal::TransferredJournal {
+            manifest,
+            steps,
+            index,
+        },
+    )?;
+    Ok(assigned.last().cloned())
+}
+
+fn decode_transferred(file: &TransferredFile) -> Result<Vec<u8>, CliError> {
+    let body = base64::engine::general_purpose::STANDARD
+        .decode(&file.data_base64)
+        .map_err(|_| transport_error("remote artifact encoding is malformed"))?;
+    if body.len() > MAX_TRANSFER_BYTES || hex(&Sha256::digest(&body)) != file.sha256 {
+        return Err(transport_error(
+            "remote artifact digest or bundle size is invalid",
+        ));
+    }
+    Ok(body)
+}
+
+fn parse_transferred_steps(body: &[u8]) -> Result<Vec<StepRecord>, CliError> {
+    let mut steps = Vec::new();
+    for line in body.split(|byte| *byte == b'\n') {
+        if line.is_empty() {
+            continue;
+        }
+        steps.push(
+            serde_json::from_slice(line)
+                .map_err(|_| transport_error("remote journal step is malformed"))?,
+        );
+    }
+    Ok(steps)
+}
+
+/// Rebind an emitted exec result to the step id the local journal assigned.
+fn rebind_journal_step(result: &mut Option<serde_json::Value>, step: Option<String>) {
+    let (Some(value), Some(step)) = (result.as_mut(), step) else {
+        return;
+    };
+    if let Some(object) = value.as_object_mut() {
+        object.insert("journal_step".into(), serde_json::Value::String(step));
+    }
+}
+
 fn install_transferred_files(root: &Path, files: &[TransferredFile]) -> Result<(), CliError> {
     if files.len() > MAX_TRANSFER_FILES {
         return Err(transport_error(
@@ -1184,10 +1285,12 @@ fn transport_error(message: impl Into<String>) -> CliError {
 
 #[cfg(test)]
 mod tests {
+    use crate::cli::{EvidenceMode, RuntimeMode};
     use std::fs;
     use std::io::Cursor;
     use std::os::unix::fs::symlink;
     use std::os::unix::process::CommandExt;
+    use std::path::Path;
     use std::process::{Command, Stdio};
     use std::sync::{Arc, Barrier};
     use std::time::{Duration, Instant};
@@ -1197,8 +1300,8 @@ mod tests {
 
     use super::{
         MAX_REMOTE_SESSION_ROOTS, ProcessGroupChild, TransferredFile, collect_files,
-        create_bounded_remote_session, install_transferred_files, read_bounded_line,
-        remove_session, validate_host, validate_relative,
+        create_bounded_remote_session, install_transferred_files, install_transferred_journal,
+        read_bounded_line, remove_session, validate_host, validate_relative,
     };
 
     #[test]
@@ -1304,6 +1407,145 @@ mod tests {
             "allocation lock escaped the fixture into {}",
             stray.display()
         );
+    }
+
+    fn transferred(relative: &str, body: &[u8]) -> TransferredFile {
+        TransferredFile {
+            relative_path: relative.into(),
+            sha256: super::hex(&sha2::Sha256::digest(body)),
+            data_base64: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, body),
+        }
+    }
+
+    /// One remote exec bundle. The endpoint allocates a fresh session per
+    /// request, so every bundle restarts at sequence 1 with its own run id.
+    fn remote_exec_bundle(run: &str, intent: &str, digest: &str) -> Vec<TransferredFile> {
+        let manifest = crate::journal::Manifest {
+            schema_version: crate::journal::JOURNAL_SCHEMA.into(),
+            run_id: run.into(),
+            adapter_version: env!("CARGO_PKG_VERSION").into(),
+            peekaboo_tag: "v4.2.2".into(),
+            peekaboo_commit: "0".repeat(40),
+            backend_digest: digest.into(),
+            runtime: RuntimeMode::App,
+            transport: "ssh".into(),
+            evidence_mode: EvidenceMode::Minimal,
+            tool_profile: None,
+            started_at: "2026-01-01T00:00:00Z".into(),
+            closed_at: Some("2026-01-01T00:00:02Z".into()),
+            state: "closed".into(),
+        };
+        let step = crate::journal::StepRecord {
+            schema_version: "macos-agent.journal-step.v2".into(),
+            sequence: 1,
+            id: "step-000001".into(),
+            correlation_id: format!("{run}-step-000001"),
+            parent_id: None,
+            recorded_at: "2026-01-01T00:00:01Z".into(),
+            intent: Some(intent.into()),
+            expected: None,
+            command: "see".into(),
+            mcp_method: None,
+            mcp_tool: None,
+            argv_shape: vec!["see".into()],
+            replay_argv: Some(vec!["see".into()]),
+            backend_digest: digest.into(),
+            runtime: RuntimeMode::App,
+            transport: "ssh".into(),
+            status: crate::journal::StepStatus::Passed,
+            failure_class: None,
+            duration_ms: 1,
+            retries: 0,
+            precondition_refs: Vec::new(),
+            postcondition_refs: Vec::new(),
+            snapshot_lineage: None,
+            replay_class: crate::journal::ReplayClass::Safe,
+            artifact_refs: Vec::new(),
+        };
+        let mut steps = serde_json::to_vec(&step).expect("step");
+        steps.push(b'\n');
+        vec![
+            transferred(
+                "manifest.json",
+                &serde_json::to_vec(&manifest).expect("manifest"),
+            ),
+            transferred("steps.jsonl", &steps),
+            transferred("summary.json", b"{\"stale\":true}"),
+        ]
+    }
+
+    fn journal_steps(root: &Path) -> Vec<crate::journal::StepRecord> {
+        fs::read_to_string(root.join("steps.jsonl"))
+            .expect("steps")
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("step"))
+            .collect()
+    }
+
+    #[test]
+    fn ssh_transfers_append_to_one_journal_instead_of_replacing_it() {
+        let root = TempDir::new().expect("root");
+        let out = root.path().join("journal");
+
+        let first = install_transferred_journal(
+            &out,
+            &remote_exec_bundle("run-a", "first", "sha256:fixture"),
+        )
+        .expect("first transfer");
+        let second = install_transferred_journal(
+            &out,
+            &remote_exec_bundle("run-b", "second", "sha256:fixture"),
+        )
+        .expect("second transfer");
+        assert_eq!(first.as_deref(), Some("step-000001"));
+        assert_eq!(second.as_deref(), Some("step-000002"));
+
+        let steps = journal_steps(&out);
+        assert_eq!(steps.len(), 2, "second transfer replaced the first");
+        assert_eq!(steps[0].sequence, 1);
+        assert_eq!(steps[1].sequence, 2);
+        assert_eq!(steps[0].intent.as_deref(), Some("first"));
+        assert_eq!(steps[1].intent.as_deref(), Some("second"));
+        assert_eq!(steps[1].id, "step-000002");
+
+        // The local journal owns run identity and its derived views; a later
+        // transfer joins the session rather than rebranding it.
+        let manifest: crate::journal::Manifest =
+            serde_json::from_slice(&fs::read(out.join("manifest.json")).expect("manifest"))
+                .expect("parse manifest");
+        assert_eq!(manifest.run_id, "run-a");
+        assert!(
+            steps
+                .iter()
+                .all(|step| step.correlation_id.starts_with("run-a-"))
+        );
+        let summary: crate::journal::Summary =
+            serde_json::from_slice(&fs::read(out.join("summary.json")).expect("summary"))
+                .expect("parse summary");
+        assert_eq!(summary.total_steps, 2);
+    }
+
+    #[test]
+    fn a_transfer_from_a_different_execution_tuple_is_refused_without_loss() {
+        let root = TempDir::new().expect("root");
+        let out = root.path().join("journal");
+        install_transferred_journal(
+            &out,
+            &remote_exec_bundle("run-a", "first", "sha256:fixture"),
+        )
+        .expect("first transfer");
+
+        assert!(
+            install_transferred_journal(
+                &out,
+                &remote_exec_bundle("run-b", "second", "sha256:replaced-backend")
+            )
+            .is_err(),
+            "a drifted backend digest must not silently join the journal"
+        );
+        let steps = journal_steps(&out);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].intent.as_deref(), Some("first"));
     }
 
     #[test]

--- a/crates/macos-agent/src/transport/mod.rs
+++ b/crates/macos-agent/src/transport/mod.rs
@@ -896,16 +896,21 @@ fn install_transferred_journal(
     let mut manifest_body = Vec::new();
     let mut steps_body = Vec::new();
     let mut index_body = None;
+    // Control files are decoded here rather than installed, so their bytes must
+    // still be charged against the one transfer budget the payload install
+    // enforces. Charging them separately would multiply the bound by the number
+    // of parts the bundle was split into.
+    let mut spent = 0usize;
     for file in files {
         match file.relative_path.as_str() {
-            "manifest.json" => manifest_body = decode_transferred(file)?,
-            "steps.jsonl" => steps_body = decode_transferred(file)?,
-            "artifacts/index.json" => index_body = Some(decode_transferred(file)?),
+            "manifest.json" => manifest_body = decode_transferred(file, &mut spent)?,
+            "steps.jsonl" => steps_body = decode_transferred(file, &mut spent)?,
+            "artifacts/index.json" => index_body = Some(decode_transferred(file, &mut spent)?),
             other if JOURNAL_CONTROL_FILES.contains(&other) => {}
             _ => payload.push(file.clone()),
         }
     }
-    install_transferred_files(root, &payload)?;
+    install_transferred_files_within(root, &payload, spent)?;
 
     let manifest = serde_json::from_slice(&manifest_body)
         .map_err(|_| transport_error("remote journal manifest is malformed"))?;
@@ -927,11 +932,12 @@ fn install_transferred_journal(
     Ok(assigned.last().cloned())
 }
 
-fn decode_transferred(file: &TransferredFile) -> Result<Vec<u8>, CliError> {
+fn decode_transferred(file: &TransferredFile, spent: &mut usize) -> Result<Vec<u8>, CliError> {
     let body = base64::engine::general_purpose::STANDARD
         .decode(&file.data_base64)
         .map_err(|_| transport_error("remote artifact encoding is malformed"))?;
-    if body.len() > MAX_TRANSFER_BYTES || hex(&Sha256::digest(&body)) != file.sha256 {
+    *spent = spent.saturating_add(body.len());
+    if *spent > MAX_TRANSFER_BYTES || hex(&Sha256::digest(&body)) != file.sha256 {
         return Err(transport_error(
             "remote artifact digest or bundle size is invalid",
         ));
@@ -964,6 +970,16 @@ fn rebind_journal_step(result: &mut Option<serde_json::Value>, step: Option<Stri
 }
 
 fn install_transferred_files(root: &Path, files: &[TransferredFile]) -> Result<(), CliError> {
+    install_transferred_files_within(root, files, 0)
+}
+
+/// Install transferred payload files against a shared transfer budget, so a
+/// bundle split into separately decoded parts still respects one size bound.
+fn install_transferred_files_within(
+    root: &Path,
+    files: &[TransferredFile],
+    spent: usize,
+) -> Result<(), CliError> {
     if files.len() > MAX_TRANSFER_FILES {
         return Err(transport_error(
             "remote artifact response exceeds its file bound",
@@ -977,7 +993,7 @@ fn install_transferred_files(root: &Path, files: &[TransferredFile]) -> Result<(
         ));
     }
     create_private_dir(root)?;
-    let mut total = 0usize;
+    let mut total = spent;
     for file in files {
         validate_relative(&file.relative_path)?;
         let body = base64::engine::general_purpose::STANDARD
@@ -1300,8 +1316,9 @@ mod tests {
 
     use super::{
         MAX_REMOTE_SESSION_ROOTS, ProcessGroupChild, TransferredFile, collect_files,
-        create_bounded_remote_session, install_transferred_files, install_transferred_journal,
-        read_bounded_line, remove_session, validate_host, validate_relative,
+        create_bounded_remote_session, decode_transferred, install_transferred_files,
+        install_transferred_journal, read_bounded_line, remove_session, validate_host,
+        validate_relative,
     };
 
     #[test]
@@ -1480,6 +1497,80 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(line).expect("step"))
             .collect()
+    }
+
+    #[test]
+    fn control_bytes_and_payload_share_one_transfer_budget() {
+        // Splitting a bundle into separately decoded parts must not multiply
+        // the size bound by the number of parts.
+        let mut spent = 0usize;
+        let first = transferred("manifest.json", b"0123456789");
+        let second = transferred("steps.jsonl", b"01234");
+        decode_transferred(&first, &mut spent).expect("first");
+        assert_eq!(spent, 10);
+        decode_transferred(&second, &mut spent).expect("second");
+        assert_eq!(spent, 15, "each decoded part charges the shared budget");
+
+        let mut exhausted = super::MAX_TRANSFER_BYTES;
+        assert!(
+            decode_transferred(&second, &mut exhausted).is_err(),
+            "a decoded control file must respect an already spent budget"
+        );
+    }
+
+    #[test]
+    fn a_transfer_that_cannot_fit_the_rotation_bound_is_refused_whole() {
+        let root = TempDir::new().expect("root");
+        let out = root.path().join("journal");
+        fs::create_dir_all(&out).expect("out");
+
+        // Seed a journal that is already at the bound. Appending until the
+        // bound is hit would leave a partially merged transfer behind an error.
+        let bundle = remote_exec_bundle("run-a", "seed", "sha256:fixture");
+        let manifest = bundle
+            .iter()
+            .find(|file| file.relative_path == "manifest.json")
+            .expect("manifest");
+        let mut spent = 0usize;
+        fs::write(
+            out.join("manifest.json"),
+            decode_transferred(manifest, &mut spent).expect("manifest body"),
+        )
+        .expect("write manifest");
+        let template: crate::journal::StepRecord = serde_json::from_slice(
+            &decode_transferred(
+                bundle
+                    .iter()
+                    .find(|file| file.relative_path == "steps.jsonl")
+                    .expect("steps"),
+                &mut spent,
+            )
+            .expect("steps body"),
+        )
+        .expect("template");
+        let mut seeded = Vec::new();
+        for sequence in 1..=512u64 {
+            let mut step = template.clone();
+            step.sequence = sequence;
+            step.id = format!("step-{sequence:06}");
+            seeded.extend(serde_json::to_vec(&step).expect("step"));
+            seeded.push(b'\n');
+        }
+        fs::write(out.join("steps.jsonl"), &seeded).expect("write steps");
+
+        assert!(
+            install_transferred_journal(
+                &out,
+                &remote_exec_bundle("run-b", "overflow", "sha256:fixture")
+            )
+            .is_err(),
+            "a transfer past the rotation bound must be refused"
+        );
+        assert_eq!(
+            journal_steps(&out).len(),
+            512,
+            "the refused transfer must not have partially merged"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1512. Closes #1513.

Both defects were found in one live acceptance run against an SSH-reachable
macOS target, `macos-agent` 1.27.11 on both ends with the locked Peekaboo
v4.2.2 backend.

**The SSH journal was being replaced, not appended.** The endpoint allocates a
fresh session root for every request, so the transferred `steps.jsonl` always
restarts at sequence 1 with its own `run_id`. `install_transferred_files` then
wrote it over the durable journal in `--out-dir`, and the remote session was
deleted immediately after — so the overwritten history was unrecoverable.
Three identical successful `exec` calls into one fresh directory left a single
step. That made the 512-step rotation bound unreachable over SSH, broke the
documented chained-`exec` flow contract, and let `journal summarize`, `review`,
and `replay-plan` under-report every earlier failure in a flow. Failure was
silent: nothing in the result, exit code, or journal said steps were dropped.

The controller now merges instead. Artifact payloads install directly; the
journal-control files are verified, parsed, and merged under the journal lock,
reassigning local sequences, ids, and correlation ids, remapping a parent named
inside the same transfer, rewriting merged artifact index rows, and rebuilding
the summary and redaction report. The local manifest keeps its run identity,
and a transfer whose execution tuple drifted is refused without losing the
steps already recorded — the same homogeneity rule `open_with_digest` enforces
for local runs. First-call behavior is unchanged. `run_remote_mcp` uses the
same path, so a reused MCP output directory stops being clobbered too.

**A refused mutation reviewed as clean.** Classification read only the process
exit code, so a mutation Peekaboo explicitly refused
(`effect: "refused"`, `refusal_reason: "target_unavailable"`,
`mutation_dispatched: false`, `escalation: "refresh_target"`) landed as generic
`upstream` and `journal review` returned `clean: true`. A false clean on a
refused mutation is a functional blocker under the runtime acceptance standard.

`exec` now classifies from the v4 outcome envelope when it is present: a
refusal becomes `upstream_refused` and is always significant, an upstream that
reports its own failure at exit zero becomes `false_success`, and an envelope
proving no mutation dispatched resolves an otherwise unknown mutation. A result
without an envelope keeps the exit-code rules unchanged, so nothing regresses
for non-v4 output. No new capability, tool, replay class, or emitted field.

## Test plan

Two new transport tests and one new journal test. Both transport tests fail
against the pre-change install-verbatim behavior — reproduced by delegating
`install_transferred_journal` back to `install_transferred_files` — with
`left: None, right: Some("step-000001")` and
`a drifted backend digest must not silently join the journal`.

- `cargo test -p nils-macos-agent --lib` — 66 passed, 0 failed.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — fmt, clippy,
  and 135 unit plus integration tests pass, including the existing
  `mcp::ssh_mcp_has_the_same_protocol_and_transfers_its_sanitized_journal`
  contract.

`crates/macos-agent/docs/specs/macos-agent-journal-v2.md` gains a remote
transfer merge section and records the refusal classification.

## Residual gap

The merge path is proven by unit and integration tests rather than a live SSH
round trip, because a round trip needs a matching adapter build on both ends
and that only exists once this ships. The endpoint side is unchanged, so the
merge is controller-local. A chained SSH flow should be exercised on the next
live computer-use acceptance after deployment.
