### PR TITLE
fix(forge-cli): support qualified GitHub PR heads

### DIFF
--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -56,7 +56,7 @@ validations_catalog:
     error_kind: head_not_pushed
     exit: DATA
   qualified_github_head:
-    rule: "GitHub-only <user>:<branch> heads require one local upstream push repository on the selected GitHub authority whose owner equals <user>; post-create/adopt provider headRefName, headRefOid, and headRepository must equal the local branch, commit, and upstream repository; gh pr list lookup never receives the unsupported qualified syntax and a saturated bounded result without the exact repository+branch fails closed; GitHub CLI does not support organization qualifiers"
+    rule: "GitHub-only <user>:<branch> heads validate only a non-empty single-qualifier structure locally and delegate username grammar/account type to GitHub; they require one local upstream push repository on the selected GitHub authority whose owner equals <user>; post-create/adopt provider headRefName, headRefOid, and headRepository must equal the local branch, commit, and upstream repository; gh pr list lookup never receives the unsupported qualified syntax and a saturated bounded result without the exact repository+branch fails closed; GitHub CLI does not support organization qualifiers"
     error_kind: qualified_head_upstream_mismatch | qualified_head_provider_mismatch
     exit: DATA
   default_branch_protected:

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -55,6 +55,10 @@ validations_catalog:
     rule: "resolved head branch has upstream and matches remote-tracking ref"
     error_kind: head_not_pushed
     exit: DATA
+  qualified_github_head:
+    rule: "GitHub-only <user>:<branch> heads require one local upstream push repository on the selected GitHub authority whose owner equals <user>; post-create/adopt provider headRefName, headRefOid, and headRepository must equal the local branch, commit, and upstream repository; gh pr list lookup never receives the unsupported qualified syntax and a saturated bounded result without the exact repository+branch fails closed; GitHub CLI does not support organization qualifiers"
+    error_kind: qualified_head_upstream_mismatch | qualified_head_provider_mismatch
+    exit: DATA
   default_branch_protected:
     rule: "refuse caller-controlled force-push / direct merge to repo default branch; governed repo.push-default permits only one verified fast-forward commit with an exact-old-OID compare-and-swap"
     error_kind: default_branch_protected
@@ -178,7 +182,7 @@ operations:
     schema_version: cli.forge-cli.pr.create.v1
     summary: Open a draft pull/merge request from the current branch.
     inputs:
-      - { name: --head,        type: string,         default: current-branch } # GitHub also accepts <owner>:<branch>; validations consume the branch suffix
+      - { name: --head,        type: string,         default: current-branch } # GitHub-only seam: <user>:<branch>; gh does not support organization qualifiers
       - { name: --base,        type: string,         default: repo-default-branch }
       - { name: --title,       type: string,         required: true }
       - { name: --body,        type: string,         required: false }
@@ -201,6 +205,7 @@ operations:
       - label_catalog # only when --strict-labels is set
       - worktree_clean
       - head_pushed
+      - qualified_github_head # only for GitHub <user>:<branch>; binds upstream repository + provider branch/repository/SHA read-back
       - test_first_evidence # only when [test_first].require resolves true
     backends:
       github:
@@ -217,6 +222,7 @@ operations:
         url: string
         head: string
         head_sha: optional<string>
+        head_repository: optional<string>
         base: string
         draft: bool
         title: string
@@ -1296,7 +1302,7 @@ macros:
       - { name: --title,                    type: string,                       required: false }
       - { name: --body,                     type: string,                       required: false }
       - { name: --body-file,                type: path,                         required: false }
-      - { name: --head,                     type: string,                       default: current-branch }
+      - { name: --head,                     type: string,                       default: current-branch } # GitHub-only <user>:<branch> seam; user forks only
       - { name: --base,                     type: string,                       default: repo-default-branch }
       - { name: --method,                   type: enum<squash|merge|rebase>,    default: squash }
       - { name: --reviewer,                 type: list<string>,                 default: [] }
@@ -1328,6 +1334,9 @@ macros:
       # resolves true the adopt path also enforces the test_first_evidence
       # validation, so an adopted feature/bug PR cannot bypass the gate. The
       # lifecycle then resumes at wait_checks. The lookup is not a recorded step.
+      # GitHub qualified <user>:<branch> lookup instead lists a bounded open
+      # set without --head and selects exact branch + headRepository identity;
+      # provider view must then match the local SHA before adoption.
       - { step: adopt,              op: pr.view,   when: "open PR exists for head branch" }
       - { step: create,             op: pr.create, when: "no open PR exists for head branch" }
       # GitHub delivery starts required-only. When that snapshot reports zero

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -178,7 +178,7 @@ operations:
     schema_version: cli.forge-cli.pr.create.v1
     summary: Open a draft pull/merge request from the current branch.
     inputs:
-      - { name: --head,        type: string,         default: current-branch }
+      - { name: --head,        type: string,         default: current-branch } # GitHub also accepts <owner>:<branch>; validations consume the branch suffix
       - { name: --base,        type: string,         default: repo-default-branch }
       - { name: --title,       type: string,         required: true }
       - { name: --body,        type: string,         required: false }

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -359,19 +359,21 @@ backend mapping, validation rules, and output schema versions.
 
 ### `pr create`
 
-- Input: `--head <branch>` (default current branch), `--base <branch>`
+- Input: `--head <branch>` (default current branch; GitHub also accepts
+  `<owner>:<branch>` for a cross-fork head), `--base <branch>`
   (default repo default branch), `--title <str>`, `--body-file <path>`
   or `--body <str>`, `--kind feature|bug`, `--draft` (default `true`),
   `--reviewer <user>...`, `--label <name>...`,
   `--label-catalog <path>`, `--strict-labels`.
 - Validation (see "Lock-down policy" for the full list):
-  - branch name MUST match `^(feat|fix)/[a-z0-9][a-z0-9-]{1,63}$` and
-    align with `--kind`;
+  - the branch, or the branch suffix of a qualified GitHub head, MUST match
+    the semantic branch-name rule and align with `--kind`; the GitHub owner
+    qualifier is preserved only for provider dispatch;
   - title length ≤ 70 chars, no trailing whitespace;
   - body MUST contain non-empty `## Summary` and `## Test plan`
     sections;
   - working tree MUST be clean (`git status --porcelain` empty);
-  - resolved head branch MUST be pushed and remote-tracked.
+  - resolved local head branch MUST be pushed and remote-tracked.
 - Output schema: `cli.forge-cli.pr.create.v1`,
   `data = { number, url, head, base, draft, title, kind, provider }`.
 

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -109,7 +109,7 @@ Parity matrix (v1):
 
 | forge-cli op                                | github backend                                                                                                                               | gitlab backend                                                         | Parity                                                                                                                   |
 | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `pr create`                                 | `gh pr create --draft`                                                                                                                       | `glab mr create --draft`                                               | exact                                                                                                                    |
+| `pr create`                                 | `gh pr create --draft`; qualified user forks use `<user>:<branch>`                                                                           | `glab mr create --draft`                                               | exact for unqualified heads; qualified heads are a GitHub-only seam                                                      |
 | `pr view <id>`                              | `gh pr view <id> --json …`                                                                                                                   | `glab mr view <id> -F json`                                            | exact                                                                                                                    |
 | `pr list`                                   | `gh pr list --json …`                                                                                                                        | `glab mr list -F json`                                                 | exact                                                                                                                    |
 | `pr edit <id>`                              | `gh pr edit <id> …`                                                                                                                          | `glab mr update <id> …`                                                | exact                                                                                                                    |
@@ -150,7 +150,7 @@ Parity matrix (v1):
 | `activity events`                           | `gh api users/<login>/events[/public]`                                                                                                       | unsupported in v1                                                      | GitHub-only seam                                                                                                         |
 | `activity feed`                             | `gh api repos/<owner>/<repo>/commits` + repository activity REST                                                                             | `glab api projects/:id/repository/commits` + project events            | normalized open vocabulary                                                                                               |
 | `activity summary`                          | `gh api graphql` contribution query                                                                                                          | unsupported in v1                                                      | GitHub-only seam                                                                                                         |
