### PR TITLE
chore(release): bump cli versions to 1.27.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-docs"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-hook"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-memory"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-out"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "chrono",
  "clap",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-runtime"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-scope-lock"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2192,7 +2192,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-session"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "axum",
  "clap",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "nils-agent-workflow-primitives"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-gql"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-grpc"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -2278,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-rest"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-test"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-testing-core"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "nils-api-websocket"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2350,11 +2350,11 @@ dependencies = [
 
 [[package]]
 name = "nils-build-info"
-version = "1.27.12"
+version = "1.27.13"
 
 [[package]]
 name = "nils-claude-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "nils-cli-template"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "nils-build-info",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "nils-codex-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2417,7 +2417,7 @@ dependencies = [
 
 [[package]]
 name = "nils-common"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "nils-docker-tools"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "nils-evidence"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "nils-forge-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "chrono",
  "clap",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "nils-fzf-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "nils-gemini-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2551,7 +2551,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-lock"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-scope"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "nils-git-summary"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "nils-github-app-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "nils-image-processing"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "nils-macos-agent"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "base64 0.23.1",
  "clap",
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "nils-markdown"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "nils-memo"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "nils-opencode-cli"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-archive"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-issue"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "chrono",
  "clap",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "nils-plan-tooling"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "nils-provider-resume"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "jiff",
  "nils-common",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "nils-screen-record"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "block2",
  "chrono",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "nils-scrub"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "regex",
  "serde",
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "nils-secrets"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "nils-semantic-commit"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "nils-term"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "indicatif",
  "pretty_assertions",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "nils-test-support"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "nils-web-evidence"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "clap",
  "clap_complete",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "nils-zsh-kit"
-version = "1.27.12"
+version = "1.27.13"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ resolver = "2"
 # edition.
 edition = "2024"
 license = "MIT"
-version = "1.27.12"
+version = "1.27.13"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,7 +3,7 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `f45636ee73d553c74ff6183b98ae9f9806b17fa558d7fa753a1461945f2e1b85`
+- Cargo.lock SHA256: `025e092dfee7a8595ef2aa635d0acf6cf150abecc88bbe48ed700cb4b03c31a2`
 - Third-party crates (`source != null`): 493
 - Workspace crates (`source == null`, excluded below): 46
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `f45636ee73d553c74ff6183b98ae9f9806b17fa558d7fa753a1461945f2e1b85`
+- Cargo.lock SHA256: `025e092dfee7a8595ef2aa635d0acf6cf150abecc88bbe48ed700cb4b03c31a2`
 - Third-party crates (`source != null`): 493
 
 ## Notice Extraction Policy

--- a/crates/agent-docs/Cargo.toml
+++ b/crates/agent-docs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-docs"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,8 +18,8 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 jiff = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -31,6 +31,6 @@ toml_edit = "0.25"
 libc = "0.2"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-hook/Cargo.toml
+++ b/crates/agent-hook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-hook"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -20,9 +20,9 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 jiff = { workspace = true }
 libc = { workspace = true }
-nils-agent-docs = { version = "1.27.12", path = "../agent-docs" }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-agent-docs = { version = "1.27.13", path = "../agent-docs" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -33,6 +33,6 @@ toml_edit = "0.25"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-memory/Cargo.toml
+++ b/crates/agent-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-memory"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,12 +18,12 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-out/Cargo.toml
+++ b/crates/agent-out/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-out"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -19,13 +19,13 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-runtime/Cargo.toml
+++ b/crates/agent-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-runtime"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 indexmap = { workspace = true }
-nils-markdown = { version = "1.27.12", path = "../nils-markdown", package = "nils-markdown" }
+nils-markdown = { version = "1.27.13", path = "../nils-markdown", package = "nils-markdown" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -31,5 +31,5 @@ minijinja = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/agent-scope-lock/Cargo.toml
+++ b/crates/agent-scope-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-scope-lock"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -15,12 +15,12 @@ path = "src/main.rs"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/agent-session/Cargo.toml
+++ b/crates/agent-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-session"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -23,10 +23,10 @@ path = "src/main_agent_bin.rs"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 jiff = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-agent-hook = { version = "1.27.12", path = "../agent-hook" }
-nils-provider-resume = { version = "1.27.12", path = "../nils-provider-resume", package = "nils-provider-resume" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-agent-hook = { version = "1.27.13", path = "../agent-hook" }
+nils-provider-resume = { version = "1.27.13", path = "../nils-provider-resume", package = "nils-provider-resume" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -43,7 +43,7 @@ libc = "0.2"
 notify = "8"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/agent-workflow-primitives/Cargo.toml
+++ b/crates/agent-workflow-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-agent-workflow-primitives"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -67,12 +67,12 @@ clap_complete = { workspace = true }
 jiff = { workspace = true }
 getrandom = { workspace = true }
 libc = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-agent-out = { version = "1.27.12", path = "../agent-out" }
-nils-agent-docs = { version = "1.27.12", path = "../agent-docs" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "1.27.12", path = "../nils-markdown", package = "nils-markdown" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-agent-out = { version = "1.27.13", path = "../agent-out" }
+nils-agent-docs = { version = "1.27.13", path = "../agent-docs" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "1.27.13", path = "../nils-markdown", package = "nils-markdown" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -80,6 +80,6 @@ sha2 = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-gql/Cargo.toml
+++ b/crates/api-gql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-gql"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -11,14 +11,14 @@ repository = "https://github.com/sympoies/nils-cli"
 name = "api-gql"
 path = "src/main.rs"
 [dependencies]
-api-testing-core = { version = "1.27.12", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "1.27.13", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-grpc/Cargo.toml
+++ b/crates/api-grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-grpc"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -11,15 +11,15 @@ repository = "https://github.com/sympoies/nils-cli"
 name = "api-grpc"
 path = "src/main.rs"
 [dependencies]
-api-testing-core = { version = "1.27.12", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "1.27.13", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.23"
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-rest/Cargo.toml
+++ b/crates/api-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-rest"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -11,15 +11,15 @@ repository = "https://github.com/sympoies/nils-cli"
 name = "api-rest"
 path = "src/main.rs"
 [dependencies]
-api-testing-core = { version = "1.27.12", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "1.27.13", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
 base64 = "0.23"
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-test/Cargo.toml
+++ b/crates/api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-test"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -15,15 +15,15 @@ path = "src/lib.rs"
 name = "api-test"
 path = "src/main.rs"
 [dependencies]
-api-testing-core = { version = "1.27.12", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "1.27.13", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-testing-core/Cargo.toml
+++ b/crates/api-testing-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-testing-core"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -24,10 +24,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting", "local-offset"] }
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/api-websocket/Cargo.toml
+++ b/crates/api-websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-api-websocket"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -11,15 +11,15 @@ repository = "https://github.com/sympoies/nils-cli"
 name = "api-websocket"
 path = "src/main.rs"
 [dependencies]
-api-testing-core = { version = "1.27.12", path = "../api-testing-core", package = "nils-api-testing-core" }
+api-testing-core = { version = "1.27.13", path = "../api-testing-core", package = "nils-api-testing-core" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake", "rustls-tls-webpki-roots"] }

--- a/crates/claude-cli/Cargo.toml
+++ b/crates/claude-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-claude-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -21,10 +21,10 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = "0.2"
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-provider-resume = { version = "1.27.12", path = "../nils-provider-resume", package = "nils-provider-resume" }
-nils-scrub = { version = "1.27.12", path = "../nils-scrub" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-provider-resume = { version = "1.27.13", path = "../nils-provider-resume", package = "nils-provider-resume" }
+nils-scrub = { version = "1.27.13", path = "../nils-scrub" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -32,5 +32,5 @@ tempfile = "3"
 
 [dev-dependencies]
 libc = "0.2"
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/cli-template/Cargo.toml
+++ b/crates/cli-template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-cli-template"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -12,14 +12,14 @@ name = "cli-template"
 path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/codex-cli/Cargo.toml
+++ b/crates/codex-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-codex-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -21,19 +21,19 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 getrandom = { workspace = true }
 libc = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "form", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 shell-words = { workspace = true }
 toml = { workspace = true }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-provider-resume = { version = "1.27.12", path = "../nils-provider-resume", package = "nils-provider-resume" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-provider-resume = { version = "1.27.13", path = "../nils-provider-resume", package = "nils-provider-resume" }
 tempfile = "3"
 
 [dev-dependencies]
 jsonschema = { version = "0.49", default-features = false }
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/docker-tools/Cargo.toml
+++ b/crates/docker-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-docker-tools"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,11 +18,11 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 shell-words = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/forge-cli/Cargo.toml
+++ b/crates/forge-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-forge-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -20,10 +20,10 @@ clap = { workspace = true }
 clap_complete = { workspace = true }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 jiff = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 libc = "0.2"
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-agent-workflow-primitives = { version = "1.27.12", path = "../agent-workflow-primitives", package = "nils-agent-workflow-primitives" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+agent-workflow-primitives = { version = "1.27.13", path = "../agent-workflow-primitives", package = "nils-agent-workflow-primitives" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 serde_yaml_ng = { workspace = true }
@@ -35,5 +35,5 @@ url = "2"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/fzf-cli/Cargo.toml
+++ b/crates/fzf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-fzf-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -14,15 +14,15 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/gemini-cli/Cargo.toml
+++ b/crates/gemini-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-gemini-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -19,11 +19,11 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 serde_json = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-cli/Cargo.toml
+++ b/crates/git-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -19,10 +19,10 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 getrandom = { workspace = true }
-git-summary = { version = "1.27.12", path = "../git-summary", package = "nils-git-summary" }
+git-summary = { version = "1.27.13", path = "../git-summary", package = "nils-git-summary" }
 libc = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha2 = { workspace = true }
@@ -30,6 +30,6 @@ thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/git-lock/Cargo.toml
+++ b/crates/git-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-lock"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -14,12 +14,12 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 chrono = { version = "0.4", features = ["clock"] }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 tempfile = "3"
 pretty_assertions = { workspace = true }

--- a/crates/git-scope/Cargo.toml
+++ b/crates/git-scope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-scope"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -14,10 +14,10 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 tempfile = "3"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }

--- a/crates/git-summary/Cargo.toml
+++ b/crates/git-summary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-git-summary"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -20,12 +20,12 @@ anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/github-app-cli/Cargo.toml
+++ b/crates/github-app-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-github-app-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -26,12 +26,12 @@ clap_complete = { workspace = true }
 # cost — while the pure-Rust `rust_crypto` backend drags in `rsa` (RUSTSEC-2023-0071)
 # and a duplicate old-generation RustCrypto/EC tree. We only mint RS256 App JWTs.
 jsonwebtoken = { version = "11", default-features = false, features = ["use_pem", "aws_lc_rs"] }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/image-processing/Cargo.toml
+++ b/crates/image-processing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-image-processing"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -14,19 +14,19 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 resvg = "0.48"
 roxmltree = "0.21"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/macos-agent/Cargo.toml
+++ b/crates/macos-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-macos-agent"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,16 +18,16 @@ path = "src/main.rs"
 base64 = "0.23"
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 jiff = { workspace = true }
 libc = "0.2"
 roxmltree = "0.21"
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/memo/Cargo.toml
+++ b/crates/memo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-memo"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -19,16 +19,16 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = "0.10"
 rusqlite = { version = "0.40.1", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-build-info/Cargo.toml
+++ b/crates/nils-build-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-build-info"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/nils-common/Cargo.toml
+++ b/crates/nils-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-common"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-common in the nils-cli workspace."
@@ -19,6 +19,6 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-evidence/Cargo.toml
+++ b/crates/nils-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-evidence"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 indexmap = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-scrub = { version = "1.27.12", path = "../nils-scrub" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-scrub = { version = "1.27.13", path = "../nils-scrub" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
@@ -30,6 +30,6 @@ thiserror = { workspace = true }
 time = { version = "0.3", features = ["formatting"] }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/nils-markdown/Cargo.toml
+++ b/crates/nils-markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-markdown"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 description = "Shared minijinja-backed Markdown template layer for the nils-cli workspace."
@@ -36,8 +36,8 @@ anyhow = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 clap_complete = { workspace = true, optional = true }
 minijinja = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info", optional = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info", optional = true }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 pretty_assertions = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -45,5 +45,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 tempfile = "3"

--- a/crates/nils-provider-resume/Cargo.toml
+++ b/crates/nils-provider-resume/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-provider-resume"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 jiff = { workspace = true }
 serde_json = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nils-scrub/Cargo.toml
+++ b/crates/nils-scrub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-scrub"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/nils-term/Cargo.toml
+++ b/crates/nils-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-term"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 description = "Library crate for nils-term in the nils-cli workspace."

--- a/crates/nils-test-support/Cargo.toml
+++ b/crates/nils-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-test-support"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 

--- a/crates/opencode-cli/Cargo.toml
+++ b/crates/opencode-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-opencode-cli"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-archive/Cargo.toml
+++ b/crates/plan-archive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-archive"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 indexmap = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-scrub = { version = "1.27.12", path = "../nils-scrub" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-scrub = { version = "1.27.13", path = "../nils-scrub" }
 regex = "1"
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -29,6 +29,6 @@ serde_yaml_ng = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-issue/Cargo.toml
+++ b/crates/plan-issue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-issue"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 default-run = "plan-issue"
@@ -25,17 +25,17 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 libc = "0.2"
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["preserve_order"] }
 sha2 = { workspace = true }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
-nils-markdown = { version = "1.27.12", path = "../nils-markdown", package = "nils-markdown" }
-plan-tooling = { version = "1.27.12", path = "../plan-tooling", package = "nils-plan-tooling" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
+nils-markdown = { version = "1.27.13", path = "../nils-markdown", package = "nils-markdown" }
+plan-tooling = { version = "1.27.13", path = "../plan-tooling", package = "nils-plan-tooling" }
 pulldown-cmark = { workspace = true }
 
 [dev-dependencies]
-nils-markdown = { version = "1.27.12", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-markdown = { version = "1.27.13", path = "../nils-markdown", package = "nils-markdown", features = ["test-support"] }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/plan-tooling/Cargo.toml
+++ b/crates/plan-tooling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-plan-tooling"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -16,17 +16,17 @@ name = "plan-tooling"
 path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 pulldown-cmark = { workspace = true }
 libc = "0.2"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/screen-record/Cargo.toml
+++ b/crates/screen-record/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-screen-record"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 build = "build.rs"
@@ -18,10 +18,10 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 ctrlc = "3.5.2"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 x11rb = { version = "0.14", features = ["randr"] }
@@ -42,7 +42,7 @@ block2 = "0.6.2"
 dispatch2 = "0.3.1"
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 tempfile = "3"
 
 [lints.rust]

--- a/crates/secrets/Cargo.toml
+++ b/crates/secrets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-secrets"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -19,12 +19,12 @@ path = "src/main.rs"
 clap = { workspace = true }
 clap_complete = { workspace = true }
 ctrlc = { version = "3.5.2", features = ["termination"] }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/semantic-commit/Cargo.toml
+++ b/crates/semantic-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-semantic-commit"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,13 +18,13 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
 serde_json = { workspace = true }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting"] }
-nils-term = { version = "1.27.12", path = "../nils-term", package = "nils-term" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-term = { version = "1.27.13", path = "../nils-term", package = "nils-term" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }

--- a/crates/web-evidence/Cargo.toml
+++ b/crates/web-evidence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-web-evidence"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -18,13 +18,13 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "rustls"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"

--- a/crates/zsh-kit/Cargo.toml
+++ b/crates/zsh-kit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nils-zsh-kit"
-version = "1.27.12"
+version = "1.27.13"
 edition.workspace = true
 license.workspace = true
 
@@ -15,12 +15,12 @@ path = "src/main.rs"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
-nils-build-info = { version = "1.27.12", path = "../nils-build-info" }
-nils-common = { version = "1.27.12", path = "../nils-common", package = "nils-common" }
+nils-build-info = { version = "1.27.13", path = "../nils-build-info" }
+nils-common = { version = "1.27.13", path = "../nils-common", package = "nils-common" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-nils-test-support = { version = "1.27.12", path = "../nils-test-support" }
+nils-test-support = { version = "1.27.13", path = "../nils-test-support" }
 pretty_assertions = { workspace = true }
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bump workspace and CLI crate versions to 1.27.13
- Refresh Cargo.lock and generated third-party artifacts

## Test plan

- Public preparation completed the canonical locked workspace check
- PR required checks must be green before merge
- The private orchestrator tags v1.27.13 only after merge
