### PR TITLE
feat(delivery): bind exact bases and sync integration branches

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -4274,7 +4274,7 @@ _forge__cli() {
             return 0
             ;;
         forge__cli__pr__list)
-            opts="-h --state --author --head --limit --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --state --author --head --base --limit --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4289,6 +4289,10 @@ _forge__cli() {
                     return 0
                     ;;
                 --head)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --base)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -4328,13 +4332,17 @@ _forge__cli() {
             return 0
             ;;
         forge__cli__pr__merge)
-            opts="-h --expected-head --method --keep-branch --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-no-checks --allow-no-checks-reason --allow-unchecked-tasks --allow-unchecked-tasks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --expected-head --expected-base --method --keep-branch --allow-non-default-base --allow-unresolved-threads --allow-unresolved-threads-reason --review-convergence --allow-no-checks --allow-no-checks-reason --allow-unchecked-tasks --allow-unchecked-tasks-reason --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --expected-head)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --expected-base)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -209,6 +209,7 @@ _arguments "${_arguments_options[@]}" : \
 '--state=[Filter by state (default\: open)]:STATE:(open closed merged all)' \
 '--author=[Filter by author handle]:AUTHOR:_default' \
 '--head=[Filter by head / source branch]:HEAD:_default' \
+'--base=[Filter by target / base branch]:BASE:_default' \
 '--limit=[Cap the number of returned PRs (default\: 30)]:LIMIT:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
@@ -818,6 +819,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 (merge)
 _arguments "${_arguments_options[@]}" : \
 '--expected-head=[Compare-and-swap head verified by the caller before merge]:SHA:_default' \
+'--expected-base=[Exact target / base branch the provider PR/MR must still use]:BRANCH:_default' \
 '--method=[Merge method override. When omitted, falls back to \`.forge-cli.toml \[merge\].method\` then the spec default \`squash\`]:METHOD:(squash merge rebase)' \
 '--allow-unresolved-threads-reason=[Required when \`--allow-unresolved-threads\` is set. Non-empty free-form text describing why the unresolved threads are safe to merge past; the reason is recorded in the merge envelope payload]:TEXT:_default' \
 '--review-convergence=[Override \`\[review_convergence\].require\`. Passing the flag without a value enables it; use \`--review-convergence=false\` to disable a repo or user-global opt-in for this invocation]::REVIEW_CONVERGENCE:(true false)' \

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -107,9 +107,12 @@ comment fails closed. It works for GitHub App installation actors without the
 user-only `GET /user` endpoint. GitHub provides no content CAS for deletion, so
 a small final-read-to-mutation race remains.
 
-Direct `pr merge` callers can pass `--expected-head <sha>` to bind the merge to
-the head they reviewed. Provider drift then fails before the merge mutation;
-`pr deliver` uses the same compare-and-swap internally.
+Direct `pr merge` callers can pass `--expected-head <sha>` and
+`--expected-base <branch>` to bind the merge to the head and target they
+reviewed. Provider drift then fails before the merge mutation; `pr deliver`
+binds both values internally. A requested `--base` is exact throughout lookup,
+adoption, create read-back, ready, and merge; `--allow-non-default-base` only
+authorizes that named target and never widens it to another non-default branch.
 
 `pr review --submit-review` requires `--expected-head <sha>` and compares the
 provider head before any native review mutation. Summary-only reviews keep the

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -207,6 +207,7 @@ operations:
       - head_pushed
       - qualified_github_head # only for GitHub <user>:<branch>; binds upstream repository + provider branch/repository/SHA read-back
       - test_first_evidence # only when [test_first].require resolves true
+      - delivery_base_matches # provider read-back must equal the requested --base
     backends:
       github:
         program: gh
@@ -263,14 +264,15 @@ operations:
       - { name: --state,  type: enum<open|closed|merged|all>, default: open }
       - { name: --author, type: string,                       required: false }
       - { name: --head,   type: string,                       required: false }
+      - { name: --base,   type: string,                       required: false }
       - { name: --limit,  type: integer,                      default: 30 }
     validations: []
     backends:
-      github: { program: gh,   argv: [pr, list, --json, "number,url,state,title,headRefName,author"] }
-      gitlab: { program: glab, argv: [mr, list, -F, json] }
+      github: { program: gh,   argv: [pr, list, --base, "{base?}", --json, "number,url,state,title,headRefName,baseRefName,author"] }
+      gitlab: { program: glab, argv: [mr, list, --target-branch, "{base?}", -F, json] }
     output:
       data:
-        items: list<{ number, url, state, title, head, author }>
+        items: list<{ number, url, state, title, head, base, author }>
 
   - id: pr.edit
     schema_version: cli.forge-cli.pr.edit.v1
@@ -835,6 +837,7 @@ operations:
     inputs:
       - { name: <id>,                       type: integer,                       required: true }
       - { name: --expected-head,            type: string,                        default: null }
+      - { name: --expected-base,            type: string,                        default: null }
       - { name: --method,                   type: enum<squash|merge|rebase>,     default: squash }
       - { name: --keep-branch,              type: bool,                          default: false }
       - { name: --allow-non-default-base,   type: bool,                          default: false }
@@ -848,6 +851,7 @@ operations:
     validations:
       - worktree_clean
       - test_first_evidence_provider_head_mismatch # when --expected-head is supplied, the first provider snapshot must still match it before merge mutation
+      - delivery_base_matches # when --expected-base is supplied, the first provider snapshot must still match it before merge mutation
       - draft_merge_refused
       - default_branch_protected
       - required_checks_green   # TTL-zero re-check

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -1082,6 +1082,9 @@ distinctions that cannot be proven offline.
   must still expose that exact head or the command returns
   `test_first_evidence_provider_head_mismatch` before any merge mutation. The
   same reviewed head remains bound through the provider merge compare-and-swap.
+- Direct callers may pass `--expected-base <branch>`. The first provider
+  snapshot must expose that exact target or the command returns
+  `delivery_base_mismatch` before any merge mutation.
 - With convergence enabled, complete native-review and review-thread/comment
   snapshots are fetched once more after the thread/task gates and immediately
   before the provider merge. A late request blocks; any semantic digest change,
@@ -1167,7 +1170,8 @@ label errors are returned before provider access in every mode.
 1. `auth status` — fail-fast on missing auth.
 2. `repo view` — resolve default branch, repo slug, default merge
    method override.
-3. Head-branch lookup (`pr list --state open --head <branch>`) — when an
+3. Exact head-and-base lookup (`pr list --state open --head <branch> --base
+   <resolved-base>`) — when an
    open PR/MR already exists for the resolved head branch, the macro
    adopts it instead of creating: the create step (and its create-input
    gates) is skipped, an `adopt` step carrying the PR's `pr.view`
