### PR TITLE
fix(agent-hook): allow exact Git version inspection

### DIFF
--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -2833,6 +2833,9 @@ fn semantic_delivery_blocked(
 }
 
 fn git_delivery_context(words: &[String], base: &Path) -> Result<Option<(PathBuf, usize)>, ()> {
+    if matches!(words, [executable, flag] if basename(executable) == "git" && flag == "--version") {
+        return Ok(None);
+    }
     let mut target = base.to_path_buf();
     let mut index = 1;
     while index < words.len() {

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -1672,6 +1672,8 @@ fn unsafe_default_delivery_blocks_default_branch_and_allows_feature_refs() {
         ),
         ("git fetch origin feature:refs/heads/feature", 0, "allow"),
         ("git push origin feature", 0, "allow"),
+        ("git --version", 0, "allow"),
+        ("git --version unexpected", 1, "block"),
         ("git log HEAD~1", 0, "allow"),
         ("git for-each-ref --format='%(refname)'", 0, "allow"),
         ("git grep 'foo.*'", 0, "allow"),


### PR DESCRIPTION
## Summary

- Admit only the exact two-token `git --version` inspection before Git delivery parsing.
- Preserve fail-closed behavior for extra arguments, unknown Git forms, and default-branch delivery.
- Add DSH policy matrix coverage for both the allowed query and the blocked boundary.

Refs https://github.com/serenvia/sympoies-infra/issues/213

## Test plan

- [x] `cargo test -p nils-agent-hook --test dsh_policy unsafe_default_delivery_blocks_default_branch_and_allows_feature_refs -- --exact`
- [x] `cargo test -p nils-agent-hook --test dsh_policy`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`