### PR TITLE
fix(agent-session): preserve existing work context claims

### DIFF
--- a/completions/bash/agent-session
+++ b/completions/bash/agent-session
@@ -2579,7 +2579,7 @@ _agent__session() {
             return 0
             ;;
         agent__session__work__context__set)
-            opts="-h --summary --intent --tier --repository --path --issue --pr --plan-ref --format --state-dir --host --help"
+            opts="-h --if-absent --summary --intent --tier --repository --path --issue --pr --plan-ref --format --state-dir --host --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/zsh/_agent-session
+++ b/completions/zsh/_agent-session
@@ -321,6 +321,7 @@ _arguments "${_arguments_options[@]}" : \
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--state-dir=[State directory. Defaults to AGENT_SESSION_STATE_DIR, XDG_STATE_HOME/agent-session, or ~/.local/state/agent-session]:PATH:_files -/' \
 '--host=[Hostname used in generated ssh attach commands]:HOST:_default' \
+'--if-absent[Preserve an existing active declaration and create this context only when none exists]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0

--- a/crates/agent-session/docs/runbooks/work-coordination.md
+++ b/crates/agent-session/docs/runbooks/work-coordination.md
@@ -49,6 +49,10 @@ agent-session work-context clear
 
 Declared context is optional in `advisory` mode. Presence and the optional
 context are renewed while the broker is live and released with the broker.
+Runtime integrations that need a baseline declaration without overwriting a
+user- or workflow-owned claim use `work-context set --if-absent`. The check and
+conditional creation are one registry-locked transaction; composing `status`
+and `set` is not an equivalent race-free substitute.
 
 ### Path scope syntax
 

--- a/crates/agent-session/docs/specs/session-coordination-v1.md
+++ b/crates/agent-session/docs/specs/session-coordination-v1.md
@@ -504,6 +504,11 @@ caller-supplied file, revision, claim ID, or idempotency key. In advisory/off
 mode a definite overlap is returned but does not reject the declaration. In
 enforce mode it retains raw claim conflict rejection. High-level `clear` is
 idempotent and still refuses to orphan a nonterminal enforce operation.
+`set --if-absent` is the atomic integration form: while holding the registry
+lock it returns an existing active declaration unchanged, including its tier,
+references, scopes, summary, claim identity, and revision; only a session with
+no active declaration creates the supplied context. It never replaces or
+downgrades a concurrently established declaration.
 
 Acknowledgement is keyed to the exact session incarnation and the most recent
 canonical advisory observation, and expires after a caller-selected duration