@@ -1181,8 +1185,10 @@ label errors are returned before provider access in every mode.
    and adopts only a row whose branch and `headRepository` exactly match the
    locally bound user/upstream repository; a same-named branch from any other
    fork is ignored. A saturated bounded result without that exact row fails
-   closed instead of assuming absence. The subsequent `pr view` must still match branch,
-   repository, and local SHA, and that SHA becomes the merge CAS input.
+   closed instead of assuming absence. The subsequent `pr view` must still
+   match branch, repository, local SHA, and the exact resolved base. The same
+   base is revalidated after checks, after ready, and by merge;
+   `--allow-non-default-base` authorizes only this value.
 4. `pr create --draft` — atom; validates branch / title / body. Only
    runs when the lookup found nothing.
 5. `pr wait-checks` — atom; blocks until terminal within one cumulative

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -808,6 +808,13 @@ pub struct PrMergeArgs {
         value_parser = clap::builder::NonEmptyStringValueParser::new()
     )]
     pub expected_head_sha: Option<String>,
+    /// Exact target / base branch the provider PR/MR must still use.
+    #[arg(
+        long = "expected-base",
+        value_name = "BRANCH",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub expected_base: Option<String>,
     /// Merge method override. When omitted, falls back to
     /// `.forge-cli.toml [merge].method` then the spec default `squash`.
     #[arg(long, value_enum)]
@@ -1285,6 +1292,9 @@ pub struct PrListArgs {
     /// Filter by head / source branch.
     #[arg(long)]
     pub head: Option<String>,
+    /// Filter by target / base branch.
+    #[arg(long)]
+    pub base: Option<String>,
     /// Cap the number of returned PRs (default: 30).
     #[arg(long, default_value_t = 30)]
     pub limit: u32,

--- a/crates/forge-cli/src/macros/pr_deliver.rs
+++ b/crates/forge-cli/src/macros/pr_deliver.rs
@@ -51,8 +51,8 @@ use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
 use crate::validations::{
     BodyHeadings, PreflightInputs, RuleVerdict, body_sections, branch_kind_matches, branch_name,
-    branch_pushed, git_branch_state, git_current_branch, git_status_porcelain, run_local_preflight,
-    worktree_clean,
+    branch_pushed, delivery_base_matches, git_branch_state, git_current_branch,
+    git_status_porcelain, run_local_preflight, worktree_clean,
 };
 
 pub const SCHEMA: &str = "pr.deliver";
@@ -220,6 +220,10 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
         schema_version: schema_version_for(BINARY, "repo.view", 1),
         payload: to_value(&repo_payload),
     });
+    let expected_base = args
+        .base
+        .clone()
+        .unwrap_or_else(|| repo_payload.default_branch.clone());
 
     // 3. Head-branch lookup, then adopt-or-create. An open PR already on
     //    the resolved head branch is adopted — the macro skips the create
@@ -251,7 +255,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
     } else {
         None
     };
-    let lookup_args = adopt_lookup_args(ctx, resolved_head);
+    let lookup_args = adopt_lookup_args(ctx, resolved_head, &expected_base);
     let existing = match pr_list::compute(runner, ctx, &lookup_args) {
         Ok(payload) => {
             match select_adoptable(payload.items, resolved_head, qualified_subject.as_ref()) {
@@ -311,6 +315,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
             test_first_required,
             resolved_head,
             qualified_subject: qualified_subject.as_ref(),
+            expected_base: &expected_base,
         };
         let verified_subject = match validate_adopted(&view, args, &adopt_context) {
             Ok(subject) => subject,
@@ -519,7 +524,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
         }
     }
 
-    if verified_subject.is_some() || qualified_subject.is_some() {
+    {
         let current_view = match pr_view::compute(runner, ctx, pr_number) {
             Ok(view) => view,
             Err(err) => {
@@ -533,6 +538,16 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
                 ));
             }
         };
+        if let Err(err) = delivery_base_matches(&expected_base, &current_view.base) {
+            return Ok(emit_chain_failure(
+                steps,
+                args,
+                ctx,
+                Some((pr_number, pr_url)),
+                &err,
+                format,
+            ));
+        }
         if let Err(err) = validate_provider_subject_head(
             verified_subject.as_ref(),
             current_view.head_sha.as_deref(),
@@ -586,6 +601,16 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
                 ));
             }
         };
+    if let Err(err) = delivery_base_matches(&expected_base, &ready_payload.base) {
+        return Ok(emit_chain_failure(
+            steps,
+            args,
+            ctx,
+            Some((pr_number, pr_url)),
+            &err,
+            format,
+        ));
+    }
     if let Err(err) =
         validate_provider_subject_head(verified_subject.as_ref(), ready_payload.head_sha.as_deref())
     {
@@ -629,7 +654,7 @@ fn execute_sequence<R: BackendRunner, C: Clock>(
                 .as_ref()
                 .map(|subject| subject.head_sha.clone())
         });
