### PR TITLE
fix(forge-cli): name the remedy in review-loop merge-gate errors

### DIFF
--- a/crates/forge-cli/src/ops/pr_review_loop.rs
+++ b/crates/forge-cli/src/ops/pr_review_loop.rs
@@ -717,8 +717,15 @@ pub fn ensure_merge_ready<R: BackendRunner>(
             return Err(ForgeError::validation(
                 schema_err(),
                 "review_state_conflict",
-                "bounded review delivery requires an explicit genesis ledger observation",
-                Some(format!("pr={number}; expected_head={expected_head}")),
+                "bounded review delivery requires an explicit genesis ledger observation; \
+                 record the reviewed head with `forge-cli pr review-loop observe <id> \
+                 --expected-head <sha> --findings-file <path>` (a bare `[]` array records a \
+                 clean review), or pass --review-convergence=false to deliver without the \
+                 enforced review policy",
+                Some(format!(
+                    "pr={number}; expected_head={expected_head}; \
+                     required_by=[review_convergence].require"
+                )),
             ));
         }
         return Ok(None);
@@ -733,7 +740,9 @@ pub fn ensure_merge_ready<R: BackendRunner>(
                     "review_finding_reopened" => "review_finding_reopened",
                     _ => "review_state_conflict",
                 },
-                "the durable review-loop hard stop blocks merge",
+                "the durable review-loop hard stop blocks merge; clear it with \
+                 `forge-cli pr review-loop extend` once a provider-visible approval comment \
+                 carries the approval_marker reported in this detail",
                 None,
             ),
             stop,