@@ -747,7 +752,7 @@ Every leaf command has its own CLI envelope identity, for example
 
 ```text
 agent-session work-context status
-agent-session work-context set [--summary TEXT] [--intent NAME] [--tier L0|L1|L2|L3] [--repository OWNER/REPO] [--path PATH]... [--issue N]... [--pr N]... [--plan-ref REF]...
+agent-session work-context set [--if-absent] [--summary TEXT] [--intent NAME] [--tier L0|L1|L2|L3] [--repository OWNER/REPO] [--path PATH]... [--issue N]... [--pr N]... [--plan-ref REF]...
 agent-session work-context clear
 agent-session work-context advise [--targets-file JSON]
 agent-session work-context acknowledge [--for DURATION]

--- a/crates/agent-session/src/cli.rs
+++ b/crates/agent-session/src/cli.rs
@@ -337,6 +337,9 @@ pub struct WorkContextStatusArgs {
 
 #[derive(Debug, Args)]
 pub struct WorkContextSetArgs {
+    /// Preserve an existing active declaration and create this context only when none exists.
+    #[arg(long)]
+    pub if_absent: bool,
     /// Short public description of the current work.
     #[arg(long, value_name = "TEXT")]
     pub summary: Option<String>,

--- a/crates/agent-session/src/coordination/advisory.rs
+++ b/crates/agent-session/src/coordination/advisory.rs
@@ -238,6 +238,7 @@ pub(crate) fn set(context: &CliContext, args: WorkContextSetArgs) -> Result<Valu
         &incarnation,
         candidate,
         record.coordination_mode == CoordinationMode::Enforce,
+        args.if_absent,
     )?;
     value
         .as_object_mut()

--- a/crates/agent-session/src/coordination/claims.rs
+++ b/crates/agent-session/src/coordination/claims.rs
@@ -641,6 +641,7 @@ pub(crate) fn set_declared(
     incarnation: &str,
     candidate: WorkContextInput,
     reject_conflict: bool,
+    if_absent: bool,
 ) -> Result<Value, CliError> {
     let _session_authority = lock_claim_session_authority(context, record, incarnation)?;
     let mut candidate = candidate.validate_and_canonicalize()?;
@@ -673,6 +674,25 @@ pub(crate) fn set_declared(
             && claim.session_incarnation == incarnation
             && claim.state == "active"
     });
+    if if_absent && let Some(index) = existing_index {
+        let existing = &locked.registry.claims[index];
+        let existing_input = input_from_record(existing);
+        let complete =
+            complete_relevant_universe(context, &locked.registry, Some((&record.id, incarnation)));
+        let evaluation = evaluate(
+            Some((&record.id, incarnation)),
+            &existing_input,
+            &locked.registry.claims,
+            complete,
+            !reject_conflict,
+        );
+        return Ok(json!({
+            "schema_version": "agent-session.work-context-set-result.v1",
+            "changed": false,
+            "context": public_context(existing)?,
+            "evaluation": evaluation,
+        }));
+    }
     let complete =
         complete_relevant_universe(context, &locked.registry, Some((&record.id, incarnation)));
     let evaluation = evaluate(

--- a/crates/agent-session/tests/integration/coordination.rs
+++ b/crates/agent-session/tests/integration/coordination.rs
@@ -2753,6 +2753,213 @@ fn self_targeting_context_set_clear_and_acknowledge_hide_mechanical_inputs() {
 }
 
 #[test]
+fn self_targeting_context_set_if_absent_preserves_an_existing_declaration() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    fs::create_dir(&state_dir).expect("state");
+    let checkout = tmp.path().join("checkout");
+    init_checkout(&checkout, "https://github.com/example/repository.git");
+    seed_brokers_at(
+        &state_dir,
+        &[
+            (
+                "alpha",
+                "incarnation-alpha",
+                "alpha-private-capability-material",
+                checkout.as_path(),
+                Some("advisory"),
+            ),
+            (
+                "beta",
+                "incarnation-beta",
+                "beta-private-capability-material",
+                checkout.as_path(),
+                Some("advisory"),
+            ),
+        ],
+    );
+    let state = state_dir.to_string_lossy();
+    let alpha_cap = capability(&state_dir, "alpha");
+    let env = [
+        ("AGENT_SESSION_ID", "alpha"),
+        ("AGENT_SESSION_CAPABILITY_FILE", alpha_cap.as_str()),
+        ("AGENT_SESSION_STATE_DIR", state.as_ref()),
+    ];
+    let existing = run_with_env(
+        &checkout,
+        &[
+            "work-context",
+            "set",
+            "--tier",
+            "L3",
+            "--summary",
+            "tracked delivery",
+            "--issue",
+            "213",
+            "--path",
+            "src/",
+            "--format",
+            "json",
+        ],
+        &env,
+    );
+    assert_eq!(existing.code, 0, "stderr={}", existing.stderr_text());
+
+    let ensured = run_with_env(
+        &checkout,
+        &[
+            "work-context",
+            "set",
+            "--if-absent",
+            "--tier",
+            "L2",
+            "--summary",
+            "generic DSH context",
+            "--format",
+            "json",
+        ],
+        &env,
+    );
+
+    assert_eq!(ensured.code, 0, "stderr={}", ensured.stderr_text());
+    assert_eq!(data(&ensured)["changed"], false);
+    assert_eq!(data(&ensured)["mode"], "advisory");
+    assert_eq!(data(&ensured)["context"], data(&existing)["context"]);
+
+    let beta_cap = capability(&state_dir, "beta");
+    let beta_env = [
+        ("AGENT_SESSION_ID", "beta"),
+        ("AGENT_SESSION_CAPABILITY_FILE", beta_cap.as_str()),
+        ("AGENT_SESSION_STATE_DIR", state.as_ref()),
+    ];
+    let created = run_with_env(
+        &checkout,
+        &[
+            "work-context",
+            "set",
+            "--if-absent",
+            "--tier",
+            "L2",
+            "--summary",
+            "fresh DSH context",
+            "--format",
+            "json",
+        ],
+        &beta_env,
+    );
+    assert_eq!(created.code, 0, "stderr={}", created.stderr_text());
+    assert_eq!(data(&created)["changed"], true);
+    assert_eq!(data(&created)["context"]["tier"], "L2");
+    assert_eq!(data(&created)["context"]["summary"], "fresh DSH context");
+}
+
+#[test]
+fn concurrent_context_set_if_absent_has_one_winner_without_overwrite() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let state_dir = tmp.path().join("state");
+    fs::create_dir(&state_dir).expect("state");
+    let checkout = tmp.path().join("checkout");
+    init_checkout(&checkout, "https://github.com/example/repository.git");
+    seed_brokers_at(
+        &state_dir,
+        &[(
+            "alpha",
+            "incarnation-alpha",
+            "alpha-private-capability-material",
+            checkout.as_path(),
+            Some("advisory"),
+        )],
+    );
+    let state = state_dir.to_string_lossy().into_owned();
+    let alpha_cap = capability(&state_dir, "alpha");
+    let env = [
+        ("AGENT_SESSION_ID", "alpha"),
+        ("AGENT_SESSION_CAPABILITY_FILE", alpha_cap.as_str()),
+        ("AGENT_SESSION_STATE_DIR", state.as_str()),
+    ];
+
+    let (first, second) = std::thread::scope(|scope| {
+        let first = scope.spawn(|| {
+            run_with_env(
+                &checkout,
+                &[
+                    "work-context",
+                    "set",
+                    "--if-absent",
+                    "--tier",
+                    "L2",
+                    "--summary",
+                    "first contender",
+                    "--format",
+                    "json",
+                ],
+                &env,
+            )
+        });
+        let second = scope.spawn(|| {
+            run_with_env(
+                &checkout,
+                &[
+                    "work-context",
+                    "set",
+                    "--if-absent",
+                    "--tier",
+                    "L3",
+                    "--summary",
+                    "second contender",
+                    "--format",
+                    "json",
+                ],
+                &env,
+            )
+        });
+        (
+            first.join().expect("first contender"),
+            second.join().expect("second contender"),
+        )
+    });
+
+    assert_eq!(first.code, 0, "stderr={}", first.stderr_text());
+    assert_eq!(second.code, 0, "stderr={}", second.stderr_text());
+    let results = [data(&first), data(&second)];
+    assert_eq!(
+        results
+            .iter()
+            .filter(|result| result["changed"] == true)
+            .count(),
+        1
+    );
+    let winner = results
+        .iter()
+        .find(|result| result["changed"] == true)
+        .expect("one winner");
+    let preserved = results
+        .iter()
+        .find(|result| result["changed"] == false)
+        .expect("one preserved result");
+    assert_eq!(preserved["context"], winner["context"]);
+    assert!(matches!(
+        winner["context"]["summary"].as_str(),
+        Some("first contender" | "second contender")
+    ));
+
+    let registry = load_coordination_registry(&state_dir);
+    let claims = registry["claims"].as_array().expect("claims");
+    let active = claims
+        .iter()
+        .filter(|claim| {
+            claim["session_id"] == "alpha"
+                && claim["session_incarnation"] == "incarnation-alpha"
+                && claim["state"] == "active"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(active.len(), 1);
+    assert_eq!(active[0]["claim_id"], winner["context"]["claim_id"]);
+    assert_eq!(active[0]["revision"], winner["context"]["revision"]);
+    assert_eq!(active[0]["summary"], winner["context"]["summary"]);
+}
+
+#[test]
 fn advisory_lifecycle_skips_stopped_and_off_peers_but_preserves_known_overlap() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let state_dir = tmp.path().join("state");


### PR DESCRIPTION
## Summary

- add atomic work-context set --if-absent for runtime integrations
- preserve existing richer claims and keep authority/admission fail-closed
- prove a single winner under same-session contention

## Test plan

- [x] cargo test -p nils-agent-session --test integration set_if_absent -- --nocapture
- [x] bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast (8,662 tests)
- [x] focused security, performance, and maintainability review

Refs serenVia/sympoies-infra#213