### PR TITLE
fix(agent-session): preserve tmux liveness under C locale

### DIFF
--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -11928,6 +11928,13 @@ struct TmuxSessionSnapshots {
     sessions: BTreeMap<String, TmuxSessionSnapshot>,
 }
 
+// tmux sanitizes control characters in format output under a C locale. Keep
+// the bulk snapshot delimiter printable, parse it from the right so even an
+// unusual pre-existing session name containing the delimiter remains intact,
+// and continue accepting prior tab-delimited fixture or wrapper output.
+const TMUX_SESSION_SNAPSHOT_FORMAT: &str = "#{session_name}|#{window_activity}";
+const TMUX_SESSION_SNAPSHOT_SEPARATOR: char = '|';
+
 impl TmuxSessionSnapshots {
     fn contains_key(&self, tmux_session: &str) -> bool {
         self.sessions.contains_key(tmux_session)
@@ -11965,7 +11972,7 @@ fn tmux_session_snapshots(tmux_bin: &Path) -> Option<TmuxSessionSnapshots> {
         .arg("list-windows")
         .arg("-a")
         .arg("-F")
-        .arg("#{session_name}\t#{window_activity}")
+        .arg(TMUX_SESSION_SNAPSHOT_FORMAT)
         .output()
         .ok()?;
     if !output.status.success() {
@@ -11974,7 +11981,10 @@ fn tmux_session_snapshots(tmux_bin: &Path) -> Option<TmuxSessionSnapshots> {
     let raw = String::from_utf8_lossy(&output.stdout);
     let mut activity_by_session: BTreeMap<String, Option<i64>> = BTreeMap::new();
     for line in raw.lines() {
-        let Some((session, activity)) = line.split_once('\t') else {
+        let Some((session, activity)) = line
+            .rsplit_once(TMUX_SESSION_SNAPSHOT_SEPARATOR)
+            .or_else(|| line.split_once('\t'))
+        else {
             continue;
         };
         if session.is_empty() {
@@ -22638,6 +22648,48 @@ fi
         let views = super::list_sessions(&context, Some(&tmux)).unwrap();
         assert_eq!(views.len(), 2);
         assert_eq!(fs::read_to_string(calls).unwrap(), "list-windows\n");
+    }
+
+    #[test]
+    fn list_bulk_tmux_probe_survives_c_locale_control_character_sanitization() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let context = test_context(tmp.path());
+        let created = create_record(RecordRequest {
+            context: &context,
+            agent: AgentKind::Codex,
+            mode: "interactive",
+            coordination_mode: crate::cli::CoordinationMode::Advisory,
+            title: None,
+            title_state: None,
+            explicit_id: Some("bulk_locale_with_underscores"),
+            cwd: Path::new("/repo"),
+            prompt: None,
+            log_file_name: None,
+            provider_resume: None,
+            agent_args: Vec::new(),
+            agent_bin: None,
+        })
+        .unwrap();
+        let tmux = tmp.path().join("tmux");
+        fs::write(
+            &tmux,
+            format!(
+                "#!/bin/sh\nif [ \"$1\" = list-windows ]; then\n  case \"$4\" in\n    *'|'*) printf '%s|100\\n' {} ;;\n    *) printf '%s_100\\n' {} ;;\n  esac\n  exit 0\nfi\nif [ \"$1\" = has-session ]; then exit 0; fi\nexit 1\n",
+                shell_words::quote(&created.record.tmux_session),
+                shell_words::quote(&created.record.tmux_session),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&tmux, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let views = super::list_sessions(&context, Some(&tmux)).unwrap();
+
+        assert_eq!(views.len(), 1);
+        assert_eq!(views[0].status, "running");
+        assert_eq!(
+            views[0].last_terminal_activity_at.as_deref(),
+            Some("1970-01-01T00:01:40Z")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix `agent-session` bulk tmux liveness snapshots when the service runs without a UTF-8 locale, as macOS launchd jobs commonly do. The change is limited to the snapshot format and parser.

## Problem

- Expected: `agent-session list` and `agent-session serve` report a live tmux-backed session as `running`.
- Actual: tmux sanitizes the tab separator in format output under the C locale, so the bulk parser discards the live row and projects the session as `stopped`.
- Impact: Agent Console cannot attach to otherwise healthy Codex, Claude, or DSH sessions launched on an affected macOS host.

## Reproduction

1. Run `agent-session list` or `agent-session serve` from a launchd job without locale variables.
2. Keep a tmux-backed agent session live.
3. Observe that the tab-delimited bulk snapshot row is sanitized and the session is projected as `stopped`.

## Issues Found

- Upstream acceptance tracker: serenvia/sympoies-infra#213

## Fix Approach

- Emit a printable pipe separator for new bulk tmux snapshots so locale sanitization cannot remove the boundary.
- Parse the separator from the right, preserving unusual session names, and retain compatibility with prior tab-delimited wrapper or fixture output.
- Add a regression that models the C-locale sanitization and asserts both live status and activity time.

## Test-First Evidence

- RED: the new locale-sanitization regression failed with expected `running` and observed `stopped` before the production edit.
- GREEN: the same focused regression passed after the snapshot format/parser change.
- Durable test-first evidence is complete and delivery-bound for the current head.

## Test plan

- `cargo test -p nils-agent-session list_bulk_tmux_probe_survives_c_locale_control_character_sanitization -- --nocapture`
- `cargo test -p nils-agent-session list_reconciles_multiple_starting_records_with_one_bulk_tmux_probe -- --nocapture`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (fmt, clippy, audits, 1,181 nextest cases, and doctests passed)
- Public GitHub required checks must pass before merge.

## Risk / Notes

- Low: the parser accepts both the new printable delimiter and prior tab-delimited output; the behavior change is isolated to bulk liveness snapshots.
- Real macOS launchd and Agent Console GUI acceptance remains an outer deployment gate after the host is available.
