### PR TITLE
ci(nextest): point the retry mitigation at its live follow-up

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,10 +8,15 @@
 [profile.ci]
 # Retry a test that fails then passes, instead of failing the whole run. The
 # workspace has a few tests that are reliable in isolation but flake under
-# full-workspace parallelism (see issue #934); without retries a single such
-# flake spuriously reds the `test` / `test_macos` gate and blocks merge.
-# nextest still reports flaky-passes distinctly, so flakes stay visible. This
-# is mitigation; the root-cause isolation fix is tracked in #934.
+# full-workspace parallelism; without retries a single such flake spuriously
+# reds the `test` / `test_macos` gate and blocks merge.
+#
+# A retried pass is recorded as `<flakyFailure>` in `junit.xml` and printed as
+# `FLAKY n/m` in the job log, but the published JUnit check does not surface it
+# while `flaky_summary` stays at its default, so a masked flake is easy to miss.
+#
+# This is mitigation. Root-causing the masked flakes and lowering `retries` is
+# tracked in #1524 (the follow-up #934 planned but did not open).
 retries = 2
 
 # Process-containment fixtures own kernel tracking resources that cannot be


### PR DESCRIPTION
## Summary

Comment-only change to `.config/nextest.toml`. No behaviour change: `retries = 2`
and every override are untouched.

## Why

The `retries = 2` comment named #934 as the owner of the outstanding root-cause
work, but #934 is closed. It planned the follow-up and never opened it, so the
config pointed at a closed issue and nothing tracked the work. That follow-up is
now #1524.

The same comment also claimed:

> nextest still reports flaky-passes distinctly, so flakes stay visible.

That does not hold for the report people read. On run
[32955921290](https://github.com/sympoies/nils-cli/actions/runs/32955921290) the
`test` job masked a real failure in
`nils-git-cli::integration dirty_checkout_adoption::real_cli_worker_lifecycle_supports_a_non_utf8_checkout_root`.
The evidence exists — that run's `junit.xml` artifact carries two
`<flakyFailure>` elements and the job log prints `FLAKY 2/3` — but the summary
line is `failures="0" errors="0"`, and the `Publish JUnit report` step leaves
`flaky_summary` at its default `false`, so the published check shows nothing.

Both statements now match reality.

## Changes

- Retarget the tracking pointer from #934 to #1524.
- Replace the visibility claim with where a retried pass actually is recorded
  (`<flakyFailure>` in `junit.xml`, `FLAKY n/m` in the job log) and why it does
  not reach the published check.

## Test plan

- `cargo nextest list -p nils-agent-hook --lib --profile ci` — the `ci` profile
  still parses and resolves.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass.

## Test-first waiver

Comment-only CI configuration with no practical failing test. The behavioural
gap the comment describes is tracked in #1524; flipping `flaky_summary` is
proposed there as step 1, not here.

Refs #1524. Refs #934.