-| `pr deliver`                                | macro: `pr list` lookup → `pr create` or adopt → `pr wait-checks` → `pr ready` → `pr merge`                                                  | same composition with gitlab atoms                                     | exact (same macro logic on both)                                                                                         |
+| `pr deliver`                                | macro: exact user/repository-aware lookup → `pr create` or adopt → `pr wait-checks` → `pr ready` → `pr merge`                                | branch lookup → same remaining composition                             | exact for unqualified heads; qualified user-fork lookup is a GitHub-only seam                                            |
 
 "emulated" means the backend's native command differs in shape, but
 `forge-cli` normalises both into the same `cli.forge-cli.pr.checks.v1`
@@ -360,22 +360,35 @@ backend mapping, validation rules, and output schema versions.
 ### `pr create`
 
 - Input: `--head <branch>` (default current branch; GitHub also accepts
-  `<owner>:<branch>` for a cross-fork head), `--base <branch>`
+  `<user>:<branch>` for a cross-fork head), `--base <branch>`
   (default repo default branch), `--title <str>`, `--body-file <path>`
   or `--body <str>`, `--kind feature|bug`, `--draft` (default `true`),
   `--reviewer <user>...`, `--label <name>...`,
   `--label-catalog <path>`, `--strict-labels`.
 - Validation (see "Lock-down policy" for the full list):
   - the branch, or the branch suffix of a qualified GitHub head, MUST match
-    the semantic branch-name rule and align with `--kind`; the GitHub owner
-    qualifier is preserved only for provider dispatch;
+    the semantic branch-name rule and align with `--kind`;
+  - a qualified GitHub user MUST own the local branch's single upstream push
+    repository on the selected GitHub authority; the full `<user>:<branch>`
+    ref is preserved for provider dispatch, while local branch checks consume
+    only the suffix;
+  - immediately after creation, GitHub's `headRefName`, `headRefOid`, and
+    `headRepository.nameWithOwner` MUST match the local branch, local commit,
+    and upstream repository before success is reported;
   - title length ≤ 70 chars, no trailing whitespace;
   - body MUST contain non-empty `## Summary` and `## Test plan`
     sections;
   - working tree MUST be clean (`git status --porcelain` empty);
   - resolved local head branch MUST be pushed and remote-tracked.
 - Output schema: `cli.forge-cli.pr.create.v1`,
-  `data = { number, url, head, base, draft, title, kind, provider }`.
+  `data = { number, url, head, head_sha?, head_repository?, base, draft,
+  title, kind, provider }`.
+
+Qualified heads are deliberately a GitHub-only user-fork seam. GitHub CLI's
+`gh pr create --head` contract accepts `<user>:<branch>` but does not support
+an organization as the qualifier. `forge-cli` therefore does not advertise
+`<owner>:<branch>` or organization-fork support; provider rejection remains
+authoritative for account-type distinctions that cannot be proven offline.
 
 ### `repo push-default`
 
@@ -1160,6 +1173,13 @@ label errors are returned before provider access in every mode.
    against the body-section gate, and the branch-kind / clean-worktree /
    resolved-head push-state rules still apply. `--title` / `--body`
    inputs are ignored on adoption — the existing PR keeps its own.
+   For a qualified GitHub `<user>:<branch>` head, `gh pr list --head` is not
+   given the unsupported qualified syntax. Delivery lists a bounded open set
+   and adopts only a row whose branch and `headRepository` exactly match the
+   locally bound user/upstream repository; a same-named branch from any other
+   fork is ignored. A saturated bounded result without that exact row fails
+   closed instead of assuming absence. The subsequent `pr view` must still match branch,
+   repository, and local SHA, and that SHA becomes the merge CAS input.
 4. `pr create --draft` — atom; validates branch / title / body. Only
    runs when the lookup found nothing.
 5. `pr wait-checks` — atom; blocks until terminal within one cumulative

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -387,8 +387,11 @@ backend mapping, validation rules, and output schema versions.
 Qualified heads are deliberately a GitHub-only user-fork seam. GitHub CLI's
 `gh pr create --head` contract accepts `<user>:<branch>` but does not support
 an organization as the qualifier. `forge-cli` therefore does not advertise
-`<owner>:<branch>` or organization-fork support; provider rejection remains
-authoritative for account-type distinctions that cannot be proven offline.
+`<owner>:<branch>` or organization-fork support. It validates only the
+non-empty, single-qualifier structure locally, so provider-valid Enterprise
+Managed User logins (including underscore suffixes) reach GitHub; provider
+rejection remains authoritative for username grammar and account-type
+distinctions that cannot be proven offline.
 
 ### `repo push-default`
 

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -36,8 +36,10 @@ use crate::config::ForgeConfig;
 use crate::error::ForgeError;
 use crate::ops::label::{LabelTarget, validate_label_inputs};
 use crate::ops::pr_create::{
-    self, Environment, VerifiedTestFirstSubject, evidence_remote_url, evidence_repository_id,
-    find_git_toplevel, test_first_gate, validate_provider_subject_head,
+    self, Environment, QualifiedHeadSubject, ResolvedHeadRef, VerifiedTestFirstSubject,
+    evidence_remote_url, evidence_repository_id, find_git_toplevel,
+    qualified_head_subject_for_workdir, resolve_head_ref, test_first_gate,
+    validate_provider_subject_head, validate_qualified_provider_subject,
 };
 use crate::ops::pr_view::PrViewPayload;
 use crate::ops::pr_wait_checks::{Clock, SystemClock, WaitOutcome};
@@ -234,9 +236,31 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
             }
         },
     };