-    let merge_args = build_merge_args(args, pr_number, expected_head_sha);
+    let merge_args = build_merge_args(args, pr_number, expected_head_sha, expected_base.clone());
     let merge_payload =
         match pr_merge::compute_with_clock(runner, clock, global, &merge_args, workdir) {
             Ok(p) => p,
@@ -672,10 +697,12 @@ fn build_merge_args(
     args: &PrDeliverArgs,
     pr_number: u64,
     expected_head_sha: Option<String>,
+    expected_base: String,
 ) -> PrMergeArgs {
     PrMergeArgs {
         id: pr_number,
         expected_head_sha,
+        expected_base: Some(expected_base),
         method: Some(args.method),
         keep_branch: false,
         allow_non_default_base: args.allow_non_default_base,
@@ -747,12 +774,17 @@ fn run_issue_closeout<R: BackendRunner>(runner: &R, ctx: &ProviderContext, pr_nu
 /// Lookup filter for the adopt step. Unqualified heads use the provider's
 /// branch filter. Qualified GitHub heads use a bounded open-PR projection and
 /// select only the exact source repository + branch identity.
-fn adopt_lookup_args(ctx: &ProviderContext, head: ResolvedHeadRef<'_>) -> PrListArgs {
+fn adopt_lookup_args(
+    ctx: &ProviderContext,
+    head: ResolvedHeadRef<'_>,
+    expected_base: &str,
+) -> PrListArgs {
     let qualified_github = ctx.provider == Provider::GitHub && head.github_user.is_some();
     PrListArgs {
         state: PrStateFilter::Open,
         author: None,
         head: (!qualified_github).then(|| head.local_branch.to_string()),
+        base: Some(expected_base.to_string()),
         limit: if qualified_github {
             QUALIFIED_ADOPT_LOOKUP_LIMIT
         } else {
@@ -806,6 +838,7 @@ struct AdoptValidationContext<'a> {
     test_first_required: bool,
     resolved_head: ResolvedHeadRef<'a>,
     qualified_subject: Option<&'a QualifiedHeadSubject>,
+    expected_base: &'a str,
 }
 
 fn validate_adopted(
@@ -813,6 +846,7 @@ fn validate_adopted(
     args: &PrDeliverArgs,
     context: &AdoptValidationContext<'_>,
 ) -> Result<Option<VerifiedTestFirstSubject>, ForgeError> {
+    delivery_base_matches(context.expected_base, &view.base)?;
     validate_qualified_provider_subject(
         context.qualified_subject,
         &view.head,
@@ -949,7 +983,11 @@ fn build_dry_run_payload(
         },
         DryRunStep {
             step: "lookup",
-            plan: pr_lookup_dry_plan(ctx, &branch),
+            plan: pr_lookup_dry_plan(
+                ctx,
+                &branch,
+                args.base.as_deref().unwrap_or("<repo-default-branch>"),
+            ),
         },
         DryRunStep {
             step: "create",
@@ -1039,18 +1077,19 @@ fn build_dry_run_payload(
     }
 }
 
-fn pr_lookup_dry_plan(ctx: &ProviderContext, head: &str) -> Vec<String> {
+fn pr_lookup_dry_plan(ctx: &ProviderContext, head: &str, expected_base: &str) -> Vec<String> {
     let head = if head.is_empty() {
         "<current-branch>"
     } else {
         head
     };
     let lookup = resolve_head_ref(ctx.provider, head)
-        .map(|resolved| adopt_lookup_args(ctx, resolved))
+        .map(|resolved| adopt_lookup_args(ctx, resolved, expected_base))
         .unwrap_or_else(|_| PrListArgs {
             state: PrStateFilter::Open,
             author: None,
             head: Some(head.to_string()),
+            base: Some(expected_base.to_string()),
             limit: 1,
         });
     pr_list::build_list_call(ctx, &lookup).plan_argv()
@@ -1333,6 +1372,7 @@ mod tests {
                 state: "open",
                 title: "collision".into(),
                 head: "feat/demo".into(),
+                base: Some("main".into()),
                 head_repository: Some(format!("other-{number}/nils-cli")),
                 author: None,
             })
@@ -1374,9 +1414,10 @@ mod tests {
     fn deliver_forwards_review_convergence_override_to_merge() {
         let mut deliver = args(false);
         deliver.review_convergence = Some(false);
-        let merge = build_merge_args(&deliver, 42, Some("head123".into()));
+        let merge = build_merge_args(&deliver, 42, Some("head123".into()), "main".into());
         assert_eq!(merge.id, 42);
         assert_eq!(merge.expected_head_sha.as_deref(), Some("head123"));
+        assert_eq!(merge.expected_base.as_deref(), Some("main"));
         assert_eq!(merge.review_convergence, Some(false));
     }
 
@@ -1449,7 +1490,7 @@ mod tests {
         });
         plan_steps.push(DryRunStep {
             step: "lookup",
-            plan: pr_lookup_dry_plan(&c, "feat/demo"),
+            plan: pr_lookup_dry_plan(&c, "feat/demo", "main"),
         });
         plan_steps.push(DryRunStep {
             step: "create",
@@ -1610,7 +1651,7 @@ mod tests {
 
     #[test]
     fn lookup_dry_plan_filters_open_prs_on_head_branch() {
-        let plan = pr_lookup_dry_plan(&ctx(), "feat/demo");
+        let plan = pr_lookup_dry_plan(&ctx(), "feat/demo", "main");
         let h_idx = plan.iter().position(|s| s == "--head").expect("--head");
         assert_eq!(plan[h_idx + 1], "feat/demo");
         let s_idx = plan.iter().position(|s| s == "--state").expect("--state");
@@ -1619,7 +1660,7 @@ mod tests {
 
     #[test]
     fn lookup_dry_plan_renders_placeholder_for_unknown_branch() {
-        let plan = pr_lookup_dry_plan(&ctx(), "");
+        let plan = pr_lookup_dry_plan(&ctx(), "", "main");
         let h_idx = plan.iter().position(|s| s == "--head").expect("--head");
         assert_eq!(plan[h_idx + 1], "<current-branch>");
     }

--- a/crates/forge-cli/src/ops/pr_create.rs
+++ b/crates/forge-cli/src/ops/pr_create.rs
@@ -37,8 +37,8 @@ use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
 use crate::validations::{
     BodyHeadings, PrKind, body_sections, branch_kind_matches, branch_name, branch_pushed,
-    git_branch_state, git_status_porcelain, no_agent_attribution, no_local_path, title_length,
-    worktree_clean,
+    delivery_base_matches, git_branch_state, git_status_porcelain, no_agent_attribution,
+    no_local_path, title_length, worktree_clean,
 };
 
 const SCHEMA: &str = "pr.create";
@@ -734,6 +734,7 @@ pub fn run_with<R: BackendRunner>(
     }
 
     let payload = create_and_fetch(runner, &ctx, &create_call, kind)?;
+    delivery_base_matches(&base, &payload.base)?;
     validate_qualified_provider_subject(
         qualified_subject.as_ref(),
         &payload.head,
@@ -868,6 +869,7 @@ fn compute_with_subject_inner<R: BackendRunner>(
         &args.labels,
     );
     let payload = create_and_fetch(runner, &ctx, &create_call, kind)?;
+    delivery_base_matches(&base, &payload.base)?;
     validate_qualified_provider_subject(
         qualified_subject.as_ref(),
         &payload.head,

--- a/crates/forge-cli/src/ops/pr_list.rs
+++ b/crates/forge-cli/src/ops/pr_list.rs
@@ -21,7 +21,7 @@ use crate::rate_limit::default_runner;
 const SCHEMA: &str = "pr.list";
 const SCHEMA_VERSION: u32 = 1;
 
-const GH_JSON_FIELDS: &str = "number,url,state,title,headRefName,headRepository,author";
+const GH_JSON_FIELDS: &str = "number,url,state,title,headRefName,headRepository,baseRefName,author";
 
 /// Envelope payload for `cli.forge-cli.pr.list.v1`.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -38,6 +38,7 @@ pub struct PrListItem {
     pub state: &'static str,
     pub title: String,
     pub head: String,
+    pub base: Option<String>,
     #[serde(skip_serializing)]
     pub head_repository: Option<String>,
     pub author: Option<String>,
@@ -120,6 +121,10 @@ pub(crate) fn build_list_call(ctx: &ProviderContext, args: &PrListArgs) -> Backe
                 argv.push(OsString::from("--head"));
                 argv.push(OsString::from(h));
             }
+            if let Some(base) = &args.base {
+                argv.push(OsString::from("--base"));
+                argv.push(OsString::from(base));
+            }
             argv.push(OsString::from("--json"));
             argv.push(OsString::from(GH_JSON_FIELDS));
         }
@@ -138,6 +143,10 @@ pub(crate) fn build_list_call(ctx: &ProviderContext, args: &PrListArgs) -> Backe
             if let Some(h) = &args.head {
                 argv.push(OsString::from("--source-branch"));
                 argv.push(OsString::from(h));
+            }
+            if let Some(base) = &args.base {
+                argv.push(OsString::from("--target-branch"));
+                argv.push(OsString::from(base));
             }
             argv.push(OsString::from("--output"));
             argv.push(OsString::from("json"));
@@ -197,6 +206,10 @@ fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<PrListIt
             )?,
             title: required_str(raw, "title")?,
             head: required_str(raw, "headRefName")?,
+            base: raw
+                .get("baseRefName")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
             head_repository: raw
                 .get("headRepository")
                 .and_then(|repository| repository.get("nameWithOwner"))
@@ -220,6 +233,10 @@ fn parse_item(raw: &serde_json::Value, ctx: &ProviderContext) -> Result<PrListIt
             )?,
             title: required_str(raw, "title")?,
             head: required_str(raw, "source_branch")?,
+            base: raw
+                .get("target_branch")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
             head_repository: None,
             author: raw
                 .get("author")
@@ -282,6 +299,7 @@ mod tests {
             state: PrStateFilter::Open,
             author: None,
             head: None,
+            base: None,
             limit: 30,
         }
     }
@@ -301,6 +319,7 @@ mod tests {
         let mut args = default_args();
         args.author = Some("alice".into());
         args.head = Some("feat/x".into());
+        args.base = Some("mainline".into());
         args.limit = 1;
         args.state = PrStateFilter::Merged;
         let call = build_list_call(&ctx(Provider::GitHub), &args);
@@ -309,6 +328,8 @@ mod tests {
         assert_eq!(plan[a_idx + 1], "alice");
         let h_idx = plan.iter().position(|s| s == "--head").unwrap();
         assert_eq!(plan[h_idx + 1], "feat/x");
+        let b_idx = plan.iter().position(|s| s == "--base").unwrap();
+        assert_eq!(plan[b_idx + 1], "mainline");
         let l_idx = plan.iter().position(|s| s == "--limit").unwrap();
         assert_eq!(plan[l_idx + 1], "1");
         let s_idx = plan.iter().position(|s| s == "--state").unwrap();
@@ -332,19 +353,22 @@ mod tests {
     fn build_list_call_gitlab_maps_state_to_flag() {
         let mut args = default_args();
         args.state = PrStateFilter::Merged;
+        args.base = Some("mainline".into());
         let call = build_list_call(&ctx(Provider::GitLab), &args);
         let plan = call.plan_argv();
         assert!(plan.contains(&"--merged".to_string()));
         assert!(plan.contains(&"--per-page".to_string()));
         assert!(plan.contains(&"--output".to_string()));
         assert!(!plan.contains(&"-F".to_string()));
+        let b_idx = plan.iter().position(|s| s == "--target-branch").unwrap();
+        assert_eq!(plan[b_idx + 1], "mainline");
     }
 
     #[test]
     fn parse_list_output_github() {
         let stdout = r#"[
-          {"number":1,"url":"u1","state":"OPEN","title":"a","headRefName":"feat/a","author":{"login":"alice"}},
-          {"number":2,"url":"u2","state":"CLOSED","title":"b","headRefName":"feat/b","author":{"login":"bob"}}
+          {"number":1,"url":"u1","state":"OPEN","title":"a","headRefName":"feat/a","baseRefName":"mainline","author":{"login":"alice"}},
+          {"number":2,"url":"u2","state":"CLOSED","title":"b","headRefName":"feat/b","baseRefName":"main","author":{"login":"bob"}}
         ]"#;
         let payload = parse_list_output(
             &ctx(Provider::GitHub),
@@ -358,12 +382,13 @@ mod tests {
         assert_eq!(payload.items[0].state, "open");
         assert_eq!(payload.items[1].state, "closed");
         assert_eq!(payload.items[0].author.as_deref(), Some("alice"));
+        assert_eq!(payload.items[0].base.as_deref(), Some("mainline"));
     }
 
     #[test]
     fn parse_list_output_gitlab() {
         let stdout = r#"[
-          {"iid":7,"web_url":"u","state":"opened","title":"x","source_branch":"feat/x","author":{"username":"alice"}}
+          {"iid":7,"web_url":"u","state":"opened","title":"x","source_branch":"feat/x","target_branch":"mainline","author":{"username":"alice"}}
         ]"#;
         let payload = parse_list_output(
             &ctx(Provider::GitLab),
@@ -375,6 +400,7 @@ mod tests {
         .unwrap();
         assert_eq!(payload.items[0].number, 7);
         assert_eq!(payload.items[0].state, "open");
+        assert_eq!(payload.items[0].base.as_deref(), Some("mainline"));
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_merge.rs
+++ b/crates/forge-cli/src/ops/pr_merge.rs
@@ -45,7 +45,7 @@ use crate::ops::required_check_gate::{CheckPresence, ensure_required_checks_gree
 use crate::ops::review_convergence::{self, ReviewConvergenceSnapshot};
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
 use crate::rate_limit::default_runner;
-use crate::validations::{git_status_porcelain, worktree_clean};
+use crate::validations::{delivery_base_matches, git_status_porcelain, worktree_clean};
 
 pub const SCHEMA: &str = "pr.merge";
 pub const SCHEMA_VERSION: u32 = 1;
@@ -310,6 +310,9 @@ fn run_lockdown_chain<R: BackendRunner, C: Clock>(
 
     // Rule 7 + base discovery — fetch pr.view once and reuse.
     let pr = fetch_pr_view(runner, ctx, args.id)?;
+    if let Some(expected_base) = args.expected_base.as_deref() {
+        delivery_base_matches(expected_base, &pr.base)?;
+    }
     if let Some(expected) = args.expected_head_sha.as_deref()
         && pr.head_sha.as_deref() != Some(expected)
     {

--- a/crates/forge-cli/src/validations.rs
+++ b/crates/forge-cli/src/validations.rs
@@ -188,6 +188,25 @@ pub fn branch_kind_matches(prefix: BranchPrefix, kind: PrKind) -> Result<(), For
     }
 }
 
+/// Require the provider-side target to equal the delivery target selected by
+/// the caller. This remains exact even when that target is not the repository
+/// default branch.
+pub fn delivery_base_matches(expected: &str, observed: &str) -> Result<(), ForgeError> {
+    if expected == observed {
+        return Ok(());
+    }
+    Err(ForgeError::validation(
+        schema(),
+        "delivery_base_mismatch",
+        format!(
+            "provider PR/MR base '{observed}' differs from requested delivery base '{expected}'"
+        ),
+        Some(format!(
+            "expected_base={expected}; observed_base={observed}; select or create a PR/MR for the exact requested base"
+        )),
+    ))
+}
+
 /// Rule 3 — `len(title) <= 70` (codepoint count) and no trailing whitespace.
 pub fn title_length(title: &str) -> Result<(), ForgeError> {
     if title.is_empty() {

--- a/crates/forge-cli/tests/integration/pr_create.rs
+++ b/crates/forge-cli/tests/integration/pr_create.rs
@@ -396,6 +396,10 @@ fn pr_create_rejects_body_and_body_file_conflict_with_usage_exit() {
 /// Dispatching gh stub: branches on the first arg-2 pair (`repo view`,
 /// `pr create`, `pr view`).
 fn write_gh_dispatch_stub(stub: &StubEnv) -> PathBuf {
+    write_gh_dispatch_stub_with_view(stub, FIXTURE_GH_VIEW_JSON)
+}
+
+fn write_gh_dispatch_stub_with_view(stub: &StubEnv, view: &str) -> PathBuf {
     let body = format!(
         r#"#!/bin/sh
 set -e
@@ -430,7 +434,7 @@ EOF
 esac
 "#,
         create = FIXTURE_GH_CREATE_STDOUT,
-        view = FIXTURE_GH_VIEW_JSON,
+        view = view,
     );
     stub.write_stub("gh", &body)
 }
@@ -562,6 +566,45 @@ fn pr_create_github_full_chain_emits_canonical_envelope() {
         envelope["data"]["url"],
         "https://github.com/sympoies/nils-cli/pull/123"
     );
+}
+
+#[test]
+fn pr_create_rejects_provider_base_drift_after_creation() {
+    let tempdir = make_git_repo("github.com", "sympoies/nils-cli");
+    let repo_path = tempdir.path().join("repo");
+    let wrong_base =
+        FIXTURE_GH_VIEW_JSON.replace(r#""baseRefName": "main""#, r#""baseRefName": "mainline""#);
+
+    let stub = StubEnv::new();
+    let gh_path = write_gh_dispatch_stub_with_view(&stub, &wrong_base);
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "create",
+            "--head",
+            "feat/sample",
+            "--base",
+            "main",
+            "--title",
+            "feat: sample feature",
+            "--kind",
+            "feature",
+            "--body",
+            well_formed_body(),
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "delivery_base_mismatch");
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_deliver_chain.rs
+++ b/crates/forge-cli/tests/integration/pr_deliver_chain.rs
@@ -165,6 +165,23 @@ const ADOPTABLE_PR_VIEW_JSON: &str = r###"{
   "body": "## Summary\n\nAdopted draft.\n\n## Test plan\n\n- [x] unit\n"
 }"###;
 
+/// Same head as the requested delivery, but targeting another non-default
+/// branch. `--allow-non-default-base` authorizes the requested target; it must
+/// never turn into permission to adopt an arbitrary target from the same head.
+const ADOPTABLE_WRONG_BASE_PR_VIEW_JSON: &str = r###"{
+  "number": 123,
+  "url": "https://github.com/sympoies/nils-cli/pull/123",
+  "state": "OPEN",
+  "isDraft": true,
+  "title": "feat: sample feature",
+  "headRefName": "feat/sample",
+  "baseRefName": "test",
+  "mergeable": "MERGEABLE",
+  "mergedAt": null,
+  "labels": [],
+  "body": "## Summary\n\nWrong target.\n\n## Test plan\n\n- [x] unit\n"
+}"###;
+
 /// Post-ready view of the adopted PR: same record once `pr ready` promoted
 /// the draft, so the merge step's draft gate passes.
 const ADOPTED_READY_PR_VIEW_JSON: &str = r###"{
@@ -2125,6 +2142,49 @@ fn pr_deliver_adopts_existing_open_pr_for_head_branch() {
     assert!(
         !create_sentinel.exists(),
         "adopt path must never call the backend pr create"
+    );
+}
+
+#[test]
+fn pr_deliver_refuses_to_adopt_same_head_on_a_different_base() {
+    let tempdir = make_git_repo();
+    let repo_path = tempdir.path().join("repo");
+
+    let stub = StubEnv::new();
+    let gh_path = write_adopt_chain_stub(&stub, ADOPTABLE_WRONG_BASE_PR_VIEW_JSON);
+    let stub = stub.env("FORGE_CLI_GH_BIN", gh_path.to_string_lossy());
+
+    let out = run_in_repo(
+        &stub,
+        &repo_path,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "deliver",
+            "--kind",
+            "feature",
+            "--title",
+            "feat: sample feature",
+            "--head",
+            "feat/sample",
+            "--base",
+            "feat/integration",
+            "--allow-non-default-base",
+            "--timeout",
+            "5s",
+            "--no-merge",
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(envelope["error"]["code"], "delivery_base_mismatch");
+    assert!(
+        !stub.tempdir.path().join("create-called").exists(),
+        "a wrong-target PR must fail closed instead of creating or adopting"
     );
 }
 

--- a/crates/forge-cli/tests/integration/pr_merge.rs
+++ b/crates/forge-cli/tests/integration/pr_merge.rs
@@ -452,6 +452,40 @@ fn pr_merge_expected_head_rejects_provider_drift_before_mutation() {
 }
 
 #[test]
+fn pr_merge_expected_base_rejects_provider_drift_before_mutation() {
+    let tempdir = make_github_repo(None);
+    let repo_path = tempdir.path().join("repo");
+    let stub = StubEnv::new();
+    let merged = stub.tempdir.path().join("github-merged");
+    let body = github_merge_stub(&stub, "", "", false);
+    let stub = stub.gh_stub(&body);
+
+    let out = run_forge_cli_in(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--format",
+            "json",
+            "pr",
+            "merge",
+            "7",
+            "--expected-base",
+            "mainline",
+        ],
+        Some(&repo_path),
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "delivery_base_mismatch");
+    assert!(
+        !merged.exists(),
+        "merge mutation must not run after base drift"
+    );
+}
+
+#[test]
 fn pr_merge_expected_head_allows_the_matching_provider_head() {
     let tempdir = make_github_repo(None);
     let repo_path = tempdir.path().join("repo");

--- a/crates/git-cli/README.md
+++ b/crates/git-cli/README.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-git-cli is a Rust CLI that groups Git workflow helpers behind a dispatcher. It exposes nine
-command groups (`utils`, `reset`, `commit`, `branch`, `worktree`, `ci`, `open`, `summary`,
-`completion`) with
+git-cli is a Rust CLI that groups Git workflow helpers behind a dispatcher. It exposes the
+top-level remote surfaces `push`, `sync-default`, and `sync-branch` plus nine command groups
+(`utils`, `reset`, `commit`, `branch`, `worktree`, `ci`, `open`, `summary`, `completion`) with
 consistent help / version handling: `git-cli help` (or `-h`/`--help`) prints top-level usage,
 `git-cli <group> help` prints group usage, and `git-cli -V`/`--version` prints the binary version.
 
@@ -132,6 +132,13 @@ from the primary checkout or from inside any linked worktree.
   else. Uses `git merge --ff-only` when the default branch is checked out here, and a
   compare-and-swap `git update-ref` when no worktree holds it. Refuses divergence
   (`not-fast-forward`), a dirty checkout, and a default branch held by another worktree.
+  Options: `--remote <name>`, `--no-fetch`, `--dry-run`, `--format text|json`.
+
+### sync-branch
+
+- `sync-branch`: Fast-forward the checked-out, published non-default branch to its own
+  remote-tracking ref. Refuses the remote default branch, detached HEAD, missing or mismatched
+  upstream, divergence, and a dirty checkout. It never publishes or rewrites commits.
   Options: `--remote <name>`, `--no-fetch`, `--dry-run`, `--format text|json`.
 
 See the [remote surfaces spec](docs/specs/git-cli-remote-surfaces.md) for the full contract.

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -2,8 +2,8 @@
 
 ## Ownership
 
-This is a crate-local specification for `git-cli push` and
-`git-cli sync-default`.
+This is a crate-local specification for `git-cli push`,
+`git-cli sync-default`, and `git-cli sync-branch`.
 
 ## Why These Exist
 
@@ -12,10 +12,11 @@ go through `semantic-commit`, worktrees through `git-cli worktree`, PR/MR
 records and merges through `forge-cli pr`, and default-branch delivery through
 `semantic-commit default-branch` / `forge-cli repo push-default`.
 
-Two mutations had no owner:
+Three mutations had no owner:
 
 - publishing a feature branch, and
-- advancing the local default branch to a commit already on its remote.
+- advancing the local default branch to a commit already on its remote, and
+- advancing a checked-out persistent integration branch to its published head.
 
 Both had to fall back to raw `git`, which the delivery guard is built to
 distrust because a raw invocation cannot prove what it will touch. These two
@@ -111,12 +112,31 @@ Refusals:
 | `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached |
 | `git-fetch-failed` | the fetch failed; `--no-fetch` syncs against the already-fetched ref |
 
+## `git-cli sync-branch`
+
+```text
+git-cli sync-branch [--remote <name>] [--no-fetch] [--dry-run]
+                    [--format text|json]
+```
+
+Fast-forwards the checked-out non-default branch to the same-named branch on
+`<remote>`. The branch must already track exactly `refs/heads/<branch>` on that
+remote, so the command cannot infer or redirect the destination. Unless
+`--no-fetch` is passed, it fetches only that branch through an explicit
+fully-qualified refspec.
+
+The command refuses detached HEAD, the remote default branch, an unknown or
+mismatched upstream, divergence, and a dirty checkout. It uses
+`git merge --ff-only` for the sole mutation; it never authors, rebases, resets,
+pushes, or changes upstream configuration.
+
 ## JSON Contract
 
 Both commands accept `--format text|json` and use the shared workspace envelope:
 
 - `cli.git-cli.push.v1`
 - `cli.git-cli.sync-default.v1`
+- `cli.git-cli.sync-branch.v1`
 
 `push` returns `branch`, `remote`, `remote_branch`, `refspec`, `head`,
 `default_branch`, `pushed`, `dry_run`, `created_remote_branch`, `upstream`, and
@@ -125,6 +145,10 @@ Both commands accept `--format text|json` and use the shared workspace envelope:
 `sync-default` returns `default_branch`, `remote`, `remote_ref`,
 `previous_head`, `new_head`, `strategy`, `already_current`, `fast_forward`,
 `dry_run`, and `fetched`.
+
+`sync-branch` returns `branch`, `remote`, `remote_ref`, `previous_head`,
+`new_head`, `strategy`, `already_current`, `fast_forward`, `dry_run`, and
+`fetched`.
 
 `--dry-run` performs every read-only check and reports the strategy and target
 head it would use, without mutating anything.

--- a/crates/git-cli/src/cli.rs
+++ b/crates/git-cli/src/cli.rs
@@ -42,6 +42,11 @@ enum Group {
         about = "Fast-forward the local default branch to its remote-tracking ref"
     )]
     SyncDefault(RawArgs),
+    #[command(
+        name = "sync-branch",
+        about = "Fast-forward the checked-out non-default branch to its remote-tracking ref"
+    )]
+    SyncBranch(RawArgs),
     #[command(about = "Summarize repository history")]
     Summary(RawArgs),
     #[command(about = "Export shell completion script")]
@@ -296,6 +301,9 @@ where
         Some(Group::Push(raw)) => publish::dispatch("push", &raw.args).unwrap_or(exit::USAGE),
         Some(Group::SyncDefault(raw)) => {
             publish::dispatch("sync-default", &raw.args).unwrap_or(exit::USAGE)
+        }
+        Some(Group::SyncBranch(raw)) => {
+            publish::dispatch("sync-branch", &raw.args).unwrap_or(exit::USAGE)
         }
         Some(Group::Summary(raw)) => git_summary::cli::run_embedded(&raw.args),
         Some(Group::Completion(raw)) => run_completion(raw),

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -11,6 +11,8 @@
 //!   branch and refuses outright when that branch is the remote's default.
 //! * [`run_sync_default`] only ever fast-forwards the local default branch to a
 //!   commit that is already published, and refuses anything else.
+//! * [`run_sync_branch`] only ever fast-forwards the checked-out, published
+//!   non-default branch to its own remote-tracking ref.
 //!
 //! Every refusal is a typed envelope error, so a caller can tell "this is
 //! forbidden" from "this could not be proven" without parsing prose.
@@ -30,6 +32,7 @@ pub fn dispatch(cmd: &str, args: &[String]) -> Option<i32> {
     match cmd {
         "push" => Some(run_push(args)),
         "sync-default" => Some(run_sync_default(args)),
+        "sync-branch" => Some(run_sync_branch(args)),
         _ => None,
     }
 }
@@ -84,6 +87,20 @@ struct PushOutput {
 #[derive(Debug, Serialize)]
 struct SyncOutput {
     default_branch: String,
+    remote: String,
+    remote_ref: String,
+    previous_head: String,
+    new_head: String,
+    strategy: &'static str,
+    already_current: bool,
+    fast_forward: bool,
+    dry_run: bool,
+    fetched: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SyncBranchOutput {
+    branch: String,
     remote: String,
     remote_ref: String,
     previous_head: String,
@@ -471,6 +488,158 @@ fn sync_default(args: &SyncArgs) -> Result<SyncOutput, CliError> {
     })
 }
 
+// ----------------------------------------------------------- sync-branch
+
+fn run_sync_branch(args: &[String]) -> i32 {
+    let requested_format = detect_format(args);
+    if take_help(args) {
+        print_sync_branch_help();
+        return 0;
+    }
+    let parsed = match parse_sync_args_for("sync-branch", args) {
+        Ok(parsed) => parsed,
+        Err(err) => return emit_error("sync-branch", requested_format, err),
+    };
+
+    match sync_branch(&parsed) {
+        Ok(output) => emit_success("sync-branch", parsed.format, &output, || {
+            if output.already_current {
+                format!(
+                    "Already current: {} at {}",
+                    output.branch,
+                    short(&output.new_head)
+                )
+            } else if output.dry_run {
+                format!(
+                    "Would fast-forward {} {}..{}",
+                    output.branch,
+                    short(&output.previous_head),
+                    short(&output.new_head)
+                )
+            } else {
+                format!(
+                    "Fast-forwarded {} {}..{}",
+                    output.branch,
+                    short(&output.previous_head),
+                    short(&output.new_head)
+                )
+            }
+        }),
+        Err(err) => emit_error("sync-branch", parsed.format, err),
+    }
+}
+
+fn sync_branch(args: &SyncArgs) -> Result<SyncBranchOutput, CliError> {
+    ensure_inside_git_repo()?;
+    require_remote(&args.remote)?;
+
+    let branch = current_branch().ok_or_else(|| {
+        CliError::data("detached-head", "HEAD is not attached to a branch")
+            .with_hint("check out the published non-default branch you want to synchronize")
+    })?;
+    let default_branch = cached_default_branch(&args.remote).ok_or_else(|| {
+        CliError::data(
+            "default-branch-unresolved",
+            format!(
+                "cannot prove '{branch}' is non-default because remote '{}' has no cached default branch",
+                args.remote
+            ),
+        )
+        .with_hint(format!(
+            "run `git remote set-head {} --auto` to cache it",
+            args.remote
+        ))
+    })?;
+    if branch == default_branch {
+        return Err(CliError::data(
+            "refuse-default-branch",
+            format!(
+                "'{branch}' is the default branch of remote '{}'; use `git-cli sync-default`",
+                args.remote
+            ),
+        ));
+    }
+    if !upstream_is_own_ref(&args.remote, &branch) {
+        return Err(CliError::data(
+            "branch-upstream-mismatch",
+            format!(
+                "'{branch}' does not track its own branch on remote '{}'",
+                args.remote
+            ),
+        )
+        .with_hint("publish or repair the branch upstream with `git-cli push` first"));
+    }
+    if !args.dry_run {
+        require_clean_checkout()?;
+    }
+
+    let remote_ref = format!("refs/remotes/{}/{branch}", args.remote);
+    if args.fetch {
+        let refspec = format!("+refs/heads/{branch}:{remote_ref}");
+        git_output(&["fetch", "--quiet", &args.remote, &refspec]).map_err(|err| {
+            CliError::runtime("git-fetch-failed", summarize_git_error(&err.to_string()))
+                .with_hint("pass `--no-fetch` to sync against the already-fetched remote ref")
+        })?;
+    }
+
+    let previous_head = rev_parse_commit("HEAD")
+        .ok_or_else(|| CliError::data("head-unresolved", "HEAD does not resolve to a commit"))?;
+    let new_head = rev_parse_commit(&remote_ref).ok_or_else(|| {
+        CliError::data(
+            "remote-branch-missing",
+            format!("'{remote_ref}' does not resolve to a commit"),
+        )
+        .with_hint("publish the branch first, or drop `--no-fetch`")
+    })?;
+
+    if previous_head == new_head {
+        return Ok(SyncBranchOutput {
+            branch,
+            remote: args.remote.clone(),
+            remote_ref,
+            previous_head: previous_head.clone(),
+            new_head: previous_head,
+            strategy: "noop",
+            already_current: true,
+            fast_forward: true,
+            dry_run: args.dry_run,
+            fetched: args.fetch,
+        });
+    }
+    if !git_status_success(&["merge-base", "--is-ancestor", &previous_head, &new_head]) {
+        return Err(CliError::data(
+            "not-fast-forward",
+            format!(
+                "'{branch}' has diverged from '{remote_ref}'; synchronizing would discard local commits"
+            ),
+        )
+        .with_hint("deliver or move the local-only commits before synchronizing")
+        .with_details(json!({
+            "local_head": previous_head,
+            "remote_head": new_head,
+        })));
+    }
+
+    if !args.dry_run {
+        git_output(&["merge", "--ff-only", "--quiet", &remote_ref]).map_err(|err| {
+            CliError::runtime("git-merge-failed", summarize_git_error(&err.to_string()))
+        })?;
+    }
+
+    Ok(SyncBranchOutput {
+        branch,
+        remote: args.remote.clone(),
+        remote_ref,
+        previous_head,
+        new_head,
+        strategy: "merge-ff-only",
+        already_current: false,
+        fast_forward: true,
+        dry_run: args.dry_run,
+        fetched: args.fetch,
+    })
+}
+
 // ----------------------------------------------------------------- git
 
 fn current_branch() -> Option<String> {
@@ -534,7 +703,7 @@ fn require_clean_checkout() -> Result<(), CliError> {
         "dirty-checkout",
         "the checkout has staged or unstaged changes",
     )
-    .with_hint("commit or stash the changes before moving the default branch"))
+    .with_hint("commit or stash the changes before moving the checked-out branch"))
 }
 
 /// Which other worktree, if any, holds `branch` checked out.
@@ -618,6 +787,10 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
 }
 
 fn parse_sync_args(args: &[String]) -> Result<SyncArgs, CliError> {
+    parse_sync_args_for("sync-default", args)
+}
+
+fn parse_sync_args_for(command: &str, args: &[String]) -> Result<SyncArgs, CliError> {
     let mut rest: Vec<String> = args.to_vec();
     let format = take_format(&mut rest)?;
     let mut remote = DEFAULT_REMOTE.to_string();
@@ -648,7 +821,9 @@ fn parse_sync_args(args: &[String]) -> Result<SyncArgs, CliError> {
                     "unknown-argument",
                     format!("unknown argument: {other}"),
                 )
-                .with_hint("run `git-cli sync-default --help` for the accepted flags"));
+                .with_hint(format!(
+                    "run `git-cli {command} --help` for the accepted flags"
+                )));
             }
         }
     }
@@ -695,6 +870,17 @@ fn print_sync_help() {
         "  Refuses anything that is not a pure fast-forward onto an already-published commit."
     );
     println!("  Moves the ref directly when no worktree holds the default branch checked out.");
+    println!(
+        "  --no-fetch syncs against the already-fetched remote ref instead of contacting the remote."
+    );
+}
+
+fn print_sync_branch_help() {
+    println!(
+        "Usage: git-cli sync-branch [--remote <name>] [--no-fetch] [--dry-run] [--format text|json]"
+    );
+    println!("  Fast-forward the checked-out non-default branch to its own remote-tracking ref.");
+    println!("  Refuses detached, default, untracked, dirty, or diverged branches.");
     println!(
         "  --no-fetch syncs against the already-fetched remote ref instead of contacting the remote."
     );

--- a/crates/git-cli/tests/integration/dispatcher.rs
+++ b/crates/git-cli/tests/integration/dispatcher.rs
@@ -41,6 +41,11 @@ fn assert_top_level_help(stdout: &str) {
         "sync-default",
         "Fast-forward the local default branch to its remote-tracking ref",
     );
+    assert_command_row(
+        stdout,
+        "sync-branch",
+        "Fast-forward the checked-out non-default branch to its remote-tracking ref",
+    );
     assert_contains(stdout, "-V, --version  Print version");
 }
 

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -23,6 +23,41 @@ fn repo_with_published_main() -> (TempDir, TempDir) {
     (repo, remote)
 }
 
+fn publish_branch(repo: &Path, branch: &str) {
+    git(repo, &["checkout", "-q", "-b", branch]);
+    git(repo, &["push", "-q", "--set-upstream", "origin", branch]);
+}
+
+fn advance_remote_branch(remote: &Path, branch: &str) -> String {
+    let scratch = TempDir::new().expect("scratch clone");
+    let remote_path = remote.to_string_lossy().to_string();
+    let scratch_path = scratch.path().to_string_lossy().to_string();
+    git(
+        remote,
+        &[
+            "clone",
+            "-q",
+            "--branch",
+            branch,
+            &remote_path,
+            &scratch_path,
+        ],
+    );
+    git(
+        scratch.path(),
+        &["config", "user.email", "test@example.com"],
+    );
+    git(scratch.path(), &["config", "user.name", "Test"]);
+    commit_file(
+        scratch.path(),
+        "remote.txt",
+        "remote\n",
+        "advance remote branch",
+    );
+    git(scratch.path(), &["push", "-q", "origin", branch]);
+    rev_parse(scratch.path(), "HEAD")
+}
+
 fn git_config_optional(repo: &Path, key: &str) -> Option<String> {
     let output = git_output(repo, &["config", "--get", key]);
     output
@@ -456,4 +491,132 @@ fn sync_default_dry_run_reports_the_plan_without_moving_the_ref() {
         previous,
         "a dry run moves nothing"
     );
+}
+
+#[test]
+fn sync_branch_fast_forwards_a_checked_out_non_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+
+    publish_branch(repo.path(), "feat/integration");
+    let previous = rev_parse(repo.path(), "HEAD");
+    let advanced = advance_remote_branch(remote.path(), "feat/integration");
+
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["schema_version"], "cli.git-cli.sync-branch.v1");
+    assert_eq!(json["data"]["branch"], "feat/integration");
+    assert_eq!(json["data"]["previous_head"], previous);
+    assert_eq!(json["data"]["new_head"], advanced);
+    assert_eq!(json["data"]["strategy"], "merge-ff-only");
+    assert_eq!(rev_parse(repo.path(), "HEAD"), advanced);
+}
+
+#[test]
+fn sync_branch_refuses_the_default_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+
+    assert_ne!(output.code, 0);
+    assert_eq!(
+        parse_json(&output)["error"]["code"],
+        "refuse-default-branch"
+    );
+}
+
+#[test]
+fn sync_branch_refuses_an_unpublished_or_mistracked_branch() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/local"],
+    );
+
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+
+    assert_ne!(output.code, 0);
+    assert_eq!(
+        parse_json(&output)["error"]["code"],
+        "branch-upstream-mismatch"
+    );
+}
+
+#[test]
+fn sync_branch_refuses_a_dirty_checkout_before_fast_forwarding() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    publish_branch(repo.path(), "feat/integration");
+    let previous = rev_parse(repo.path(), "HEAD");
+    advance_remote_branch(remote.path(), "feat/integration");
+
+    std::fs::write(repo.path().join("dirty.txt"), "dirty\n").expect("write dirty file");
+    git(repo.path(), &["add", "dirty.txt"]);
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+
+    assert_ne!(output.code, 0);
+    assert_eq!(parse_json(&output)["error"]["code"], "dirty-checkout");
+    assert_eq!(rev_parse(repo.path(), "HEAD"), previous);
+    assert_eq!(
+        rev_parse(repo.path(), "refs/remotes/origin/feat/integration"),
+        previous,
+        "a dirty refusal must occur before fetch mutates the remote-tracking ref"
+    );
+}
+
+#[test]
+fn sync_branch_refuses_a_detached_head() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+    publish_branch(repo.path(), "feat/integration");
+    git(repo.path(), &["checkout", "-q", "--detach"]);
+
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+
+    assert_ne!(output.code, 0);
+    assert_eq!(parse_json(&output)["error"]["code"], "detached-head");
+}
+
+#[test]
+fn sync_branch_refuses_diverged_history_without_moving_head() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    publish_branch(repo.path(), "feat/integration");
+    commit_file(repo.path(), "local.txt", "local\n", "advance locally");
+    let local_head = rev_parse(repo.path(), "HEAD");
+    let remote_head = advance_remote_branch(remote.path(), "feat/integration");
+
+    let output = harness.run(repo.path(), &["sync-branch", "--format", "json"]);
+
+    assert_ne!(output.code, 0);
+    let json = parse_json(&output);
+    assert_eq!(json["error"]["code"], "not-fast-forward");
+    assert_eq!(json["error"]["details"]["local_head"], local_head);
+    assert_eq!(json["error"]["details"]["remote_head"], remote_head);
+    assert_eq!(rev_parse(repo.path(), "HEAD"), local_head);
+}
+
+#[test]
+fn sync_branch_dry_run_reports_fast_forward_without_moving_head() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_published_main();
+    publish_branch(repo.path(), "feat/integration");
+    let previous = rev_parse(repo.path(), "HEAD");
+    let advanced = advance_remote_branch(remote.path(), "feat/integration");
+
+    let output = harness.run(
+        repo.path(),
+        &["sync-branch", "--dry-run", "--format", "json"],
+    );
+
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["previous_head"], previous);
+    assert_eq!(json["data"]["new_head"], advanced);
+    assert_eq!(rev_parse(repo.path(), "HEAD"), previous);
 }


### PR DESCRIPTION
## Summary

Make branch-targeted delivery safe for repositories that use persistent non-default integration branches, without weakening the default-branch protections owned by semantic-commit.

## Changes

- Bind PR lookup, adoption, create readback, ready, and merge to the exact requested base branch.
- Add `git-cli sync-branch` for clean, same-name-upstream, fast-forward-only synchronization of published non-default branches.
- Document and complete the new forge-cli and git-cli contracts and shell completions.

## Test-First Evidence

Regression coverage first demonstrated missing exact-base filtering and the absence of a guarded non-default-branch synchronization surface. The completed evidence record is bound to the delivered head.

## Test plan

- `bash .agents/scripts/pre-pr.sh`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- Focused forge-cli PR delivery and git-cli synchronization integration suites
- Signed-commit verification

## Risk / Notes

The new paths fail closed on base mismatches, dirty or detached checkouts, incorrect upstreams, default branches, and divergent histories. Existing default-branch delivery behavior remains unchanged.