@@ -745,7 +754,9 @@ pub fn ensure_merge_ready<R: BackendRunner>(
         return Err(ForgeError::validation(
             schema_err(),
             "review_state_conflict",
-            "the latest review-loop observation is not bound to the merge head",
+            "the latest review-loop observation is not bound to the merge head; re-review the \
+             current head and record it with `forge-cli pr review-loop observe <id> \
+             --expected-head <merge_head> --findings-file <path>`",
             Some(format!(
                 "merge_head={expected_head}; review_loop_head={}",
                 state.head_sha
@@ -764,7 +775,10 @@ pub fn ensure_merge_ready<R: BackendRunner>(
         return Err(ForgeError::validation(
             schema_err(),
             "review_findings_open",
-            "the durable review-loop ledger still contains blocking open findings",
+            "the durable review-loop ledger still contains blocking open findings; repair them, \
+             push, then record the repaired head with `forge-cli pr review-loop observe <id> \
+             --expected-head <sha> --findings-file <path>` carrying disposition `fixed` (use \
+             `accepted`, `preference`, or `follow-up` when no repair is warranted)",
             Some(format!("findings={}", open_blocking_findings.join(","))),
         ));
     }
@@ -797,7 +811,8 @@ pub fn recheck_merge_ready<R: BackendRunner>(
             ForgeError::validation(
                 schema_err(),
                 "review_state_conflict",
-                "the review-loop state disappeared before merge",
+                "the review-loop state disappeared before merge; a concurrent ledger write \
+                 raced this delivery, so re-run it to re-read the chain",
                 None,
             )
         })?;
@@ -805,7 +820,8 @@ pub fn recheck_merge_ready<R: BackendRunner>(
         return Err(ForgeError::validation(
             schema_err(),
             "review_state_conflict",
-            "the review-loop state changed after merge gates and before provider merge",
+            "the review-loop state changed after merge gates and before provider merge; a \
+             concurrent ledger write raced this delivery, so re-run it to re-read the chain",
             Some(format!(
                 "expected_tip={}; provider_tip={}",
                 previous.state_tip_digest, current.state_tip_digest
@@ -3099,6 +3115,25 @@ mod tests {
         .expect_err("bounded delivery needs a ledger");
 
         assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error.message().contains("forge-cli pr review-loop observe"),
+            "the gate must name the command that satisfies it: {}",
+            error.message()
+        );
+        assert!(
+            error.message().contains("--review-convergence=false"),
+            "the gate must name its bypass: {}",
+            error.message()
+        );
+        // This is the only merge gate whose trigger is invisible on the pull
+        // request itself, so the detail has to name the config that armed it.
+        assert!(
+            error
+                .detail()
+                .is_some_and(|detail| detail.contains("required_by=[review_convergence].require")),
+            "the gate must name the config key that enabled it: {:?}",
+            error.detail()
+        );
     }
 
     #[test]
@@ -3126,6 +3161,11 @@ mod tests {
         .expect_err("hard stop blocks merge");
 
         assert_eq!(error.kind(), "review_round_limit_exceeded");
+        assert!(
+            error.message().contains("forge-cli pr review-loop extend"),
+            "the gate must name the command that clears it: {}",
+            error.message()
+        );
     }
 
     #[test]
@@ -3144,6 +3184,11 @@ mod tests {
         .expect_err("ledger head mismatch");
 
         assert_eq!(error.kind(), "review_state_conflict");
+        assert!(
+            error.message().contains("forge-cli pr review-loop observe"),
+            "the gate must name the command that rebinds the ledger: {}",
+            error.message()
+        );
         assert!(
             error
                 .detail()
@@ -3170,6 +3215,12 @@ mod tests {
         .expect_err("blocking findings stay open");
 
         assert_eq!(error.kind(), "review_findings_open");
+        assert!(
+            error.message().contains("forge-cli pr review-loop observe")
+                && error.message().contains("fixed"),
+            "the gate must name the command and disposition that clear it: {}",
+            error.message()
+        );
         assert!(
             error
                 .detail()


### PR DESCRIPTION
## Summary

Every blocking gate in the `pr merge` / `pr deliver` rule set states its remedy.
The review-loop gates do not, so hitting one tells you that delivery stopped but
not how to continue.

Existing convention — **problem → how to satisfy → how to bypass**:

```
Rule 13  "{n} unresolved review thread(s) on the PR/MR; disposition each (repair /
          resolve as accepted / convert to a follow-up) or pass
          --allow-unresolved-threads to bypass"

Rule 14  "{n} unchecked task-list item(s) in the PR/MR description; disposition each
          (...) or pass --allow-unchecked-tasks with --allow-unchecked-tasks-reason
          to bypass"

create   "this repo requires test-first evidence for feature/bug PRs; pass
          --test-first-evidence <dir> pointing at a verified ... record"
```

Review-loop, before this change:

```
"bounded review delivery requires an explicit genesis ledger observation"
detail: "pr=392; expected_head=<sha>"
```

The genesis gate deserves the most attention because **it is the only merge gate
whose trigger is invisible on the pull request**. Unresolved threads, unchecked
boxes, and missing evidence are all visible in the PR or the invocation. This one
fires from `[review_convergence].require` in a config file the operator may have
set months earlier, and the error named neither the config nor the command that
satisfies it.

## Changes

Six messages in `ensure_merge_ready` / `recheck_merge_ready` now name their remedy:

| kind | added remedy |
|---|---|
| `review_state_conflict` (genesis) | `pr review-loop observe`, the empty-`[]` clean-review form, and `--review-convergence=false`; detail gains `required_by=[review_convergence].require` |
| hard stop | `pr review-loop extend` once an approval comment carries the `approval_marker` already reported in the detail |
| `review_state_conflict` (head drift) | re-observe at the merge head |
| `review_findings_open` | repair, push, re-observe with disposition `fixed` (or `accepted` / `preference` / `follow-up`) |
| `review_state_conflict` (state vanished / changed pre-merge) | names the concurrent-write race and says to re-run |

No behavior, error kind, exit code, or schema changes — message and detail text only.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` green: 1362 tests
  passed (one pre-existing flaky `forgejo_issue_list_paginates_and_excludes_pull_requests`,
  unrelated to this change), plus fmt, clippy, and doc tests.
- The four `merge_gate_*` tests asserted only `error.kind()`; they now also pin the
  remedy content, so a future refactor cannot silently drop it.
- Test-first evidence: on the pre-change file, `forge-cli pr review-loop observe`,
  `forge-cli pr review-loop extend`, and `required_by=[review_convergence].require`
  each occur **0 times**, so every added assertion fails against the old messages.