-    let lookup_args = adopt_lookup_args(&head);
+    let resolved_head = match resolve_head_ref(ctx.provider, &head) {
+        Ok(resolved) => resolved,
+        Err(err) => return Ok(emit_chain_failure(steps, args, ctx, None, &err, format)),
+    };
+    let qualified_subject = if resolved_head.github_user.is_some() {
+        if let Err(err) = branch_pushed(workdir, resolved_head.local_branch, git_branch_state) {
+            return Ok(emit_chain_failure(steps, args, ctx, None, &err, format));
+        }
+        match qualified_head_subject_for_workdir(ctx, resolved_head, workdir) {
+            Ok(subject) => subject,
+            Err(err) => return Ok(emit_chain_failure(steps, args, ctx, None, &err, format)),
+        }
+    } else {
+        None
+    };
+    let lookup_args = adopt_lookup_args(ctx, resolved_head);
     let existing = match pr_list::compute(runner, ctx, &lookup_args) {
-        Ok(payload) => payload.items.into_iter().next(),
+        Ok(payload) => {
+            match select_adoptable(payload.items, resolved_head, qualified_subject.as_ref()) {
+                Ok(existing) => existing,
+                Err(err) => {
+                    return Ok(emit_chain_failure(steps, args, ctx, None, &err, format));
+                }
+            }
+        }
         Err(err) => {
             return Ok(emit_chain_failure(steps, args, ctx, None, &err, format));
         }
@@ -280,14 +304,15 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
         let repository_id = gate_applies
             .then(|| evidence_repository_id(ctx, remote_url.as_deref(), global.repo.as_deref()))
             .flatten();
-        let verified_subject = match validate_adopted(
-            &view,
-            args,
+        let adopt_context = AdoptValidationContext {
             workdir,
-            &global.remote,
-            repository_id.as_deref(),
+            remote: &global.remote,
+            repository_id: repository_id.as_deref(),
             test_first_required,
-        ) {
+            resolved_head,
+            qualified_subject: qualified_subject.as_ref(),
+        };
+        let verified_subject = match validate_adopted(&view, args, &adopt_context) {
             Ok(subject) => subject,
             Err(err) => {
                 steps.push(Step {
@@ -494,7 +519,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
         }
     }
 
-    if let Some(subject) = verified_subject.as_ref() {
+    if verified_subject.is_some() || qualified_subject.is_some() {
         let current_view = match pr_view::compute(runner, ctx, pr_number) {
             Ok(view) => view,
             Err(err) => {
@@ -508,9 +533,25 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
                 ));
             }
         };
-        if let Err(err) =
-            validate_provider_subject_head(Some(subject), current_view.head_sha.as_deref())
-        {
+        if let Err(err) = validate_provider_subject_head(
+            verified_subject.as_ref(),
+            current_view.head_sha.as_deref(),
+        ) {
+            return Ok(emit_chain_failure(
+                steps,
+                args,
+                ctx,
+                Some((pr_number, pr_url)),
+                &err,
+                format,
+            ));
+        }
+        if let Err(err) = validate_qualified_provider_subject(
+            qualified_subject.as_ref(),
+            &current_view.head,
+            current_view.head_sha.as_deref(),
+            current_view.head_repository.as_deref(),
+        ) {
             return Ok(emit_chain_failure(
                 steps,
                 args,
@@ -557,6 +598,21 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
             format,
         ));
     }
+    if let Err(err) = validate_qualified_provider_subject(
+        qualified_subject.as_ref(),
+        &ready_payload.head,
+        ready_payload.head_sha.as_deref(),
+        ready_payload.head_repository.as_deref(),
+    ) {
+        return Ok(emit_chain_failure(
+            steps,
+            args,
+            ctx,
+            Some((pr_number, pr_url)),
+            &err,
+            format,
+        ));
+    }
     steps.push(Step {
         step: "ready",
         ok: true,
@@ -565,13 +621,15 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
     });
 
     // 6. pr.merge
-    let merge_args = build_merge_args(
-        args,
-        pr_number,
-        verified_subject
-            .as_ref()
-            .map(|subject| subject.head.clone()),
-    );
+    let expected_head_sha = verified_subject
+        .as_ref()
+        .map(|subject| subject.head.clone())
+        .or_else(|| {
+            qualified_subject
+                .as_ref()
+                .map(|subject| subject.head_sha.clone())
+        });
+    let merge_args = build_merge_args(args, pr_number, expected_head_sha);
     let merge_payload =
         match pr_merge::compute_with_clock(runner, clock, global, &merge_args, workdir) {
             Ok(p) => p,
@@ -686,16 +744,50 @@ fn run_issue_closeout<R: BackendRunner>(runner: &R, ctx: &ProviderContext, pr_nu
     }
 }
 
-/// Lookup filter for the adopt step: open PRs whose head / source branch is
-/// the resolved head. The first match wins; the provider returns them
-/// newest-first.
-fn adopt_lookup_args(head: &str) -> PrListArgs {
+/// Lookup filter for the adopt step. Unqualified heads use the provider's
+/// branch filter. Qualified GitHub heads use a bounded open-PR projection and
+/// select only the exact source repository + branch identity.
+fn adopt_lookup_args(ctx: &ProviderContext, head: ResolvedHeadRef<'_>) -> PrListArgs {
+    let qualified_github = ctx.provider == Provider::GitHub && head.github_user.is_some();
     PrListArgs {
         state: PrStateFilter::Open,
         author: None,
-        head: Some(head.to_string()),
-        limit: 1,
+        head: (!qualified_github).then(|| head.local_branch.to_string()),
+        limit: if qualified_github {
+            QUALIFIED_ADOPT_LOOKUP_LIMIT
+        } else {
+            1
+        },
     }
+}
+
+const QUALIFIED_ADOPT_LOOKUP_LIMIT: u32 = 100;
+
+fn select_adoptable(
+    items: Vec<pr_list::PrListItem>,
+    resolved_head: ResolvedHeadRef<'_>,
+    qualified_subject: Option<&QualifiedHeadSubject>,
+) -> Result<Option<pr_list::PrListItem>, ForgeError> {
+    let Some(subject) = qualified_subject else {
+        return Ok(items.into_iter().next());
+    };
+    let lookup_saturated = items.len() >= QUALIFIED_ADOPT_LOOKUP_LIMIT as usize;
+    let found = items.into_iter().find(|item| {
+        item.head == resolved_head.local_branch
+            && item
+                .head_repository
+                .as_deref()
+                .is_some_and(|repository| repository.eq_ignore_ascii_case(&subject.head_repository))
+    });
+    if found.is_none() && lookup_saturated {
+        return Err(ForgeError::validation(
+            schema_version_for(BINARY, "error", 1),
+            "qualified_head_provider_mismatch",
+            "bounded GitHub PR lookup could not prove the qualified head is absent",
+            Some("narrow the open PR set before retrying qualified-head delivery".into()),
+        ));
+    }
+    Ok(found)
 }
 
 /// Adopt-path validation. Mirrors the create-path gates that still apply to
@@ -707,28 +799,44 @@ fn adopt_lookup_args(head: &str) -> PrListArgs {
 /// local-path) are skipped — the PR already carries its own provider-validated
 /// title and body. `test_first_required` is resolved by the caller from
 /// layered config so this stays a pure validation.
+struct AdoptValidationContext<'a> {
+    workdir: &'a Path,
+    remote: &'a str,
+    repository_id: Option<&'a str>,
+    test_first_required: bool,
+    resolved_head: ResolvedHeadRef<'a>,
+    qualified_subject: Option<&'a QualifiedHeadSubject>,
+}
+
 fn validate_adopted(
     view: &PrViewPayload,
     args: &PrDeliverArgs,
-    workdir: &Path,
-    remote: &str,
-    repository_id: Option<&str>,
-    test_first_required: bool,
+    context: &AdoptValidationContext<'_>,
 ) -> Result<Option<VerifiedTestFirstSubject>, ForgeError> {
-    let prefix = branch_name(&view.head)?;
+    validate_qualified_provider_subject(
+        context.qualified_subject,
+        &view.head,
+        view.head_sha.as_deref(),
+        view.head_repository.as_deref(),
+    )?;
+    let prefix = branch_name(context.resolved_head.local_branch)?;
     branch_kind_matches(prefix, args.kind.into_kind())?;
     let headings = BodyHeadings::default();
     body_sections(view.body.as_deref().unwrap_or(""), &headings)?;
-    worktree_clean(workdir, git_status_porcelain)?;
-    branch_pushed(workdir, &view.head, git_branch_state)?;
+    worktree_clean(context.workdir, git_status_porcelain)?;
+    branch_pushed(
+        context.workdir,
+        context.resolved_head.local_branch,
+        git_branch_state,
+    )?;
     test_first_gate(
         args.kind.into_kind(),
-        test_first_required,
+        context.test_first_required,
         args.test_first_evidence.as_deref(),
-        workdir,
-        remote,
-        repository_id,
-        &view.head,
+        context.workdir,
+        context.remote,
+        context.repository_id,
+        context.resolved_head.local_branch,
     )
 }
 
@@ -825,6 +933,11 @@ fn build_dry_run_payload(
         Some(head) => head.clone(),
         None => git_current_branch(workdir).unwrap_or_default(),
     };
+    let resolved_head = resolve_head_ref(ctx.provider, &branch).ok();
+    let local_branch = resolved_head
+        .as_ref()
+        .map(|resolved| resolved.local_branch)
+        .unwrap_or(branch.as_str());
     let mut plan_steps = vec![
         DryRunStep {
             step: "auth_status",
@@ -870,7 +983,7 @@ fn build_dry_run_payload(
     let body = resolve_preview_body(args);
     let headings = BodyHeadings::default();
     let inputs = PreflightInputs {
-        branch: &branch,
+        branch: local_branch,
         kind: args.kind.into_kind(),
         title: &args.title,
         body: &body,
@@ -878,6 +991,12 @@ fn build_dry_run_payload(
     };
     let mut local_preflight =
         run_local_preflight(&inputs, workdir, git_status_porcelain, git_branch_state);
+    if let Some(resolved) = resolved_head.filter(|resolved| resolved.github_user.is_some()) {
+        local_preflight.push(RuleVerdict::from_result(
+            "qualified_head_upstream",
+            qualified_head_subject_for_workdir(ctx, resolved, workdir).map(|_| ()),
+        ));
+    }
     // Faithful test-first gate: when the repo opts in, the real run enforces
     // evidence for feature/bug kinds (both create and adopt paths), so surface
     // the same verdict here instead of predicting a success the real deliver
@@ -905,7 +1024,7 @@ fn build_dry_run_payload(
         workdir,
         &global.remote,
         repository_id.as_deref(),
-        &branch,
+        local_branch,
     ) {
         local_preflight.push(verdict);
     }
@@ -926,7 +1045,15 @@ fn pr_lookup_dry_plan(ctx: &ProviderContext, head: &str) -> Vec<String> {
     } else {
         head
     };
-    pr_list::build_list_call(ctx, &adopt_lookup_args(head)).plan_argv()
+    let lookup = resolve_head_ref(ctx.provider, head)
+        .map(|resolved| adopt_lookup_args(ctx, resolved))
+        .unwrap_or_else(|_| PrListArgs {
+            state: PrStateFilter::Open,
+            author: None,
+            head: Some(head.to_string()),
+            limit: 1,
+        });
+    pr_list::build_list_call(ctx, &lookup).plan_argv()
 }
 
 fn repo_view_dry_plan(ctx: &ProviderContext) -> Vec<String> {
@@ -1189,6 +1316,30 @@ mod tests {
         let snapshot = visible_snapshot(&ctx());
         let snapshot = with_total_duration(snapshot, std::time::Duration::from_millis(13));
         assert_eq!(snapshot.duration_ms, Some(20));
+    }
+
+    #[test]
+    fn qualified_head_adoption_fails_closed_when_the_bounded_lookup_is_saturated() {
+        let resolved = resolve_head_ref(Provider::GitHub, "alice:feat/demo").unwrap();
+        let subject = QualifiedHeadSubject {
+            branch: "feat/demo".into(),
+            head_sha: "abc123".into(),
+            head_repository: "alice/nils-cli".into(),
+        };
+        let items = (0..QUALIFIED_ADOPT_LOOKUP_LIMIT)
+            .map(|number| pr_list::PrListItem {
+                number: u64::from(number),
+                url: format!("https://github.com/sympoies/nils-cli/pull/{number}"),
+                state: "open",
+                title: "collision".into(),
+                head: "feat/demo".into(),
+                head_repository: Some(format!("other-{number}/nils-cli")),
+                author: None,
+            })
+            .collect();
+
+        let err = select_adoptable(items, resolved, Some(&subject)).unwrap_err();
+        assert_eq!(err.kind(), "qualified_head_provider_mismatch");
     }
 
     fn args(no_merge: bool) -> PrDeliverArgs {

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -156,6 +156,62 @@ fn schema_ok() -> String {
     schema_version_for(BINARY, SCHEMA, SCHEMA_VERSION)
 }
 
+/// Provider-facing and local forms of a PR head reference.
+///
+/// GitHub accepts `<owner>:<branch>` for cross-fork PRs. The owner qualifier
+/// is preserved for `gh pr create`, while every local governance check remains
+/// bound to the semantic branch suffix. GitLab and local-provider heads remain
+/// unqualified and therefore unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ResolvedHeadRef<'a> {
+    pub provider_ref: &'a str,
+    pub local_branch: &'a str,
+}
+
+pub(crate) fn resolve_head_ref<'a>(
+    provider: Provider,
+    head: &'a str,
+) -> Result<ResolvedHeadRef<'a>, ForgeError> {
+    let Some((owner, branch)) = head.split_once(':') else {
+        return Ok(ResolvedHeadRef {
+            provider_ref: head,
+            local_branch: head,
+        });
+    };
+
+    if provider != Provider::GitHub {
+        return Ok(ResolvedHeadRef {
+            provider_ref: head,
+            local_branch: head,
+        });
+    }
+
+    let owner_bytes = owner.as_bytes();
+    let owner_is_valid = !owner_bytes.is_empty()
+        && owner_bytes.len() <= 39
+        && owner_bytes[0].is_ascii_alphanumeric()
+        && owner_bytes[owner_bytes.len() - 1].is_ascii_alphanumeric()
+        && owner_bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-');
+    if !owner_is_valid || branch.is_empty() || branch.contains(':') {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "branch_name_invalid",
+            format!("GitHub head '{head}' is not a valid <owner>:<branch> reference"),
+            Some(
+                "rule=<github-owner>:<(feat|fix|chore|docs|ci|refactor)/semantic-branch>"
+                    .to_string(),
+            ),
+        ));
+    }
+
+    Ok(ResolvedHeadRef {
+        provider_ref: head,
+        local_branch: branch,
+    })
+}
+
 /// Resolve the git toplevel for layered-config discovery. Returns `None`
 /// outside a work tree (the layered loader then walks to the filesystem root).
 pub(crate) fn find_git_toplevel(start: &Path) -> Option<PathBuf> {
@@ -405,7 +461,8 @@ pub fn run_with<R: BackendRunner>(
 
     // 3. Validation chain — order matches spec §"pr create" so the most
     //    obvious failure (bad branch name) is reported first.
-    let prefix = branch_name(&head)?;
+    let resolved_head = resolve_head_ref(ctx.provider, &head)?;
+    let prefix = branch_name(resolved_head.local_branch)?;
     let kind: PrKind = args.kind.into_kind();
     branch_kind_matches(prefix, kind)?;
     title_length(&args.title)?;
@@ -425,7 +482,9 @@ pub fn run_with<R: BackendRunner>(
         label_target,
     )?;
     worktree_clean(&env.workdir, |w| (env.git_status)(w))?;
-    branch_pushed(&env.workdir, &head, |w, branch| (env.head_state)(w, branch))?;
+    branch_pushed(&env.workdir, resolved_head.local_branch, |w, branch| {
+        (env.head_state)(w, branch)
+    })?;
     let gate_applies = test_first_gate_applies(kind, env.test_first_required);
     let remote_url = evidence_remote_url(
         gate_applies,
@@ -444,7 +503,7 @@ pub fn run_with<R: BackendRunner>(
         &env.workdir,
         &global.remote,
         repository_id.as_deref(),
-        &head,
+        resolved_head.local_branch,
     )?;
 
     let draft = !args.no_draft;
@@ -457,7 +516,7 @@ pub fn run_with<R: BackendRunner>(
 
     let create_call = build_create_call(
         &ctx,
-        &head,
+        resolved_head.provider_ref,
         &base,
         &args.title,
         &body,
@@ -540,7 +599,8 @@ fn compute_with_subject_inner<R: BackendRunner>(
         None => (env.default_branch)(runner as &dyn BackendRunner, &ctx)?,
     };
     let body = read_body(args.body.as_deref(), args.body_file.as_deref())?;
-    let prefix = branch_name(&head)?;
+    let resolved_head = resolve_head_ref(ctx.provider, &head)?;
+    let prefix = branch_name(resolved_head.local_branch)?;
     let kind: PrKind = args.kind.into_kind();
     branch_kind_matches(prefix, kind)?;
     title_length(&args.title)?;
@@ -562,7 +622,9 @@ fn compute_with_subject_inner<R: BackendRunner>(
         )?;
     }
     worktree_clean(&env.workdir, |w| (env.git_status)(w))?;
-    branch_pushed(&env.workdir, &head, |w, branch| (env.head_state)(w, branch))?;
+    branch_pushed(&env.workdir, resolved_head.local_branch, |w, branch| {
+        (env.head_state)(w, branch)
+    })?;
     let gate_applies = test_first_gate_applies(kind, env.test_first_required);
     let remote_url = evidence_remote_url(
         gate_applies,
@@ -581,7 +643,7 @@ fn compute_with_subject_inner<R: BackendRunner>(
         &env.workdir,
         &global.remote,
         repository_id.as_deref(),
-        &head,
+        resolved_head.local_branch,
     )?;
 
     let draft = !args.no_draft;
@@ -589,7 +651,7 @@ fn compute_with_subject_inner<R: BackendRunner>(
     let body_path = body_tempfile.path().to_path_buf();
     let create_call = build_create_call(
         &ctx,
-        &head,
+        resolved_head.provider_ref,
         &base,
         &args.title,
         &body,

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -51,6 +51,8 @@ type DefaultBranchFn<'a> =
 type GitStatusFn<'a> = Box<dyn Fn(&Path) -> Result<String, ForgeError> + 'a>;
 type HeadStateFn<'a> =
     Box<dyn Fn(&Path, &str) -> Result<crate::validations::HeadState, ForgeError> + 'a>;
+type UpstreamRepositoryFn<'a> =
+    Box<dyn Fn(&Path, &str) -> Result<GitHubUpstreamRepository, ForgeError> + 'a>;
 
 /// Envelope payload for `cli.forge-cli.pr.create.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -61,6 +63,9 @@ pub struct PrCreatePayload {
     pub head: String,
     /// Immutable provider head commit observed after creation.
     pub head_sha: Option<String>,
+    /// Provider repository identity for the source head when exposed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_repository: Option<String>,
     pub base: String,
     pub draft: bool,
     pub title: String,
@@ -98,6 +103,7 @@ pub struct Environment<'a> {
     pub default_branch: DefaultBranchFn<'a>,
     pub git_status: GitStatusFn<'a>,
     pub head_state: HeadStateFn<'a>,
+    pub(crate) upstream_repository: UpstreamRepositoryFn<'a>,
     pub workdir: PathBuf,
     pub headings: BodyHeadings,
     /// Resolved `[test_first].require`: when true, feature/bug PRs must carry
@@ -141,6 +147,7 @@ impl<'a> Environment<'a> {
             }),
             git_status: Box::new(git_status_porcelain),
             head_state: Box::new(git_branch_state),
+            upstream_repository: Box::new(git_branch_upstream_repository),
             workdir,
             headings: BodyHeadings::default(),
             test_first_required: cfg.resolve_test_first_required(None),
@@ -158,7 +165,7 @@ fn schema_ok() -> String {
 
 /// Provider-facing and local forms of a PR head reference.
 ///
-/// GitHub accepts `<owner>:<branch>` for cross-fork PRs. The owner qualifier
+/// GitHub accepts `<user>:<branch>` for cross-fork PRs. The user qualifier
 /// is preserved for `gh pr create`, while every local governance check remains
 /// bound to the semantic branch suffix. GitLab and local-provider heads remain
 /// unqualified and therefore unchanged.
@@ -166,6 +173,20 @@ fn schema_ok() -> String {
 pub(crate) struct ResolvedHeadRef<'a> {
     pub provider_ref: &'a str,
     pub local_branch: &'a str,
+    pub github_user: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubUpstreamRepository {
+    pub authority: String,
+    pub repository: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct QualifiedHeadSubject {
+    pub branch: String,
+    pub head_sha: String,
+    pub head_repository: String,
 }
 
 pub(crate) fn resolve_head_ref<'a>(
@@ -176,6 +197,7 @@ pub(crate) fn resolve_head_ref<'a>(
         return Ok(ResolvedHeadRef {
             provider_ref: head,
             local_branch: head,
+            github_user: None,
         });
     };
 
@@ -183,6 +205,7 @@ pub(crate) fn resolve_head_ref<'a>(
         return Ok(ResolvedHeadRef {
             provider_ref: head,
             local_branch: head,
+            github_user: None,
         });
     }
 
@@ -198,9 +221,9 @@ pub(crate) fn resolve_head_ref<'a>(
         return Err(ForgeError::validation(
             schema_err(),
             "branch_name_invalid",
-            format!("GitHub head '{head}' is not a valid <owner>:<branch> reference"),
+            format!("GitHub head '{head}' is not a valid <user>:<branch> reference"),
             Some(
-                "rule=<github-owner>:<(feat|fix|chore|docs|ci|refactor)/semantic-branch>"
+                "rule=<github-user>:<(feat|fix|chore|docs|ci|refactor)/semantic-branch>; GitHub CLI does not support organization-qualified fork heads"
                     .to_string(),
             ),
         ));
@@ -209,7 +232,191 @@ pub(crate) fn resolve_head_ref<'a>(
     Ok(ResolvedHeadRef {
         provider_ref: head,
         local_branch: branch,
+        github_user: Some(owner),
     })
+}
+
+fn qualified_head_error(message: impl Into<String>, detail: Option<String>) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "qualified_head_upstream_mismatch",
+        message,
+        detail,
+    )
+}
+
+fn provider_subject_error(message: impl Into<String>, detail: Option<String>) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "qualified_head_provider_mismatch",
+        message,
+        detail,
+    )
+}
+
+pub(crate) fn git_branch_upstream_repository(
+    workdir: &Path,
+    branch: &str,
+) -> Result<GitHubUpstreamRepository, ForgeError> {
+    let config_key = format!("branch.{branch}.remote");
+    let remote = run_identity_git(workdir, &["config", "--get", &config_key])?;
+    let remote = remote.trim();
+    if remote.is_empty() || remote == "." {
+        return Err(qualified_head_error(
+            "qualified GitHub head requires a remote-tracking upstream repository",
+            None,
+        ));
+    }
+
+    let push_urls = run_identity_git(
+        workdir,
+        &["remote", "get-url", "--push", "--all", "--", remote],
+    )?;
+    let destinations = push_urls
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    let [push_url] = destinations.as_slice() else {
+        return Err(qualified_head_error(
+            "qualified GitHub head requires exactly one upstream push repository",
+            Some(format!("push_destination_count={}", destinations.len())),
+        ));
+    };
+    let parsed = nils_common::git::parse_git_remote_url(push_url).ok_or_else(|| {
+        qualified_head_error(
+            "qualified GitHub head upstream is not a supported Git remote",
+            None,
+        )
+    })?;
+    let authority = crate::provider::parse_host(push_url).ok_or_else(|| {
+        qualified_head_error(
+            "qualified GitHub head upstream has no supported forge authority",
+            None,
+        )
+    })?;
+    let repository = parsed.path.trim_matches('/').trim_end_matches(".git");
+    let mut parts = repository.split('/');
+    let owner = parts.next().unwrap_or_default();
+    let name = parts.next().unwrap_or_default();
+    if owner.is_empty() || name.is_empty() || parts.next().is_some() {
+        return Err(qualified_head_error(
+            "qualified GitHub head upstream must identify one user repository",
+            None,
+        ));
+    }
+    Ok(GitHubUpstreamRepository {
+        authority: crate::provider::canonical_provider_host(Provider::GitHub, &authority),
+        repository: format!("{owner}/{name}").to_ascii_lowercase(),
+    })
+}
+
+fn run_identity_git(workdir: &Path, args: &[&str]) -> Result<String, ForgeError> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(workdir)
+        .args(args)
+        .output()
+        .map_err(|error| {
+            qualified_head_error(
+                "failed to inspect the qualified head upstream repository",
+                Some(error.to_string()),
+            )
+        })?;
+    if !output.status.success() {
+        return Err(qualified_head_error(
+            "failed to inspect the qualified head upstream repository",
+            None,
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn validate_qualified_head_subject(
+    ctx: &ProviderContext,
+    resolved: ResolvedHeadRef<'_>,
+    head_sha: &str,
+    upstream: GitHubUpstreamRepository,
+) -> Result<Option<QualifiedHeadSubject>, ForgeError> {
+    let Some(user) = resolved.github_user else {
+        return Ok(None);
+    };
+    let selected_authority = crate::provider::canonical_provider_host(Provider::GitHub, &ctx.host);
+    let upstream_user = upstream
+        .repository
+        .split_once('/')
+        .map(|(owner, _)| owner)
+        .unwrap_or_default();
+    if upstream.authority != selected_authority || !upstream_user.eq_ignore_ascii_case(user) {
+        return Err(qualified_head_error(
+            "qualified GitHub user does not match the local branch upstream repository",
+            Some("bind the branch upstream to the same GitHub user passed in --head".into()),
+        ));
+    }
+    Ok(Some(QualifiedHeadSubject {
+        branch: resolved.local_branch.to_string(),
+        head_sha: head_sha.to_string(),
+        head_repository: upstream.repository,
+    }))
+}
+
+fn qualified_head_subject_for_env(
+    ctx: &ProviderContext,
+    resolved: ResolvedHeadRef<'_>,
+    env: &Environment<'_>,
+) -> Result<Option<QualifiedHeadSubject>, ForgeError> {
+    let Some(_) = resolved.github_user else {
+        return Ok(None);
+    };
+    let state = (env.head_state)(&env.workdir, resolved.local_branch)?;
+    let upstream = (env.upstream_repository)(&env.workdir, resolved.local_branch)?;
+    validate_qualified_head_subject(ctx, resolved, &state.head_sha, upstream)
+}
+
+pub(crate) fn qualified_head_subject_for_workdir(
+    ctx: &ProviderContext,
+    resolved: ResolvedHeadRef<'_>,
+    workdir: &Path,
+) -> Result<Option<QualifiedHeadSubject>, ForgeError> {
+    let Some(_) = resolved.github_user else {
+        return Ok(None);
+    };
+    let state = git_branch_state(workdir, resolved.local_branch)?;
+    let upstream = git_branch_upstream_repository(workdir, resolved.local_branch)?;
+    validate_qualified_head_subject(ctx, resolved, &state.head_sha, upstream)
+}
+
+pub(crate) fn validate_qualified_provider_subject(
+    subject: Option<&QualifiedHeadSubject>,
+    provider_branch: &str,
+    provider_head: Option<&str>,
+    provider_repository: Option<&str>,
+) -> Result<(), ForgeError> {
+    let Some(subject) = subject else {
+        return Ok(());
+    };
+    let Some(provider_head) = provider_head.filter(|value| !value.is_empty()) else {
+        return Err(provider_subject_error(
+            "GitHub did not expose the qualified PR head commit",
+            None,
+        ));
+    };
+    let Some(provider_repository) = provider_repository.filter(|value| !value.is_empty()) else {
+        return Err(provider_subject_error(
+            "GitHub did not expose the qualified PR head repository",
+            None,
+        ));
+    };
+    if provider_branch != subject.branch
+        || provider_head != subject.head_sha
+        || !provider_repository.eq_ignore_ascii_case(&subject.head_repository)
+    {
+        return Err(provider_subject_error(
+            "GitHub qualified PR head does not match the local pushed branch subject",
+            Some("branch, head commit, and source repository must all match".into()),
+        ));
+    }
+    Ok(())
 }
 
 /// Resolve the git toplevel for layered-config discovery. Returns `None`
@@ -485,6 +692,7 @@ pub fn run_with<R: BackendRunner>(
     branch_pushed(&env.workdir, resolved_head.local_branch, |w, branch| {
         (env.head_state)(w, branch)
     })?;
+    let qualified_subject = qualified_head_subject_for_env(&ctx, resolved_head, env)?;
     let gate_applies = test_first_gate_applies(kind, env.test_first_required);
     let remote_url = evidence_remote_url(
         gate_applies,
@@ -534,6 +742,12 @@ pub fn run_with<R: BackendRunner>(
     }
 
     let payload = create_and_fetch(runner, &ctx, &create_call, kind)?;
+    validate_qualified_provider_subject(
+        qualified_subject.as_ref(),
+        &payload.head,
+        payload.head_sha.as_deref(),
+        payload.head_repository.as_deref(),
+    )?;
     validate_provider_subject_head(verified_subject.as_ref(), payload.head_sha.as_deref())?;
     Ok(emit_success(schema_ok(), payload, format, render_text))
 }
@@ -625,6 +839,7 @@ fn compute_with_subject_inner<R: BackendRunner>(
     branch_pushed(&env.workdir, resolved_head.local_branch, |w, branch| {
         (env.head_state)(w, branch)
     })?;
+    let qualified_subject = qualified_head_subject_for_env(&ctx, resolved_head, env)?;
     let gate_applies = test_first_gate_applies(kind, env.test_first_required);
     let remote_url = evidence_remote_url(
         gate_applies,
@@ -661,6 +876,12 @@ fn compute_with_subject_inner<R: BackendRunner>(
         &args.labels,
     );
     let payload = create_and_fetch(runner, &ctx, &create_call, kind)?;
+    validate_qualified_provider_subject(
+        qualified_subject.as_ref(),
+        &payload.head,
+        payload.head_sha.as_deref(),
+        payload.head_repository.as_deref(),
+    )?;
     validate_provider_subject_head(verified_subject.as_ref(), payload.head_sha.as_deref())?;
     Ok(PrCreateComputation {
         payload,
@@ -923,6 +1144,12 @@ pub fn parse_view_output(
                 .and_then(|item| item.as_str())
                 .map(str::to_string)
                 .filter(|value| !value.is_empty()),
+            head_repository: value
+                .get("headRepository")
+                .and_then(|repository| repository.get("nameWithOwner"))
+                .and_then(|value| value.as_str())
+                .map(|value| value.to_ascii_lowercase())
+                .filter(|value| !value.is_empty()),
             base: required_str(&value, "baseRefName")?,
             draft: value
                 .get("isDraft")
@@ -941,6 +1168,10 @@ pub fn parse_view_output(
                 .unwrap_or(url_fallback),
             head: required_str(&value, "source_branch")?,
             head_sha: crate::ops::pr_view::gitlab_head_sha(&value),
+            head_repository: value
+                .get("source_project_id")
+                .and_then(|value| value.as_u64())
+                .map(|id| format!("gitlab-project-id:{id}")),
             base: required_str(&value, "target_branch")?,
             draft: gitlab_is_draft(&value),
             title: required_str(&value, "title")?,
@@ -1226,6 +1457,12 @@ mod tests {
                 Ok(crate::validations::HeadState {
                     head_sha: "abc".into(),
                     upstream_sha: Some("abc".into()),
+                })
+            }),
+            upstream_repository: Box::new(|_, _| {
+                Ok(GitHubUpstreamRepository {
+                    authority: "github.com".into(),
+                    repository: "o/r".into(),
                 })
             }),
             workdir: PathBuf::from("."),

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -209,21 +209,13 @@ pub(crate) fn resolve_head_ref<'a>(
         });
     }
 
-    let owner_bytes = owner.as_bytes();
-    let owner_is_valid = !owner_bytes.is_empty()
-        && owner_bytes.len() <= 39
-        && owner_bytes[0].is_ascii_alphanumeric()
-        && owner_bytes[owner_bytes.len() - 1].is_ascii_alphanumeric()
-        && owner_bytes
-            .iter()
-            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'-');
-    if !owner_is_valid || branch.is_empty() || branch.contains(':') {
+    if owner.is_empty() || branch.is_empty() || branch.contains(':') {
         return Err(ForgeError::validation(
             schema_err(),
             "branch_name_invalid",
             format!("GitHub head '{head}' is not a valid <user>:<branch> reference"),
             Some(
-                "rule=<github-user>:<(feat|fix|chore|docs|ci|refactor)/semantic-branch>; GitHub CLI does not support organization-qualified fork heads"
+                "rule=<non-empty-github-user>:<(feat|fix|chore|docs|ci|refactor)/semantic-branch> with exactly one qualifier; forge-cli delegates username grammar and account type to GitHub; GitHub CLI does not support organization-qualified fork heads"
                     .to_string(),
             ),
         ));

--- a/crates/forge-cli/src/ops/pr_list.rs
+++ b/crates/forge-cli/src/ops/pr_list.rs
@@ -21,7 +21,7 @@ use crate::rate_limit::default_runner;
 const SCHEMA: &str = "pr.list";
 const SCHEMA_VERSION: u32 = 1;
 
-const GH_JSON_FIELDS: &str = "number,url,state,title,headRefName,author";
+const GH_JSON_FIELDS: &str = "number,url,state,title,headRefName,headRepository,author";
 
 /// Envelope payload for `cli.forge-cli.pr.list.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -38,6 +38,8 @@ pub struct PrListItem {
     pub state: &'static str,
     pub title: String,
     pub head: String,
+    #[serde(skip_serializing)]
+    pub head_repository: Option<String>,
     pub author: Option<String>,
 }
 
@@ -195,6 +197,12 @@ fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<PrListIt
             )?,
             title: required_str(raw, "title")?,
             head: required_str(raw, "headRefName")?,
+            head_repository: raw
+                .get("headRepository")
+                .and_then(|repository| repository.get("nameWithOwner"))
+                .and_then(|value| value.as_str())
+                .map(|value| value.to_ascii_lowercase())
+                .filter(|value| !value.is_empty()),
             author: raw
                 .get("author")
                 .and_then(|v| v.get("login").and_then(|n| n.as_str()))
@@ -212,6 +220,7 @@ fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<PrListIt
             )?,
             title: required_str(raw, "title")?,
             head: required_str(raw, "source_branch")?,
+            head_repository: None,
             author: raw
                 .get("author")
                 .and_then(|v| v.get("username").and_then(|n| n.as_str()))

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -659,6 +659,48 @@ fn pr_create_github_qualified_head_validates_local_suffix_and_preserves_provider
 }
 
 #[test]
+fn pr_create_github_qualified_head_accepts_managed_user_login() {
+    let tempdir = make_git_repo("github.com", "managed_user/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "sympoies/nils-cli",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "managed_user:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: managed user fork",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    let plan = envelope["data"]["plan"].as_array().expect("plan array");
+    let head_index = plan
+        .iter()
+        .position(|value| value == "--head")
+        .expect("--head argument");
+    assert_eq!(plan[head_index + 1], "managed_user:feat/sample");
+}
+
+#[test]
 fn pr_create_github_qualified_head_rejects_upstream_user_mismatch_before_provider() {
     let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
     let repo_path = tempdir.path().join("repo");
@@ -795,11 +837,11 @@ fn pr_create_github_qualified_head_rejects_provider_repository_mismatch() {
 }
 
 #[test]
-fn pr_create_qualified_head_is_github_only_and_rejects_invalid_owners() {
+fn pr_create_qualified_head_is_github_only_and_rejects_malformed_refs() {
     for (provider, head) in [
         ("gitlab", "fork-owner:feat/sample"),
-        ("github", "fork-owner-:feat/sample"),
-        ("github", "fork/owner:feat/sample"),
+        ("github", ":feat/sample"),
+        ("github", "fork-owner:"),
         ("github", "fork-owner:feat/sample:extra"),
     ] {
         let tempdir = make_git_repo(
@@ -843,7 +885,54 @@ fn pr_create_qualified_head_is_github_only_and_rejects_invalid_owners() {
         );
         let envelope = parse_envelope(&out.stdout);
         assert_eq!(envelope["error"]["code"], "branch_name_invalid");
+        if provider == "github" {
+            let detail = envelope["error"]["details"]["detail"]
+                .as_str()
+                .expect("qualified-head error detail");
+            assert!(detail.contains("delegates username grammar and account type to GitHub"));
+            assert!(detail.contains("does not support organization-qualified fork heads"));
+        }
     }
+}
+
+#[test]
+fn pr_create_qualified_head_remains_rejected_for_local_provider() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    let store_root = tempdir.path().join("local-store");
+    let store_root = store_root.to_string_lossy();
+    let stub = StubEnv::new();
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "local",
+            "--repo",
+            "local:sympoies/nils-cli",
+            "--store-root",
+            store_root.as_ref(),
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "managed_user:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: local qualified head",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 64, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "provider_unsupported");
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -567,6 +567,99 @@ fn pr_create_head_flag_uses_named_branch_push_state() {
 }
 
 #[test]
+fn pr_create_github_qualified_head_validates_local_suffix_and_preserves_provider_ref() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    git(&repo_path, &["checkout", "-q", "main"]);
+
+    let stub = StubEnv::new();
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "fork-owner:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: cross-fork sample",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    let plan = envelope["data"]["plan"].as_array().expect("plan array");
+    let head_index = plan
+        .iter()
+        .position(|value| value == "--head")
+        .expect("--head argument");
+    assert_eq!(plan[head_index + 1], "fork-owner:feat/sample");
+}
+
+#[test]
+fn pr_create_qualified_head_is_github_only_and_rejects_invalid_owners() {
+    for (provider, head) in [
+        ("gitlab", "fork-owner:feat/sample"),
+        ("github", "fork-owner-:feat/sample"),
+        ("github", "fork/owner:feat/sample"),
+        ("github", "fork-owner:feat/sample:extra"),
+    ] {
+        let tempdir = make_git_repo(
+            if provider == "github" {
+                "github.com"
+            } else {
+                "gitlab.com"
+            },
+            "sympoies/nils-cli",
+        );
+        let repo_path = tempdir.path().join("repo");
+        let stub = StubEnv::new();
+        let out = run_in_repo(
+            &stub,
+            &repo_path,
+            &[
+                "--provider",
+                provider,
+                "--dry-run",
+                "--format",
+                "json",
+                "pr",
+                "create",
+                "--head",
+                head,
+                "--base",
+                "main",
+                "--title",
+                "feat: invalid qualified head",
+                "--kind",
+                "feature",
+                "--body",
+                well_formed_body(),
+            ],
+        );
+
+        assert_eq!(
+            out.code, 65,
+            "provider={provider} head={head} stdout={} stderr={}",
+            out.stdout, out.stderr
+        );
+        let envelope = parse_envelope(&out.stdout);
+        assert_eq!(envelope["error"]["code"], "branch_name_invalid");
+    }
+}
+
+#[test]
 fn pr_create_gitlab_full_chain_emits_canonical_envelope() {
     let tempdir = make_git_repo("gitlab.com", "sympoies/nils-cli");
     let repo_path = tempdir.path().join("repo");

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -435,6 +435,46 @@ esac
     stub.write_stub("gh", &body)
 }
 
+fn write_qualified_gh_dispatch_stub(
+    stub: &StubEnv,
+    provider_head_sha: &str,
+    provider_head_repository: &str,
+) -> PathBuf {
+    let body = format!(
+        r#"#!/bin/sh
+set -e
+case "$1 $2" in
+  "pr create")
+    printf '%s\n' 'https://github.com/sympoies/nils-cli/pull/124'
+    ;;
+  "pr view")
+    cat <<'EOF'
+{{
+  "number": 124,
+  "url": "https://github.com/sympoies/nils-cli/pull/124",
+  "state": "OPEN",
+  "isDraft": true,
+  "title": "feat: cross-fork sample",
+  "headRefName": "feat/sample",
+  "headRefOid": "{provider_head_sha}",
+  "headRepository": {{ "nameWithOwner": "{provider_head_repository}" }},
+  "baseRefName": "main",
+  "mergeable": "MERGEABLE",
+  "mergedAt": null,
+  "labels": []
+}}
+EOF
+    ;;
+  *)
+    echo "stub: unexpected gh args" >&2
+    exit 99
+    ;;
+esac
+"#,
+    );
+    stub.write_stub("gh", &body)
+}
+
 fn write_glab_dispatch_stub(stub: &StubEnv) -> PathBuf {
     let body = format!(
         r#"#!/bin/sh
@@ -570,6 +610,15 @@ fn pr_create_head_flag_uses_named_branch_push_state() {
 fn pr_create_github_qualified_head_validates_local_suffix_and_preserves_provider_ref() {
     let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
     let repo_path = tempdir.path().join("repo");
+    git(
+        &repo_path,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/fork-owner/nils-cli.git",
+        ],
+    );
     git(&repo_path, &["checkout", "-q", "main"]);
 
     let stub = StubEnv::new();
@@ -579,6 +628,8 @@ fn pr_create_github_qualified_head_validates_local_suffix_and_preserves_provider
         &[
             "--provider",
             "github",
+            "--repo",
+            "sympoies/nils-cli",
             "--dry-run",
             "--format",
             "json",
@@ -605,6 +656,142 @@ fn pr_create_github_qualified_head_validates_local_suffix_and_preserves_provider
         .position(|value| value == "--head")
         .expect("--head argument");
     assert_eq!(plan[head_index + 1], "fork-owner:feat/sample");
+}
+
+#[test]
+fn pr_create_github_qualified_head_rejects_upstream_user_mismatch_before_provider() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "sympoies/nils-cli",
+            "--dry-run",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "fork-owner:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: cross-fork sample",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["error"]["code"],
+        "qualified_head_upstream_mismatch"
+    );
+}
+
+#[test]
+fn pr_create_github_qualified_head_rejects_provider_sha_mismatch() {
+    let tempdir = make_git_repo("github.com", "fork-owner/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let gh_path = write_qualified_gh_dispatch_stub(
+        &stub,
+        "0000000000000000000000000000000000000000",
+        "fork-owner/nils-cli",
+    );
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "sympoies/nils-cli",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "fork-owner:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: cross-fork sample",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["error"]["code"],
+        "qualified_head_provider_mismatch"
+    );
+}
+
+#[test]
+fn pr_create_github_qualified_head_rejects_provider_repository_mismatch() {
+    let tempdir = make_git_repo("github.com", "fork-owner/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    let local_sha = String::from_utf8(
+        Command::new("git")
+            .arg("-C")
+            .arg(&repo_path)
+            .args(["rev-parse", "feat/sample"])
+            .output()
+            .expect("git rev-parse")
+            .stdout,
+    )
+    .expect("sha utf8");
+
+    let stub = StubEnv::new();
+    let gh_path = write_qualified_gh_dispatch_stub(&stub, local_sha.trim(), "other-user/nils-cli");
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "sympoies/nils-cli",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "fork-owner:feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: cross-fork sample",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["error"]["code"],
+        "qualified_head_provider_mismatch"
+    );
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_deliver_chain.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver_chain.rs
@@ -616,7 +616,7 @@ EOF"#,
         ),
     };
     let body = format!(
-        r#"#!/bin/sh
+        r###"#!/bin/sh
 set -e
 case "$1 $2" in
   "auth status")
@@ -714,7 +714,7 @@ EOF
     exit 99
     ;;
 esac
-"#,
+"###,
         create = FIXTURE_CREATE_STDOUT,
         pre_view = pre_view,
         post_view = post_view,
@@ -862,6 +862,71 @@ esac
     perm.set_mode(0o755);
     fs::set_permissions(&path, perm).expect("chmod");
     path
+}
+
+fn write_qualified_head_collision_stub(stub: &StubEnv, head_sha: &str) -> PathBuf {
+    let create_sentinel = stub.tempdir.path().join("qualified-create-called");
+    let list_args = stub.tempdir.path().join("qualified-list-args");
+    let body = format!(
+        r###"#!/bin/sh
+set -e
+case "$1 $2" in
+  "auth status")
+    printf '%s\n' 'github.com' 1>&2
+    ;;
+  "repo view")
+    cat <<'EOF'
+{{
+  "name": "nils-cli",
+  "owner": {{ "login": "sympoies" }},
+  "url": "https://github.com/sympoies/nils-cli",
+  "defaultBranchRef": {{ "name": "main" }},
+  "mergeCommitAllowed": false,
+  "squashMergeAllowed": true,
+  "rebaseMergeAllowed": false
+}}
+EOF
+    ;;
+  "pr list")
+    printf '%s\n' "$*" > {list_args}
+    cat <<'EOF'
+[{{"number":123,"url":"https://github.com/sympoies/nils-cli/pull/123","state":"OPEN","title":"feat: other fork","headRefName":"feat/sample","headRepository":{{"nameWithOwner":"other-user/nils-cli"}},"author":{{"login":"other-user"}}}}]
+EOF
+    ;;
+  "pr create")
+    touch {create_sentinel}
+    printf '%s\n' 'https://github.com/sympoies/nils-cli/pull/124'
+    ;;
+  "pr view")
+    case "$3" in
+      124)
+        cat <<'EOF'
+{{"number":124,"url":"https://github.com/sympoies/nils-cli/pull/124","state":"OPEN","isDraft":true,"title":"feat: qualified fork","headRefName":"feat/sample","headRefOid":"{head_sha}","headRepository":{{"nameWithOwner":"fork-owner/nils-cli"}},"baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[],"body":"## Summary\n\nCreated.\n\n## Test plan\n\nVerified.\n"}}
+EOF
+        ;;
+      *)
+        cat <<'EOF'
+{{"number":123,"url":"https://github.com/sympoies/nils-cli/pull/123","state":"OPEN","isDraft":true,"title":"feat: other fork","headRefName":"feat/sample","headRefOid":"{head_sha}","headRepository":{{"nameWithOwner":"other-user/nils-cli"}},"baseRefName":"main","mergeable":"MERGEABLE","mergedAt":null,"labels":[],"body":"## Summary\n\nWrong fork.\n\n## Test plan\n\nWrong fork.\n"}}
+EOF
+        ;;
+    esac
+    ;;
+  "pr checks")
+    cat <<'EOF'
+{checks}
+EOF
+    ;;
+  *)
+    echo "stub: unexpected gh args" >&2
+    exit 99
+    ;;
+esac
+"###,
+        checks = FIXTURE_CHECKS_JSON,
+        create_sentinel = create_sentinel.display(),
+        list_args = list_args.display(),
+    );
+    stub.write_stub("gh", &body)
 }
 
 /// Full-chain stub whose post-merge `pr view` reports a closing-keyword
@@ -2060,6 +2125,76 @@ fn pr_deliver_adopts_existing_open_pr_for_head_branch() {
     assert!(
         !create_sentinel.exists(),
         "adopt path must never call the backend pr create"
+    );
+}
+
+#[test]
+fn pr_deliver_github_qualified_head_does_not_adopt_same_branch_from_another_user() {
+    let tempdir = make_git_repo();
+    let repo_path = tempdir.path().join("repo");
+    git(
+        &repo_path,
+        &[
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/fork-owner/nils-cli.git",
+        ],
+    );
+    let head_sha = git_output(&repo_path, &["rev-parse", "feat/sample"]);
+
+    let stub = StubEnv::new();
+    let create_sentinel = stub.tempdir.path().join("qualified-create-called");
+    let list_args = stub.tempdir.path().join("qualified-list-args");
+    let gh_path = write_qualified_head_collision_stub(&stub, &head_sha);
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "sympoies/nils-cli",
+            "--format",
+            "json",
+            "pr",
+            "deliver",
+            "--kind",
+            "feature",
+            "--title",
+            "feat: qualified fork",
+            "--body",
+            "## Summary\n\nCreated.\n\n## Test plan\n\nVerified.\n",
+            "--head",
+            "fork-owner:feat/sample",
+            "--base",
+            "main",
+            "--timeout",
+            "5s",
+            "--no-merge",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    let steps = envelope["data"]["steps"]
+        .as_array()
+        .expect("steps")
+        .iter()
+        .map(|step| step["step"].as_str().unwrap_or(""))
+        .collect::<Vec<_>>();
+    assert!(steps.contains(&"create"), "steps={steps:?}");
+    assert!(!steps.contains(&"adopt"), "steps={steps:?}");
+    assert!(
+        create_sentinel.exists(),
+        "the exact qualified head must be created"
+    );
+    let lookup = fs::read_to_string(list_args).expect("list args");
+    assert!(
+        !lookup.contains("fork-owner:feat/sample"),
+        "gh pr list must not receive unsupported qualified --head syntax: {lookup}"
     );
 }
 


### PR DESCRIPTION
## Summary

- accept GitHub's `<user>:<branch>` head syntax for governed user-fork PR creation while preserving GitLab and local-provider behavior
- validate only the non-empty single-qualifier structure locally, allowing provider-valid Enterprise Managed User logins with underscore suffixes while leaving username grammar and account type to GitHub
- bind the qualified user to the local branch's single upstream push repository, then require provider branch, repository, and head OID to match the local pushed subject after creation and during delivery
- adopt only an exact source repository + branch from a bounded GitHub open-PR projection without passing qualified syntax to `gh pr list`; a saturated projection without the exact row fails closed
- document qualified heads as a GitHub-only parity seam and record GitHub CLI's lack of organization-qualified fork-head support

## Test plan

- RED: the exact qualified-head integration test ran once and failed with `branch_name_invalid` before the implementation
- security RED: 6 focused integration tests ran before the identity fix; 2 passed and 4 failed for upstream-user, provider-OID, provider-repository, and same-branch adoption mismatches
- Managed User RED: the exact underscore-login regression ran once and failed with `branch_name_invalid` (0/1; 492 unrelated tests filtered)
- GREEN: 9 focused qualified-head cases passed (1 bounded-lookup unit test and 8 integration tests)
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (docs audits, fmt, clippy, 1371/1371 nextest cases, doctests)
