### PR TITLE
fix(agent-hook): add quarantined workspace recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+]
+
+[[package]]
 name = "harfrust"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +1930,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.8+1.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +1954,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2103,6 +2139,7 @@ version = "1.27.16"
 dependencies = [
  "clap",
  "clap_complete",
+ "git2",
  "jiff",
  "libc",
  "nils-agent-docs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-uti
 axum = { version = "0.8", features = ["ws"] }
 futures-util = "0.3"
 getrandom = "0.4"
+git2 = "0.21"
 libc = "0.2"
 
 [profile.dev]

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -3,8 +3,8 @@
 This file documents third-party Rust crate licenses used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `6dc14bf99861287c412f0224726440ca504bf9ff0f2becea213851165fa97d0b`
-- Third-party crates (`source != null`): 493
+- Cargo.lock SHA256: `bcf43b99e63ece1db0720b60aa89ccb7b6f2fc797429f85158cf35292ef86586`
+- Third-party crates (`source != null`): 496
 - Workspace crates (`source == null`, excluded below): 46
 
 ## Notes
@@ -17,7 +17,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 
 | License Expression | Crate Count |
 | --- | ---: |
-| MIT OR Apache-2.0 | 236 |
+| MIT OR Apache-2.0 | 239 |
 | MIT | 103 |
 | Apache-2.0 OR MIT | 40 |
 | Zlib OR Apache-2.0 OR MIT | 20 |
@@ -185,6 +185,7 @@ This file documents third-party Rust crate licenses used by this workspace.
 | getrandom | 0.3.4 | MIT OR Apache-2.0 | crates.io |
 | getrandom | 0.4.3 | MIT OR Apache-2.0 | crates.io |
 | gif | 0.14.2 | MIT OR Apache-2.0 | crates.io |
+| git2 | 0.21.0 | MIT OR Apache-2.0 | crates.io |
 | harfrust | 0.12.0 | MIT | crates.io |
 | hashbrown | 0.16.1 | MIT OR Apache-2.0 | crates.io |
 | hashbrown | 0.17.1 | MIT OR Apache-2.0 | crates.io |
@@ -247,8 +248,10 @@ This file documents third-party Rust crate licenses used by this workspace.
 | kurbo | 0.13.1 | Apache-2.0 OR MIT | crates.io |
 | lazy_static | 1.5.0 | MIT OR Apache-2.0 | crates.io |
 | libc | 0.2.189 | MIT OR Apache-2.0 | crates.io |
+| libgit2-sys | 0.18.8+1.9.7 | MIT OR Apache-2.0 | crates.io |
 | libm | 0.2.16 | MIT | crates.io |
 | libsqlite3-sys | 0.38.2 | MIT | crates.io |
+| libz-sys | 1.1.29 | MIT OR Apache-2.0 | crates.io |
 | linux-raw-sys | 0.12.1 | Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT | crates.io |
 | litemap | 0.8.2 | Unicode-3.0 | crates.io |
 | lock_api | 0.4.14 | MIT OR Apache-2.0 | crates.io |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,8 +3,8 @@
 This file documents third-party notice-file discovery for Rust crates used by this workspace.
 
 - Data source: `cargo metadata --format-version 1 --locked`
-- Cargo.lock SHA256: `6dc14bf99861287c412f0224726440ca504bf9ff0f2becea213851165fa97d0b`
-- Third-party crates (`source != null`): 493
+- Cargo.lock SHA256: `bcf43b99e63ece1db0720b60aa89ccb7b6f2fc797429f85158cf35292ef86586`
+- Third-party crates (`source != null`): 496
 
 ## Notice Extraction Policy
 
@@ -1157,6 +1157,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### git2 0.21.0
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### harfrust 0.12.0
 
 - License: `MIT`
@@ -1683,6 +1692,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
   - `LICENSE-APACHE`
   - `LICENSE-MIT`
 
+### libgit2-sys 0.18.8+1.9.7
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
+
 ### libm 0.2.16
 
 - License: `MIT`
@@ -1698,6 +1716,15 @@ This file documents third-party notice-file discovery for Rust crates used by th
 - Notice files: No explicit NOTICE file discovered.
 - License file references:
   - `LICENSE`
+
+### libz-sys 1.1.29
+
+- License: `MIT OR Apache-2.0`
+- Source: `crates.io`
+- Notice files: No explicit NOTICE file discovered.
+- License file references:
+  - `LICENSE-APACHE`
+  - `LICENSE-MIT`
 
 ### linux-raw-sys 0.12.1
 

--- a/completions/bash/agent-hook
+++ b/completions/bash/agent-hook
@@ -43,6 +43,9 @@ _agent__hook() {
             agent__hook,workspace-lease)
                 cmd="agent__hook__workspace__lease"
                 ;;
+            agent__hook,workspace-recovery)
+                cmd="agent__hook__workspace__recovery"
+                ;;
             agent__hook__finish__line,admit)
                 cmd="agent__hook__finish__line__admit"
                 ;;
@@ -100,6 +103,12 @@ _agent__hook() {
             agent__hook__workspace__lease,renew)
                 cmd="agent__hook__workspace__lease__renew"
                 ;;
+            agent__hook__workspace__recovery,inspect)
+                cmd="agent__hook__workspace__recovery__inspect"
+                ;;
+            agent__hook__workspace__recovery,verify-handoff)
+                cmd="agent__hook__workspace__recovery__verify__handoff"
+                ;;
             *)
                 ;;
         esac
@@ -107,7 +116,7 @@ _agent__hook() {
 
     case "${cmd}" in
         agent__hook)
-            opts="-h -V --config --policy --state-dir --help --version dispatch validate inventory doctor setup recovery finish-line workspace-lease completion"
+            opts="-h -V --config --policy --state-dir --help --version dispatch validate inventory doctor setup recovery finish-line workspace-lease workspace-recovery completion"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -1786,6 +1795,167 @@ _agent__hook() {
             return 0
             ;;
         agent__hook__workspace__lease__renew)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__recovery)
+            opts="-h --config --policy --state-dir --help inspect verify-handoff"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__recovery__inspect)
+            opts="-h --format --config --policy --state-dir --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --config)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --policy)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
+                --state-dir)
+                    COMPREPLY=()
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o plusdirs
+                    fi
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        agent__hook__workspace__recovery__verify__handoff)
             opts="-h --format --config --policy --state-dir --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/completions/zsh/_agent-hook
+++ b/completions/zsh/_agent-hook
@@ -392,6 +392,49 @@ json\:"Single-record JSON envelope (snake_case)"))' \
     ;;
 esac
 ;;
+(workspace-recovery)
+_arguments "${_arguments_options[@]}" : \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help]' \
+'--help[Print help]' \
+":: :_agent-hook__subcmd__workspace-recovery_commands" \
+"*::: :->workspace-recovery" \
+&& ret=0
+
+    case $state in
+    (workspace-recovery)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:agent-hook-workspace-recovery-command-$line[1]:"
+        case $line[1] in
+            (inspect)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+(verify-handoff)
+_arguments "${_arguments_options[@]}" : \
+'--format=[Automation-safe output format. Workspace lease defaults to strict JSON]:FORMAT:((text\:"Human-readable text output"
+json\:"Single-record JSON envelope (snake_case)"))' \
+'--config=[Override the strict user config path]:PATH:_files' \
+'--policy=[Override the selected versioned policy bundle path]:PATH:_files' \
+'--state-dir=[Override the private state root]:PATH:_files -/' \
+'-h[Print help (see more with '\''--help'\'')]' \
+'--help[Print help (see more with '\''--help'\'')]' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+;;
 (completion)
 _arguments "${_arguments_options[@]}" : \
 '--config=[Override the strict user config path]:PATH:_files' \
@@ -418,6 +461,7 @@ _agent-hook_commands() {
 'recovery:Create, authorize, inspect, consume, or revoke governed recovery' \
 'finish-line:Persist edit generations, execute declared validations, and enforce the DSH stop boundary' \
 'workspace-lease:Bind canonical workspaces and operate durable cross-process mutation leases' \
+'workspace-recovery:Inspect a denied dirty checkout and verify a clean managed-worktree handoff' \
 'completion:Print a shell completion script' \
     )
     _describe -t commands 'agent-hook commands' commands "$@"
@@ -583,6 +627,24 @@ _agent-hook__subcmd__workspace-lease__subcmd__release_commands() {
 _agent-hook__subcmd__workspace-lease__subcmd__renew_commands() {
     local commands; commands=()
     _describe -t commands 'agent-hook workspace-lease renew commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-recovery_commands] )) ||
+_agent-hook__subcmd__workspace-recovery_commands() {
+    local commands; commands=(
+'inspect:Project bounded dirty paths and linked worktrees without repository commands' \
+'verify-handoff:Verify one different clean managed worktree for an operator handoff' \
+    )
+    _describe -t commands 'agent-hook workspace-recovery commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-recovery__subcmd__inspect_commands] )) ||
+_agent-hook__subcmd__workspace-recovery__subcmd__inspect_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-recovery inspect commands' commands "$@"
+}
+(( $+functions[_agent-hook__subcmd__workspace-recovery__subcmd__verify-handoff_commands] )) ||
+_agent-hook__subcmd__workspace-recovery__subcmd__verify-handoff_commands() {
+    local commands; commands=()
+    _describe -t commands 'agent-hook workspace-recovery verify-handoff commands' commands "$@"
 }
 
 if [ "$funcstack[1]" = "_agent-hook" ]; then

--- a/crates/agent-hook/Cargo.toml
+++ b/crates/agent-hook/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 clap_complete = { workspace = true }
+git2 = { workspace = true }
 jiff = { workspace = true }
 libc = { workspace = true }
 nils-agent-docs = { version = "1.27.16", path = "../agent-docs" }

--- a/crates/agent-hook/README.md
+++ b/crates/agent-hook/README.md
@@ -58,6 +58,8 @@ printf '%s' "$WORKSPACE_BEGIN_JSON" | agent-hook workspace-lease begin
 printf '%s' "$WORKSPACE_COMPLETE_JSON" | agent-hook workspace-lease complete
 printf '%s' "$WORKSPACE_RENEW_JSON" | agent-hook workspace-lease renew
 printf '%s' "$WORKSPACE_RELEASE_JSON" | agent-hook workspace-lease release
+printf '%s' "$WORKSPACE_RECOVERY_JSON" | agent-hook workspace-recovery inspect
+printf '%s' "$WORKSPACE_HANDOFF_JSON" | agent-hook workspace-recovery verify-handoff
 agent-hook completion zsh
 ```
 
@@ -153,6 +155,24 @@ Private state lives below
 `${XDG_STATE_HOME:-$HOME/.local/state}/agent-hook/workspace-leases/` (or the
 global `--state-dir` override) behind owner-only directories, bounded files,
 and per-workspace cross-process locks.
+
+The separate `workspace-recovery` service is a read-only escape hatch for a
+fresh DSH session whose initial workspace bind was denied as dirty. `inspect`
+accepts only an absolute checkout path and projects its canonical branch/head,
+bounded dirty path names, and bounded linked-worktree facts. `verify-handoff`
+additionally accepts one exact absolute candidate path and succeeds only when
+it is a different clean, non-bare, non-detached, non-prunable worktree below
+the managed `git-cli worktree` root. Both operations use a fresh in-process
+libgit2 repository context with no registered repository command filters and
+disable index refreshes. Dirty submodules remain dirty through an explicit,
+bounded recursive `SubmoduleIgnore::None` walk without launching a child Git
+process. Result data is capped at 192 KiB and carries typed omitted counts when
+dirty/worktree arrays are shortened for the 256 KiB DSH transport. The
+operations do not launch Git,
+execute repository filters, create lease state, return file contents, or
+create, clean, stash, commit, switch, adopt, or transfer a worktree. A fresh
+session at a verified handoff path must still pass the normal lease bind.
+Recoverable exit `69` failures include typed bounded recovery details.
 
 The separate `finish-line` service exposes nine public operations: `open`,
 `begin`, `run`, `register`, `admit`, `observe`, `verdict`, `stop`, and

--- a/crates/agent-hook/docs/reports/agent-hook-completion-migration-contract.md
+++ b/crates/agent-hook/docs/reports/agent-hook-completion-migration-contract.md
@@ -7,7 +7,7 @@
 - Contract owner: Codex
 - Target PR: pending
 - Status: implemented
-- Last updated: 2026-08-25
+- Last updated: 2026-08-27
 - Enforcement: `completion_mode=clap-first`;
   `completion_mode_toggles=forbidden`;
   `alternate_completion_dispatch=forbidden`;
@@ -26,6 +26,7 @@
 | `recovery authorize` | challenge/output paths and reviewed digest |
 | `recovery consume` | capability path and exact binding values |
 | `recovery status`, `recovery revoke` | public capability selector and output enum |
+| `workspace-recovery inspect`, `verify-handoff` | JSON-default output enum; strict request data is supplied on stdin |
 | `finish-line open`, `begin`, `run`, `register`, `admit`, `observe`, `verdict`, `stop`, `status` | JSON-default output enum; request data is strict service JSON on stdin; `run` describes foreground probe/supervision; the acceptance commands describe immutable registration, pre-body admission, authenticated terminal observation, and detached verdicts; internal `quiesce` and `release` lifecycle RPCs are excluded |
 | `completion` | `bash` and `zsh` shell enum |
 

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -29,6 +29,8 @@ The CLI resolves only absolute XDG roots and rejects relative roots.
 | provider payload | standard input | 1 MiB |
 | workspace-lease request | standard input | 256 KiB, strict duplicate-free JSON |
 | workspace-lease state | state-owned per-worktree JSON | 512 KiB, `0600`, keyed private identity |
+| workspace-recovery request | standard input | 64 KiB, strict duplicate-free JSON |
+| workspace-recovery result | standard output | 192 KiB result data, 512 inspected worktrees, 2,048 inspected dirty paths, 16 KiB per path; arrays carry omitted counts when projected |
 | trace | state-owned JSONL | 256 entries, 256 KiB, redacted metadata only |
 | rule inventory | one policy bundle | 512 rules, unique IDs |
 | reason metadata | one aggregate decision | 64 reasons, 256 bytes per code/message |
@@ -106,6 +108,11 @@ above.
   native WorkspaceLease provider requests. Matching results use
   `agent-hook.workspace-lease.<command>-result.v1` inside the normal
   `cli.agent-hook.workspace-lease-<command>.v1` service envelope.
+- `agent-hook.workspace-recovery.inspect.v1` and
+  `agent-hook.workspace-recovery.verify-handoff.v1`: strict read-only dirty
+  checkout inspection and exact clean managed-worktree handoff verification.
+  Both return `agent-hook.workspace-recovery.result.v1` inside the matching
+  `cli.agent-hook.workspace-recovery-<command>.v1` service envelope.
 - `agent-hook.normalized-decision.v1`: aggregate action, ordered reason codes,
   optional bounded context or replacement, shadow observations, and config /
   policy digests.
@@ -365,6 +372,41 @@ canonical paths, Git directories, session/parent IDs, tool arguments, command
 output, or persisted digests. Canonical paths exist only in the private state
 needed to revalidate physical identity and run a trusted, hooks-disabled Git
 dirty-state probe.
+
+## Native DSH workspace recovery
+
+`agent-hook workspace-recovery inspect --format json` and
+`agent-hook workspace-recovery verify-handoff --format json` each read exactly
+one strict, duplicate-free JSON object from standard input. Requests are
+limited to 64 KiB and carry protocol version `1`, an absolute current checkout
+path, and, for handoff verification, one exact absolute candidate path.
+
+The result projects only canonical checkout/worktree paths, branch and object
+identity, bounded dirty path names with typed status states, managed/bare/
+detached/prunable flags, and an optional verified handoff. It never includes
+file contents, environment values, Git command output, lease authority, or
+provider payloads. Result data is capped at 192 KiB so the complete service
+envelope stays within the DSH client's 256 KiB transport cap. Oversized dirty
+and worktree arrays are deterministically shortened and report
+`dirty_entries_omitted` / `worktrees_omitted`; omission never changes the
+dirty decision.
+
+Inspection runs in-process through fresh libgit2 repository contexts. The
+process registers no repository-provided filters and does not launch Git or
+any repository command. Regular status excludes submodules from
+repository-controlled ignore semantics; every submodule layer is instead
+checked explicitly with `SubmoduleIgnore::None` through a bounded recursive
+walk. Repository cycles, excessive depth/count, ambiguous paths, and
+open/status failures fail closed. Index refresh is disabled and
+workspace-lease records are never written. Recoverable exit `69` failures
+carry typed `retryable`, `next_action`, and bounded `recovery` details.
+
+A handoff is eligible only when it is a different, clean, live, non-bare,
+non-detached, non-prunable worktree below the exact managed root convention
+owned by `git-cli worktree`. Verification does not create, clean, stash,
+commit, switch, adopt, or transfer the candidate. Its output is advisory to
+the host: a fresh DSH session at that exact path must independently acquire a
+normal workspace lease, so post-verification drift remains fail-closed.
 
 ## Native DSH finish line
 

--- a/crates/agent-hook/src/cli.rs
+++ b/crates/agent-hook/src/cli.rs
@@ -51,6 +51,8 @@ pub enum Command {
     FinishLine(FinishLineArgs),
     /// Bind canonical workspaces and operate durable cross-process mutation leases.
     WorkspaceLease(WorkspaceLeaseArgs),
+    /// Inspect a denied dirty checkout and verify a clean managed-worktree handoff.
+    WorkspaceRecovery(WorkspaceRecoveryArgs),
     /// Print a shell completion script.
     Completion(CompletionArgs),
 }
@@ -59,6 +61,20 @@ pub enum Command {
 pub struct WorkspaceLeaseArgs {
     #[command(subcommand)]
     pub command: WorkspaceLeaseCommand,
+}
+
+#[derive(Debug, Args)]
+pub struct WorkspaceRecoveryArgs {
+    #[command(subcommand)]
+    pub command: WorkspaceRecoveryCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum WorkspaceRecoveryCommand {
+    /// Project bounded dirty paths and linked worktrees without repository commands.
+    Inspect(WorkspaceLeaseFormatArgs),
+    /// Verify one different clean managed worktree for an operator handoff.
+    VerifyHandoff(WorkspaceLeaseFormatArgs),
 }
 
 #[derive(Debug, Subcommand)]

--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -3614,36 +3614,9 @@ fn current_branch(layout: &GitLayout) -> Option<String> {
 
 pub(crate) fn checkout_dirty(
     layout: &GitLayout,
-    run_child: &mut dyn FnMut(Command) -> Result<Output, HookError>,
+    _run_child: &mut dyn FnMut(Command) -> Result<Output, HookError>,
 ) -> Result<bool, HookError> {
-    let mut command = trusted_git_command()?;
-    command
-        .args([
-            "-c",
-            "core.fsmonitor=false",
-            "-c",
-            "core.hooksPath=/dev/null",
-            "-c",
-            "core.untrackedCache=false",
-            "-c",
-            "core.pager=cat",
-            "status",
-            "--porcelain=v1",
-            "-z",
-            "--untracked-files=normal",
-        ])
-        .current_dir(&layout.root)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
-    let output = run_child(command)?;
-    if !output.status.success() {
-        return Err(HookError::runtime(
-            "checkout-status-unavailable",
-            "checkout dirty-state inspection failed",
-        ));
-    }
-    Ok(!output.stdout.is_empty())
+    crate::git_inspection::checkout_dirty(layout)
 }
 
 fn trusted_git_command() -> Result<Command, HookError> {

--- a/crates/agent-hook/src/git_inspection.rs
+++ b/crates/agent-hook/src/git_inspection.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
 
-use git2::{Repository, Status, StatusOptions, SubmoduleIgnore, SubmoduleStatus};
+use git2::{Repository, Status, StatusOptions, Submodule};
 use serde::Serialize;
 use serde_json::json;
 
@@ -24,6 +24,13 @@ const MAX_DIRTY_ENTRIES: usize = 2_048;
 const MAX_PATH_BYTES: usize = 16 * 1024;
 const MAX_SUBMODULES: usize = 512;
 const MAX_SUBMODULE_DEPTH: usize = 16;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RepositoryIdentity {
+    workdir: PathBuf,
+    git_dir: PathBuf,
+    common_dir: PathBuf,
+}
 
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct DirtyEntry {
@@ -70,25 +77,13 @@ fn states(status: Status) -> Vec<&'static str> {
     result
 }
 
-fn submodule_states(status: SubmoduleStatus) -> Vec<&'static str> {
+fn submodule_index_states(submodule: &Submodule<'_>) -> Vec<&'static str> {
     let mut result = Vec::new();
-    for (dirty, name) in [
-        (status.is_index_added(), "index-new"),
-        (status.is_index_modified(), "index-modified"),
-        (status.is_index_deleted(), "index-deleted"),
-        (status.is_wd_added(), "worktree-new"),
-        (status.is_wd_deleted(), "worktree-deleted"),
-        (status.is_wd_modified(), "worktree-modified"),
-        (
-            status.contains(SubmoduleStatus::WD_INDEX_MODIFIED),
-            "worktree-modified",
-        ),
-        (status.is_wd_wd_modified(), "worktree-modified"),
-        (status.is_wd_untracked(), "worktree-modified"),
-    ] {
-        if dirty && !result.contains(&name) {
-            result.push(name);
-        }
+    match (submodule.head_id(), submodule.index_id()) {
+        (None, Some(_)) => result.push("index-new"),
+        (Some(_), None) => result.push("index-deleted"),
+        (Some(head), Some(index)) if head != index => result.push("index-modified"),
+        _ => {}
     }
     result
 }
@@ -149,6 +144,55 @@ fn submodule_prefix(prefix: &str, path: &Path) -> Result<String, HookError> {
     Ok(full)
 }
 
+fn repository_identity(repository: &Repository) -> Result<RepositoryIdentity, HookError> {
+    let workdir = repository
+        .workdir()
+        .and_then(|path| fs::canonicalize(path).ok())
+        .ok_or_else(unavailable)?;
+    let git_dir = fs::canonicalize(repository.path()).map_err(|_| unavailable())?;
+    let common_dir = fs::canonicalize(repository.commondir()).map_err(|_| unavailable())?;
+    Ok(RepositoryIdentity {
+        workdir,
+        git_dir,
+        common_dir,
+    })
+}
+
+fn canonical_descendant(root: &Path, relative: &Path) -> Result<PathBuf, HookError> {
+    submodule_prefix("", relative)?;
+    let root = fs::canonicalize(root).map_err(|_| unavailable())?;
+    let mut candidate = root.clone();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            return Err(unavailable());
+        };
+        candidate.push(component);
+        let metadata = fs::symlink_metadata(&candidate).map_err(|_| unavailable())?;
+        if metadata.file_type().is_symlink() {
+            return Err(unavailable());
+        }
+    }
+    let candidate = fs::canonicalize(candidate).map_err(|_| unavailable())?;
+    if !candidate.starts_with(&root) {
+        return Err(unavailable());
+    }
+    Ok(candidate)
+}
+
+fn directory_nonempty(path: &Path) -> Result<bool, HookError> {
+    let mut entries = fs::read_dir(path).map_err(|_| unavailable())?;
+    entries
+        .next()
+        .transpose()
+        .map_err(|_| unavailable())
+        .map(|entry| entry.is_some())
+}
+
+fn reopened_identity(workdir: &Path) -> Result<RepositoryIdentity, HookError> {
+    let repository = Repository::open(workdir).map_err(|_| unavailable())?;
+    repository_identity(&repository)
+}
+
 fn push_entry(
     result: &mut Vec<DirtyEntry>,
     states: Vec<&'static str>,
@@ -181,22 +225,32 @@ fn push_entry(
     Ok(())
 }
 
-fn collect_repository_status(
+struct InspectionState<'a, F, G> {
+    seen: HashSet<PathBuf>,
+    submodule_count: usize,
+    result: &'a mut Vec<DirtyEntry>,
+    before_submodule_status: &'a mut G,
+    before_revalidate: &'a mut F,
+}
+
+fn collect_repository_status<F, G>(
     repository: &Repository,
     prefix: &str,
     depth: usize,
-    seen: &mut HashSet<PathBuf>,
-    submodule_count: &mut usize,
-    result: &mut Vec<DirtyEntry>,
-) -> Result<(), HookError> {
+    state: &mut InspectionState<'_, F, G>,
+) -> Result<(), HookError>
+where
+    F: FnMut(&Path) -> Result<(), HookError>,
+    G: FnMut(&str) -> Result<(), HookError>,
+{
     if depth > MAX_SUBMODULE_DEPTH {
         return Err(HookError::data(
             "workspace-inspection-too-large",
             "workspace submodule depth exceeds the bounded inspection",
         ));
     }
-    let identity = fs::canonicalize(repository.path()).map_err(|_| unavailable())?;
-    if !seen.insert(identity) {
+    let identity = repository_identity(repository)?;
+    if !state.seen.insert(identity.git_dir.clone()) {
         return Err(unavailable());
     }
     let mut options = StatusOptions::new();
@@ -216,12 +270,12 @@ fn collect_repository_status(
     for entry in statuses.iter() {
         let status = states(entry.status());
         let (path, lossy) = projected_path(prefix, entry.path_bytes())?;
-        push_entry(result, status, path, lossy)?;
+        push_entry(state.result, status, path, lossy)?;
     }
     let submodules = repository.submodules().map_err(|_| unavailable())?;
     for submodule in submodules {
-        *submodule_count = submodule_count.saturating_add(1);
-        if *submodule_count > MAX_SUBMODULES {
+        state.submodule_count = state.submodule_count.saturating_add(1);
+        if state.submodule_count > MAX_SUBMODULES {
             return Err(HookError::data(
                 "workspace-inspection-too-large",
                 "workspace submodule count exceeds the bounded inspection",
@@ -229,39 +283,117 @@ fn collect_repository_status(
         }
         let name = submodule.name().map_err(|_| unavailable())?;
         let path = submodule_prefix(prefix, submodule.path())?;
-        let status = repository
-            .submodule_status(name, SubmoduleIgnore::None)
-            .map_err(|_| unavailable())?;
-        push_entry(result, submodule_states(status), path.clone(), false)?;
-        if status.is_in_wd() && !status.is_wd_uninitialized() {
-            let nested = submodule.open().map_err(|_| unavailable())?;
-            collect_repository_status(
-                &nested,
-                &path,
-                depth.saturating_add(1),
-                seen,
-                submodule_count,
-                result,
-            )?;
+        let unresolved_workdir = identity.workdir.join(submodule.path());
+        let expected_workdir = match fs::symlink_metadata(&unresolved_workdir) {
+            Ok(_) => Some(canonical_descendant(&identity.workdir, submodule.path())?),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(_) => return Err(unavailable()),
+        };
+        let validated_nested = if let Some(expected_workdir) = expected_workdir.as_ref() {
+            let git_marker = expected_workdir.join(".git");
+            match fs::symlink_metadata(&git_marker) {
+                Ok(metadata) => {
+                    if metadata.file_type().is_symlink() {
+                        return Err(unavailable());
+                    }
+                    let expected_git_dir =
+                        canonical_descendant(&identity.git_dir, &Path::new("modules").join(name))?;
+                    let nested = submodule.open().map_err(|_| unavailable())?;
+                    let nested_identity = repository_identity(&nested)?;
+                    if nested_identity.workdir != *expected_workdir
+                        || nested_identity.git_dir != expected_git_dir
+                    {
+                        return Err(unavailable());
+                    }
+                    Some((nested, nested_identity))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(_) => return Err(unavailable()),
+            }
+        } else {
+            None
+        };
+        (state.before_submodule_status)(name)?;
+        push_entry(
+            state.result,
+            submodule_index_states(&submodule),
+            path.clone(),
+            false,
+        )?;
+        if let Some((nested, nested_identity)) = validated_nested {
+            let expected_workdir = expected_workdir.as_ref().ok_or_else(unavailable)?;
+            let nested_head = nested
+                .head()
+                .ok()
+                .and_then(|head| head.target())
+                .ok_or_else(unavailable)?;
+            match submodule.index_id() {
+                Some(index) if index != nested_head => {
+                    push_entry(state.result, vec!["worktree-modified"], path.clone(), false)?
+                }
+                None => push_entry(state.result, vec!["worktree-new"], path.clone(), false)?,
+                _ => {}
+            }
+            let entries_before = state.result.len();
+            collect_repository_status(&nested, &path, depth.saturating_add(1), state)?;
+            if state.result.len() > entries_before {
+                push_entry(state.result, vec!["worktree-modified"], path.clone(), false)?;
+            }
+            (state.before_revalidate)(expected_workdir)?;
+            if reopened_identity(expected_workdir)? != nested_identity {
+                return Err(unavailable());
+            }
+        } else {
+            match (expected_workdir.as_ref(), submodule.index_id()) {
+                (None, Some(_)) => {
+                    push_entry(state.result, vec!["worktree-deleted"], path.clone(), false)?
+                }
+                (Some(workdir), index) if directory_nonempty(workdir)? => push_entry(
+                    state.result,
+                    vec![if index.is_some() {
+                        "worktree-modified"
+                    } else {
+                        "worktree-new"
+                    }],
+                    path.clone(),
+                    false,
+                )?,
+                _ => {}
+            }
         }
+    }
+    (state.before_revalidate)(&identity.workdir)?;
+    if reopened_identity(&identity.workdir)? != identity {
+        return Err(unavailable());
     }
     Ok(())
 }
 
-pub(crate) fn dirty_entries(layout: &GitLayout) -> Result<Vec<DirtyEntry>, HookError> {
+fn dirty_entries_with_observers<F, G>(
+    layout: &GitLayout,
+    before_submodule_status: &mut G,
+    before_revalidate: &mut F,
+) -> Result<Vec<DirtyEntry>, HookError>
+where
+    F: FnMut(&Path) -> Result<(), HookError>,
+    G: FnMut(&str) -> Result<(), HookError>,
+{
     let repository = Repository::open(&layout.root).map_err(|_| unavailable())?;
     let mut result = Vec::new();
-    let mut submodule_count = 0;
-    collect_repository_status(
-        &repository,
-        "",
-        0,
-        &mut HashSet::new(),
-        &mut submodule_count,
-        &mut result,
-    )?;
+    let mut state = InspectionState {
+        seen: HashSet::new(),
+        submodule_count: 0,
+        result: &mut result,
+        before_submodule_status,
+        before_revalidate,
+    };
+    collect_repository_status(&repository, "", 0, &mut state)?;
     result.sort_by(|left, right| left.path.cmp(&right.path));
     Ok(result)
+}
+
+pub(crate) fn dirty_entries(layout: &GitLayout) -> Result<Vec<DirtyEntry>, HookError> {
+    dirty_entries_with_observers(layout, &mut |_| Ok(()), &mut |_| Ok(()))
 }
 
 pub(crate) fn checkout_dirty(layout: &GitLayout) -> Result<bool, HookError> {
@@ -270,7 +402,54 @@ pub(crate) fn checkout_dirty(layout: &GitLayout) -> Result<bool, HookError> {
 
 #[cfg(test)]
 mod tests {
-    use super::projected_path;
+    use std::cell::Cell;
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    use git2::{IndexAddOption, Repository, Signature};
+    use tempfile::TempDir;
+
+    use super::{dirty_entries_with_observers, projected_path};
+    use crate::dsh_policy::git_layout;
+
+    fn committed_repository(path: &Path) {
+        fs::create_dir_all(path).expect("repository directory");
+        let repository = Repository::init(path).expect("repository init");
+        fs::write(path.join("tracked.txt"), "base\n").expect("tracked file");
+        let mut index = repository.index().expect("index");
+        index
+            .add_all(["tracked.txt"], IndexAddOption::DEFAULT, None)
+            .expect("index add");
+        index.write().expect("index write");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repository.find_tree(tree_id).expect("tree");
+        let signature =
+            Signature::now("Workspace Test", "workspace@example.com").expect("signature");
+        repository
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "test: initial",
+                &tree,
+                &[],
+            )
+            .expect("initial commit");
+    }
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn path_projection_marks_invalid_utf8_without_a_filesystem_fixture() {
@@ -286,5 +465,211 @@ mod tests {
 
         assert_eq!(path, "nested/notes.txt");
         assert!(!lossy);
+    }
+
+    #[test]
+    fn current_checkout_identity_change_between_scan_and_revalidation_fails_closed() {
+        let temp = TempDir::new().expect("temporary directory");
+        let current = temp.path().join("current");
+        let foreign = temp.path().join("foreign");
+        committed_repository(&current);
+        committed_repository(&foreign);
+        fs::write(
+            foreign.join("foreign-secret.txt"),
+            "must not be projected\n",
+        )
+        .expect("foreign dirty file");
+        let layout = git_layout(&current).expect("current layout");
+        let canonical_current = fs::canonicalize(&current).expect("canonical current");
+        let mut switched = false;
+
+        let result = dirty_entries_with_observers(&layout, &mut |_| Ok(()), &mut |workdir| {
+            if workdir == canonical_current && !switched {
+                fs::rename(current.join(".git"), current.join(".git-before-switch"))
+                    .expect("preserve original git directory");
+                fs::write(
+                    current.join(".git"),
+                    format!("gitdir: {}\n", foreign.join(".git").display()),
+                )
+                .expect("redirect current checkout");
+                switched = true;
+            }
+            Ok(())
+        });
+
+        assert!(switched, "phase-controlled identity switch was not reached");
+        let error = result.expect_err("identity change must fail closed");
+        assert_eq!(error.code, "workspace-inspection-unavailable");
+        assert!(!error.message.contains("foreign-secret"));
+    }
+
+    #[test]
+    fn redirected_submodule_identity_is_rejected_before_status_traversal() {
+        let temp = TempDir::new().expect("temporary directory");
+        let current = temp.path().join("current");
+        let source = temp.path().join("source");
+        let foreign = temp.path().join("foreign");
+        committed_repository(&current);
+        committed_repository(&source);
+        committed_repository(&foreign);
+        fs::write(foreign.join("tracked.txt"), "foreign head\n").expect("foreign tracked change");
+        git(&foreign, &["add", "tracked.txt"]);
+        git(
+            &foreign,
+            &[
+                "-c",
+                "user.email=workspace@example.com",
+                "-c",
+                "user.name=Workspace Test",
+                "commit",
+                "--quiet",
+                "-m",
+                "test: foreign head",
+            ],
+        );
+        git(
+            &current,
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                "--quiet",
+                source.to_str().expect("source UTF-8"),
+                "module",
+            ],
+        );
+        git(
+            &current,
+            &[
+                "-c",
+                "user.email=workspace@example.com",
+                "-c",
+                "user.name=Workspace Test",
+                "commit",
+                "--quiet",
+                "-am",
+                "test: add submodule",
+            ],
+        );
+        fs::write(
+            current.join("module/.git"),
+            format!("gitdir: {}\n", foreign.join(".git").display()),
+        )
+        .expect("redirect submodule gitfile");
+        let layout = git_layout(&current).expect("current layout");
+        let mut status_attempted = false;
+
+        let result = dirty_entries_with_observers(
+            &layout,
+            &mut |_| {
+                status_attempted = true;
+                Ok(())
+            },
+            &mut |_| Ok(()),
+        );
+
+        let error = result.expect_err("redirected submodule must fail closed");
+        assert_eq!(error.code, "workspace-inspection-unavailable");
+        assert!(
+            !status_attempted,
+            "redirected submodule reached status traversal before identity rejection"
+        );
+    }
+
+    #[test]
+    fn submodule_status_cannot_traverse_a_temporary_foreign_gitdir() {
+        let temp = TempDir::new().expect("temporary directory");
+        let current = temp.path().join("current");
+        let source = temp.path().join("source");
+        let foreign = temp.path().join("foreign");
+        committed_repository(&current);
+        committed_repository(&source);
+        committed_repository(&foreign);
+        fs::write(foreign.join("tracked.txt"), "foreign head\n").expect("foreign tracked change");
+        git(&foreign, &["add", "tracked.txt"]);
+        git(
+            &foreign,
+            &[
+                "-c",
+                "user.email=workspace@example.com",
+                "-c",
+                "user.name=Workspace Test",
+                "commit",
+                "--quiet",
+                "-m",
+                "test: foreign head",
+            ],
+        );
+        git(
+            &current,
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                "--quiet",
+                source.to_str().expect("source UTF-8"),
+                "module",
+            ],
+        );
+        git(
+            &current,
+            &[
+                "-c",
+                "user.email=workspace@example.com",
+                "-c",
+                "user.name=Workspace Test",
+                "commit",
+                "--quiet",
+                "-am",
+                "test: add submodule",
+            ],
+        );
+        fs::write(
+            foreign.join("foreign-secret.txt"),
+            "must not affect trusted status\n",
+        )
+        .expect("foreign dirty file");
+        let layout = git_layout(&current).expect("current layout");
+        let gitfile = current.join("module/.git");
+        let trusted_gitfile = temp.path().join("trusted-submodule-gitfile");
+        let canonical_submodule =
+            fs::canonicalize(current.join("module")).expect("canonical trusted submodule");
+        let switched = Cell::new(false);
+        let restored = Cell::new(false);
+
+        let result = dirty_entries_with_observers(
+            &layout,
+            &mut |_| {
+                fs::rename(&gitfile, &trusted_gitfile).expect("preserve trusted gitfile");
+                fs::write(
+                    &gitfile,
+                    format!("gitdir: {}\n", foreign.join(".git").display()),
+                )
+                .expect("temporary foreign gitfile");
+                switched.set(true);
+                Ok(())
+            },
+            &mut |workdir| {
+                if workdir == canonical_submodule && switched.get() && !restored.get() {
+                    fs::remove_file(&gitfile).expect("remove temporary foreign gitfile");
+                    fs::rename(&trusted_gitfile, &gitfile).expect("restore trusted gitfile");
+                    restored.set(true);
+                }
+                Ok(())
+            },
+        );
+
+        assert!(switched.get(), "status phase did not switch the gitfile");
+        assert!(
+            restored.get(),
+            "revalidation phase did not restore the gitfile"
+        );
+        let entries = result.expect("trusted repository remains inspectable");
+        assert!(
+            entries.is_empty(),
+            "foreign status affected result: {entries:?}"
+        );
     }
 }

--- a/crates/agent-hook/src/git_inspection.rs
+++ b/crates/agent-hook/src/git_inspection.rs
@@ -267,3 +267,24 @@ pub(crate) fn dirty_entries(layout: &GitLayout) -> Result<Vec<DirtyEntry>, HookE
 pub(crate) fn checkout_dirty(layout: &GitLayout) -> Result<bool, HookError> {
     Ok(!dirty_entries(layout)?.is_empty())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::projected_path;
+
+    #[test]
+    fn path_projection_marks_invalid_utf8_without_a_filesystem_fixture() {
+        let (path, lossy) = projected_path("nested", b"opaque-\xff.txt").expect("projection");
+
+        assert_eq!(path, "nested/opaque-\u{fffd}.txt");
+        assert!(lossy);
+    }
+
+    #[test]
+    fn path_projection_preserves_valid_utf8() {
+        let (path, lossy) = projected_path("nested", b"notes.txt").expect("projection");
+
+        assert_eq!(path, "nested/notes.txt");
+        assert!(!lossy);
+    }
+}

--- a/crates/agent-hook/src/git_inspection.rs
+++ b/crates/agent-hook/src/git_inspection.rs
@@ -1,0 +1,269 @@
+//! In-process, fail-closed Git inspection for pre-lease decisions.
+//!
+//! Core Git's worktree comparison may execute repository-configured clean or
+//! process filters.  This module deliberately uses a fresh libgit2 process
+//! context instead: libgit2 registers only its built-in CRLF and ident filters
+//! unless the embedding application explicitly registers another filter.  The
+//! agent-hook process never registers repository command filters and disables
+//! index refreshes, so inspection cannot cross the
+//! no-lease boundary by spawning repository-controlled programs or writing the
+//! index.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use git2::{Repository, Status, StatusOptions, SubmoduleIgnore, SubmoduleStatus};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::dsh_policy::GitLayout;
+use crate::error::HookError;
+
+const MAX_DIRTY_ENTRIES: usize = 2_048;
+const MAX_PATH_BYTES: usize = 16 * 1024;
+const MAX_SUBMODULES: usize = 512;
+const MAX_SUBMODULE_DEPTH: usize = 16;
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DirtyEntry {
+    pub(crate) states: Vec<&'static str>,
+    pub(crate) path: String,
+    pub(crate) lossy: bool,
+}
+
+fn unavailable() -> HookError {
+    HookError::unavailable_with(
+        "workspace-inspection-unavailable",
+        "workspace status could not be inspected safely",
+        json!({
+            "retryable": true,
+            "next_action": "verify-checkout-and-retry",
+            "recovery": {
+                "kind": "bounded-retry",
+                "max_attempts": 1,
+            },
+        }),
+    )
+}
+
+fn states(status: Status) -> Vec<&'static str> {
+    let mut result = Vec::new();
+    for (flag, name) in [
+        (Status::INDEX_NEW, "index-new"),
+        (Status::INDEX_MODIFIED, "index-modified"),
+        (Status::INDEX_DELETED, "index-deleted"),
+        (Status::INDEX_RENAMED, "index-renamed"),
+        (Status::INDEX_TYPECHANGE, "index-typechange"),
+        (Status::WT_NEW, "worktree-new"),
+        (Status::WT_MODIFIED, "worktree-modified"),
+        (Status::WT_DELETED, "worktree-deleted"),
+        (Status::WT_RENAMED, "worktree-renamed"),
+        (Status::WT_TYPECHANGE, "worktree-typechange"),
+        (Status::WT_UNREADABLE, "worktree-unreadable"),
+        (Status::CONFLICTED, "conflicted"),
+    ] {
+        if status.contains(flag) {
+            result.push(name);
+        }
+    }
+    result
+}
+
+fn submodule_states(status: SubmoduleStatus) -> Vec<&'static str> {
+    let mut result = Vec::new();
+    for (dirty, name) in [
+        (status.is_index_added(), "index-new"),
+        (status.is_index_modified(), "index-modified"),
+        (status.is_index_deleted(), "index-deleted"),
+        (status.is_wd_added(), "worktree-new"),
+        (status.is_wd_deleted(), "worktree-deleted"),
+        (status.is_wd_modified(), "worktree-modified"),
+        (
+            status.contains(SubmoduleStatus::WD_INDEX_MODIFIED),
+            "worktree-modified",
+        ),
+        (status.is_wd_wd_modified(), "worktree-modified"),
+        (status.is_wd_untracked(), "worktree-modified"),
+    ] {
+        if dirty && !result.contains(&name) {
+            result.push(name);
+        }
+    }
+    result
+}
+
+fn projected_path(prefix: &str, path: &[u8]) -> Result<(String, bool), HookError> {
+    let full_len = prefix
+        .len()
+        .saturating_add(usize::from(!prefix.is_empty()))
+        .saturating_add(path.len());
+    if path.is_empty() || full_len > MAX_PATH_BYTES || path.contains(&0) {
+        return Err(HookError::data(
+            "workspace-inspection-path-invalid",
+            "workspace status contains an invalid path",
+        ));
+    }
+    let projected = String::from_utf8_lossy(path);
+    let lossy = matches!(projected, std::borrow::Cow::Owned(_));
+    let path = if prefix.is_empty() {
+        projected.into_owned()
+    } else {
+        format!("{prefix}/{projected}")
+    };
+    Ok((path, lossy))
+}
+
+fn submodule_prefix(prefix: &str, path: &Path) -> Result<String, HookError> {
+    if path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::Prefix(_)
+                    | Component::RootDir
+                    | Component::ParentDir
+                    | Component::CurDir
+            )
+        })
+    {
+        return Err(unavailable());
+    }
+    let relative = path.to_str().ok_or_else(unavailable)?;
+    if relative.is_empty()
+        || relative.as_bytes().contains(&0)
+        || relative.chars().any(char::is_control)
+    {
+        return Err(unavailable());
+    }
+    let full = if prefix.is_empty() {
+        relative.to_string()
+    } else {
+        format!("{prefix}/{relative}")
+    };
+    if full.len() > MAX_PATH_BYTES {
+        return Err(HookError::data(
+            "workspace-inspection-path-invalid",
+            "workspace status contains an invalid path",
+        ));
+    }
+    Ok(full)
+}
+
+fn push_entry(
+    result: &mut Vec<DirtyEntry>,
+    states: Vec<&'static str>,
+    path: String,
+    lossy: bool,
+) -> Result<(), HookError> {
+    if states.is_empty() {
+        return Ok(());
+    }
+    if let Some(existing) = result.iter_mut().find(|entry| entry.path == path) {
+        for state in states {
+            if !existing.states.contains(&state) {
+                existing.states.push(state);
+            }
+        }
+        existing.lossy |= lossy;
+        return Ok(());
+    }
+    if result.len() >= MAX_DIRTY_ENTRIES {
+        return Err(HookError::data(
+            "workspace-inspection-too-large",
+            "workspace status exceeds the bounded recovery projection",
+        ));
+    }
+    result.push(DirtyEntry {
+        states,
+        path,
+        lossy,
+    });
+    Ok(())
+}
+
+fn collect_repository_status(
+    repository: &Repository,
+    prefix: &str,
+    depth: usize,
+    seen: &mut HashSet<PathBuf>,
+    submodule_count: &mut usize,
+    result: &mut Vec<DirtyEntry>,
+) -> Result<(), HookError> {
+    if depth > MAX_SUBMODULE_DEPTH {
+        return Err(HookError::data(
+            "workspace-inspection-too-large",
+            "workspace submodule depth exceeds the bounded inspection",
+        ));
+    }
+    let identity = fs::canonicalize(repository.path()).map_err(|_| unavailable())?;
+    if !seen.insert(identity) {
+        return Err(unavailable());
+    }
+    let mut options = StatusOptions::new();
+    options
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .include_ignored(false)
+        .include_unmodified(false)
+        .exclude_submodules(true)
+        .renames_head_to_index(false)
+        .renames_index_to_workdir(false)
+        .no_refresh(true)
+        .update_index(false);
+    let statuses = repository
+        .statuses(Some(&mut options))
+        .map_err(|_| unavailable())?;
+    for entry in statuses.iter() {
+        let status = states(entry.status());
+        let (path, lossy) = projected_path(prefix, entry.path_bytes())?;
+        push_entry(result, status, path, lossy)?;
+    }
+    let submodules = repository.submodules().map_err(|_| unavailable())?;
+    for submodule in submodules {
+        *submodule_count = submodule_count.saturating_add(1);
+        if *submodule_count > MAX_SUBMODULES {
+            return Err(HookError::data(
+                "workspace-inspection-too-large",
+                "workspace submodule count exceeds the bounded inspection",
+            ));
+        }
+        let name = submodule.name().map_err(|_| unavailable())?;
+        let path = submodule_prefix(prefix, submodule.path())?;
+        let status = repository
+            .submodule_status(name, SubmoduleIgnore::None)
+            .map_err(|_| unavailable())?;
+        push_entry(result, submodule_states(status), path.clone(), false)?;
+        if status.is_in_wd() && !status.is_wd_uninitialized() {
+            let nested = submodule.open().map_err(|_| unavailable())?;
+            collect_repository_status(
+                &nested,
+                &path,
+                depth.saturating_add(1),
+                seen,
+                submodule_count,
+                result,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn dirty_entries(layout: &GitLayout) -> Result<Vec<DirtyEntry>, HookError> {
+    let repository = Repository::open(&layout.root).map_err(|_| unavailable())?;
+    let mut result = Vec::new();
+    let mut submodule_count = 0;
+    collect_repository_status(
+        &repository,
+        "",
+        0,
+        &mut HashSet::new(),
+        &mut submodule_count,
+        &mut result,
+    )?;
+    result.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(result)
+}
+
+pub(crate) fn checkout_dirty(layout: &GitLayout) -> Result<bool, HookError> {
+    Ok(!dirty_entries(layout)?.is_empty())
+}

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -18,6 +18,7 @@ mod finish_line;
 #[cfg(not(target_os = "linux"))]
 #[path = "finish_line_unsupported.rs"]
 mod finish_line;
+mod git_inspection;
 mod liveness;
 mod model;
 mod observe;
@@ -30,6 +31,7 @@ pub mod setup;
 mod strict_json;
 mod trace;
 mod workspace_lease;
+mod workspace_recovery;
 
 use std::collections::BTreeMap;
 use std::env;
@@ -46,6 +48,7 @@ use serde_json::json;
 
 use cli::{
     Cli, Command, DispatchFormat, FinishLineCommand, RecoveryCommand, WorkspaceLeaseCommand,
+    WorkspaceRecoveryCommand,
 };
 use error::HookError;
 use model::{
@@ -159,6 +162,7 @@ fn dispatch(layout: Layout, policy_override: Option<&std::path::Path>, command: 
         Command::Completion(args) => completion::run(args.shell),
         Command::FinishLine(args) => run_finish_line(&layout, args.command),
         Command::WorkspaceLease(args) => run_workspace_lease(&layout, args.command),
+        Command::WorkspaceRecovery(args) => run_workspace_recovery(args.command),
         Command::Dispatch(args) => run_dispatch(&layout, policy_override, args),
         Command::Validate(args) => {
             let loaded = match contract::load(&layout, policy_override) {
@@ -362,6 +366,26 @@ fn run_workspace_lease(layout: &Layout, command: WorkspaceLeaseCommand) -> i32 {
     };
     let format = OutputFormat::from(format);
     match workspace_lease::run(&layout.state_root, operation) {
+        Ok(outcome) => emit_success(name, format, &outcome.data, || outcome.text),
+        Err(error) => emit_error(name, &error, format == OutputFormat::Json),
+    }
+}
+
+fn run_workspace_recovery(command: WorkspaceRecoveryCommand) -> i32 {
+    let (name, format, operation) = match command {
+        WorkspaceRecoveryCommand::Inspect(args) => (
+            "agent-hook workspace-recovery inspect",
+            args.format,
+            workspace_recovery::Operation::Inspect,
+        ),
+        WorkspaceRecoveryCommand::VerifyHandoff(args) => (
+            "agent-hook workspace-recovery verify-handoff",
+            args.format,
+            workspace_recovery::Operation::VerifyHandoff,
+        ),
+    };
+    let format = OutputFormat::from(format);
+    match workspace_recovery::run(operation) {
         Ok(outcome) => emit_success(name, format, &outcome.data, || outcome.text),
         Err(error) => emit_error(name, &error, format == OutputFormat::Json),
     }

--- a/crates/agent-hook/src/workspace_recovery.rs
+++ b/crates/agent-hook/src/workspace_recovery.rs
@@ -1,0 +1,527 @@
+//! Strict, read-only workspace recovery facts for a denied DSH lease.
+
+use std::env;
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+
+use git2::Repository;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::{Value, json};
+
+use crate::dsh_policy::{GitLayout, git_layout};
+use crate::error::HookError;
+use crate::git_inspection::{DirtyEntry, dirty_entries};
+
+const PROTOCOL_VERSION: u64 = 1;
+const INSPECT_SCHEMA: &str = "agent-hook.workspace-recovery.inspect.v1";
+const VERIFY_SCHEMA: &str = "agent-hook.workspace-recovery.verify-handoff.v1";
+const RESULT_SCHEMA: &str = "agent-hook.workspace-recovery.result.v1";
+const REQUEST_MAX_BYTES: u64 = 64 * 1024;
+const RESULT_MAX_BYTES: usize = 192 * 1024;
+const MAX_WORKTREES: usize = 512;
+const MAX_PATH_BYTES: usize = 16 * 1024;
+const MAX_BRANCH_BYTES: usize = 512;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum Operation {
+    Inspect,
+    VerifyHandoff,
+}
+
+pub(crate) struct Outcome {
+    pub(crate) data: Value,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct InspectRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    cwd: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VerifyRequest {
+    #[serde(rename = "schema_version")]
+    _schema_version: String,
+    version: u64,
+    cwd: PathBuf,
+    handoff_path: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct Checkout {
+    path: String,
+    branch: Option<String>,
+    head: Option<String>,
+    managed: bool,
+    dirty_entries: Vec<DirtyEntry>,
+    dirty_entries_omitted: usize,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Worktree {
+    path: String,
+    branch: Option<String>,
+    head: Option<String>,
+    bare: bool,
+    detached: bool,
+    prunable: bool,
+    managed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Handoff {
+    status: &'static str,
+    path: String,
+    branch: String,
+    head: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ResultPayload {
+    schema_version: &'static str,
+    action: &'static str,
+    state: &'static str,
+    checkout: Checkout,
+    worktrees: Vec<Worktree>,
+    worktrees_omitted: usize,
+    handoff: Option<Handoff>,
+}
+
+fn wire_invalid() -> HookError {
+    HookError::data(
+        "workspace-recovery-wire-invalid",
+        "workspace recovery request does not match the strict protocol",
+    )
+}
+
+fn unavailable(code: &'static str, message: &'static str) -> HookError {
+    HookError::unavailable_with(
+        code,
+        message,
+        json!({
+            "retryable": true,
+            "next_action": "verify-checkout-and-retry",
+            "recovery": {
+                "kind": "bounded-retry",
+                "max_attempts": 1,
+            },
+        }),
+    )
+}
+
+fn read_request<T: DeserializeOwned>(expected_schema: &str) -> Result<T, HookError> {
+    let mut bytes = Vec::new();
+    io::stdin()
+        .take(REQUEST_MAX_BYTES.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(|_| wire_invalid())?;
+    if bytes.is_empty() || bytes.len() as u64 > REQUEST_MAX_BYTES {
+        return Err(wire_invalid());
+    }
+    let value = crate::strict_json::from_slice(&bytes).map_err(|_| wire_invalid())?;
+    if value.get("schema_version").and_then(Value::as_str) != Some(expected_schema) {
+        return Err(wire_invalid());
+    }
+    serde_json::from_value(value).map_err(|_| wire_invalid())
+}
+
+fn validate_request(version: u64, cwd: &Path) -> Result<GitLayout, HookError> {
+    if version != PROTOCOL_VERSION || !cwd.is_absolute() {
+        return Err(wire_invalid());
+    }
+    git_layout(cwd).ok_or_else(|| {
+        unavailable(
+            "workspace-recovery-checkout-unavailable",
+            "workspace recovery checkout is unavailable",
+        )
+    })
+}
+
+fn display_path(path: &Path) -> Result<String, HookError> {
+    let value = path.to_str().ok_or_else(|| {
+        HookError::data(
+            "workspace-recovery-path-invalid",
+            "workspace recovery path is not valid UTF-8",
+        )
+    })?;
+    if value.is_empty() || value.len() > MAX_PATH_BYTES || value.chars().any(char::is_control) {
+        return Err(HookError::data(
+            "workspace-recovery-path-invalid",
+            "workspace recovery path is invalid",
+        ));
+    }
+    Ok(value.to_string())
+}
+
+fn display_branch(value: Option<&str>) -> Result<Option<String>, HookError> {
+    value
+        .map(|value| {
+            if value.is_empty()
+                || value.len() > MAX_BRANCH_BYTES
+                || value.chars().any(char::is_control)
+            {
+                return Err(HookError::data(
+                    "workspace-recovery-branch-invalid",
+                    "workspace recovery branch is invalid",
+                ));
+            }
+            Ok(value.to_string())
+        })
+        .transpose()
+}
+
+fn canonical_or_raw(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn absolute_or_existing(path: PathBuf) -> Option<PathBuf> {
+    if path.exists() {
+        fs::canonicalize(path).ok()
+    } else if path.is_absolute() {
+        Some(path)
+    } else {
+        env::current_dir().ok().map(|cwd| cwd.join(path))
+    }
+}
+
+fn agent_home() -> Option<PathBuf> {
+    if let Some(value) = env::var_os("AGENT_HOME").filter(|value| !value.is_empty()) {
+        return absolute_or_existing(PathBuf::from(value));
+    }
+    if let Some(value) = env::var_os("XDG_STATE_HOME").filter(|value| !value.is_empty()) {
+        return absolute_or_existing(PathBuf::from(value).join("agent-runtime-kit"));
+    }
+    if let Some(value) = env::var_os("HOME").filter(|value| !value.is_empty()) {
+        return absolute_or_existing(PathBuf::from(value).join(".local/state/agent-runtime-kit"));
+    }
+    Some(env::temp_dir().join("agent-runtime-kit"))
+}
+
+fn repo_key(repo_root: &Path) -> String {
+    let basename = repo_root
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("repo");
+    let mut slug = String::new();
+    let mut last_dash = false;
+    for character in basename.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            last_dash = false;
+        } else if matches!(character, '-' | '_' | '.') {
+            slug.push(character);
+            last_dash = false;
+        } else if !last_dash {
+            slug.push('-');
+            last_dash = true;
+        }
+    }
+    let slug = slug.trim_matches(['-', '_', '.']);
+    let slug = slug.chars().take(80).collect::<String>();
+    let slug = slug.trim_matches(['-', '_', '.']);
+    let slug = if slug.is_empty() { "repo" } else { slug };
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in repo_root.to_string_lossy().as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{slug}-{:08x}", hash as u32)
+}
+
+fn primary_root(layout: &GitLayout) -> Result<PathBuf, HookError> {
+    let candidate = layout.common_dir.parent().filter(|_| {
+        layout
+            .common_dir
+            .file_name()
+            .is_some_and(|name| name == ".git")
+    });
+    candidate
+        .and_then(|path| fs::canonicalize(path).ok())
+        .ok_or_else(|| {
+            unavailable(
+                "workspace-recovery-repository-unavailable",
+                "workspace recovery repository root is unavailable",
+            )
+        })
+}
+
+fn repository_facts(path: &Path, managed_root: &Path) -> Result<Worktree, HookError> {
+    let canonical = fs::canonicalize(path).map_err(|_| {
+        unavailable(
+            "workspace-recovery-worktree-unavailable",
+            "workspace recovery worktree is unavailable",
+        )
+    })?;
+    let repository = Repository::open(&canonical).map_err(|_| {
+        unavailable(
+            "workspace-recovery-worktree-unavailable",
+            "workspace recovery worktree is unavailable",
+        )
+    })?;
+    let head = repository.head().ok();
+    let branch = head
+        .as_ref()
+        .filter(|value| value.is_branch())
+        .and_then(|value| value.shorthand().ok())
+        .map(str::to_string);
+    let head_id = head
+        .as_ref()
+        .and_then(|value| value.target())
+        .map(|id| id.to_string());
+    let detached = repository.head_detached().unwrap_or(true);
+    Ok(Worktree {
+        path: display_path(&canonical)?,
+        branch: display_branch(branch.as_deref())?,
+        head: head_id,
+        bare: repository.is_bare(),
+        detached,
+        prunable: false,
+        managed: canonical.starts_with(managed_root),
+    })
+}
+
+fn prunable_worktree(path: &Path, managed_root: &Path) -> Result<Worktree, HookError> {
+    let projected = canonical_or_raw(path);
+    if !projected.is_absolute() {
+        return Err(unavailable(
+            "workspace-recovery-worktree-unavailable",
+            "workspace recovery worktree is unavailable",
+        ));
+    }
+    Ok(Worktree {
+        path: display_path(&projected)?,
+        branch: None,
+        head: None,
+        bare: false,
+        detached: true,
+        prunable: true,
+        managed: projected.starts_with(managed_root),
+    })
+}
+
+fn inventory(layout: &GitLayout) -> Result<Vec<Worktree>, HookError> {
+    let primary = primary_root(layout)?;
+    let home = agent_home().ok_or_else(|| {
+        unavailable(
+            "workspace-recovery-agent-home-unavailable",
+            "workspace recovery managed-worktree root is unavailable",
+        )
+    })?;
+    let managed_root = canonical_or_raw(&home.join("worktrees").join(repo_key(&primary)));
+    let repository = Repository::open(&primary).map_err(|_| {
+        unavailable(
+            "workspace-recovery-repository-unavailable",
+            "workspace recovery repository is unavailable",
+        )
+    })?;
+    let mut entries = vec![repository_facts(&primary, &managed_root)?];
+    let names = repository.worktrees().map_err(|_| {
+        unavailable(
+            "workspace-recovery-worktrees-unavailable",
+            "workspace recovery worktree inventory is unavailable",
+        )
+    })?;
+    if names.len() > MAX_WORKTREES.saturating_sub(1) {
+        return Err(HookError::data(
+            "workspace-recovery-worktrees-too-large",
+            "workspace recovery worktree inventory exceeds its bound",
+        ));
+    }
+    for name in names.iter() {
+        let Ok(Some(name)) = name else {
+            return Err(unavailable(
+                "workspace-recovery-worktrees-unavailable",
+                "workspace recovery worktree inventory is unavailable",
+            ));
+        };
+        let worktree = repository.find_worktree(name).map_err(|_| {
+            unavailable(
+                "workspace-recovery-worktrees-unavailable",
+                "workspace recovery worktree inventory is unavailable",
+            )
+        })?;
+        let prunable = worktree.is_prunable(None).map_err(|_| {
+            unavailable(
+                "workspace-recovery-worktrees-unavailable",
+                "workspace recovery worktree inventory is unavailable",
+            )
+        })?;
+        entries.push(if prunable {
+            prunable_worktree(worktree.path(), &managed_root)?
+        } else {
+            repository_facts(worktree.path(), &managed_root)?
+        });
+    }
+    entries.sort_by(|left, right| left.path.cmp(&right.path));
+    entries.dedup_by(|left, right| left.path == right.path);
+    Ok(entries)
+}
+
+fn inspect(
+    layout: GitLayout,
+    action: &'static str,
+    handoff_path: Option<&Path>,
+) -> Result<ResultPayload, HookError> {
+    let entries = inventory(&layout)?;
+    let current_path = display_path(&layout.root)?;
+    let current = entries
+        .iter()
+        .find(|entry| entry.path == current_path)
+        .ok_or_else(|| {
+            unavailable(
+                "workspace-recovery-checkout-unavailable",
+                "workspace recovery checkout is unavailable",
+            )
+        })?;
+    let current_dirty = dirty_entries(&layout)?;
+    let checkout = Checkout {
+        path: current.path.clone(),
+        branch: current.branch.clone(),
+        head: current.head.clone(),
+        managed: current.managed,
+        dirty_entries: current_dirty,
+        dirty_entries_omitted: 0,
+    };
+    let handoff = if let Some(requested) = handoff_path {
+        if !requested.is_absolute() {
+            return Err(wire_invalid());
+        }
+        let canonical = fs::canonicalize(requested).map_err(|_| {
+            HookError::data(
+                "workspace-recovery-handoff-invalid",
+                "workspace recovery handoff path is invalid",
+            )
+        })?;
+        let projected = display_path(&canonical)?;
+        let candidate = entries
+            .iter()
+            .find(|entry| entry.path == projected)
+            .filter(|entry| {
+                entry.path != current.path
+                    && entry.managed
+                    && !entry.bare
+                    && !entry.detached
+                    && !entry.prunable
+                    && entry.branch.is_some()
+                    && entry.head.is_some()
+            })
+            .ok_or_else(|| {
+                HookError::data(
+                    "workspace-recovery-handoff-ineligible",
+                    "workspace recovery handoff is not an eligible managed worktree",
+                )
+            })?;
+        let candidate_layout = git_layout(&canonical).ok_or_else(|| {
+            unavailable(
+                "workspace-recovery-handoff-unavailable",
+                "workspace recovery handoff checkout is unavailable",
+            )
+        })?;
+        if !dirty_entries(&candidate_layout)?.is_empty() {
+            return Err(HookError::data(
+                "workspace-recovery-handoff-dirty",
+                "workspace recovery handoff checkout is dirty",
+            ));
+        }
+        Some(Handoff {
+            status: "verified",
+            path: candidate.path.clone(),
+            branch: candidate.branch.clone().expect("checked branch"),
+            head: candidate.head.clone().expect("checked head"),
+        })
+    } else {
+        None
+    };
+    Ok(ResultPayload {
+        schema_version: RESULT_SCHEMA,
+        action,
+        state: if checkout.dirty_entries.is_empty() {
+            "clean-now"
+        } else {
+            "dirty"
+        },
+        checkout,
+        worktrees: entries,
+        worktrees_omitted: 0,
+        handoff,
+    })
+}
+
+fn bounded_payload(mut payload: ResultPayload) -> Result<ResultPayload, HookError> {
+    loop {
+        let bytes = serde_json::to_vec(&payload).map_err(|_| {
+            unavailable(
+                "workspace-recovery-output-unavailable",
+                "workspace recovery output could not be rendered",
+            )
+        })?;
+        if bytes.len() <= RESULT_MAX_BYTES {
+            return Ok(payload);
+        }
+        if !payload.checkout.dirty_entries.is_empty() {
+            let retained = payload.checkout.dirty_entries.len() / 2;
+            let omitted = payload.checkout.dirty_entries.len() - retained;
+            payload.checkout.dirty_entries.truncate(retained);
+            payload.checkout.dirty_entries_omitted = payload
+                .checkout
+                .dirty_entries_omitted
+                .saturating_add(omitted);
+            continue;
+        }
+        if !payload.worktrees.is_empty() {
+            let retained = payload.worktrees.len() / 2;
+            let omitted = payload.worktrees.len() - retained;
+            payload.worktrees.truncate(retained);
+            payload.worktrees_omitted = payload.worktrees_omitted.saturating_add(omitted);
+            continue;
+        }
+        return Err(HookError::data(
+            "workspace-recovery-output-too-large",
+            "workspace recovery output exceeds its bounded contract",
+        ));
+    }
+}
+
+pub(crate) fn run(operation: Operation) -> Result<Outcome, HookError> {
+    let payload = bounded_payload(match operation {
+        Operation::Inspect => {
+            let request: InspectRequest = read_request(INSPECT_SCHEMA)?;
+            let layout = validate_request(request.version, &request.cwd)?;
+            inspect(layout, "inspect", None)?
+        }
+        Operation::VerifyHandoff => {
+            let request: VerifyRequest = read_request(VERIFY_SCHEMA)?;
+            let layout = validate_request(request.version, &request.cwd)?;
+            inspect(layout, "verify-handoff", Some(&request.handoff_path))?
+        }
+    })?;
+    let data = serde_json::to_value(&payload).map_err(|_| {
+        unavailable(
+            "workspace-recovery-output-unavailable",
+            "workspace recovery output could not be rendered",
+        )
+    })?;
+    let text = if let Some(handoff) = payload.handoff {
+        format!("verified clean managed worktree handoff: {}", handoff.path)
+    } else {
+        format!(
+            "workspace recovery inspection: {} dirty paths, {} worktrees",
+            payload
+                .checkout
+                .dirty_entries
+                .len()
+                .saturating_add(payload.checkout.dirty_entries_omitted),
+            payload
+                .worktrees
+                .len()
+                .saturating_add(payload.worktrees_omitted)
+        )
+    };
+    Ok(Outcome { data, text })
+}

--- a/crates/agent-hook/src/workspace_recovery.rs
+++ b/crates/agent-hook/src/workspace_recovery.rs
@@ -72,6 +72,15 @@ struct Worktree {
     detached: bool,
     prunable: bool,
     managed: bool,
+    #[serde(skip)]
+    identity: Option<RepositoryIdentity>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RepositoryIdentity {
+    workdir: PathBuf,
+    git_dir: PathBuf,
+    common_dir: PathBuf,
 }
 
 #[derive(Debug, Serialize)]
@@ -251,19 +260,79 @@ fn primary_root(layout: &GitLayout) -> Result<PathBuf, HookError> {
         })
 }
 
-fn repository_facts(path: &Path, managed_root: &Path) -> Result<Worktree, HookError> {
-    let canonical = fs::canonicalize(path).map_err(|_| {
-        unavailable(
-            "workspace-recovery-worktree-unavailable",
-            "workspace recovery worktree is unavailable",
-        )
-    })?;
-    let repository = Repository::open(&canonical).map_err(|_| {
-        unavailable(
-            "workspace-recovery-worktree-unavailable",
-            "workspace recovery worktree is unavailable",
-        )
-    })?;
+fn worktree_unavailable() -> HookError {
+    unavailable(
+        "workspace-recovery-worktree-unavailable",
+        "workspace recovery worktree is unavailable",
+    )
+}
+
+fn worktrees_unavailable() -> HookError {
+    unavailable(
+        "workspace-recovery-worktrees-unavailable",
+        "workspace recovery worktree inventory is unavailable",
+    )
+}
+
+fn repository_identity(repository: &Repository) -> Result<RepositoryIdentity, HookError> {
+    let workdir = repository
+        .workdir()
+        .and_then(|path| fs::canonicalize(path).ok())
+        .ok_or_else(worktree_unavailable)?;
+    let git_dir = fs::canonicalize(repository.path()).map_err(|_| worktree_unavailable())?;
+    let common_dir =
+        fs::canonicalize(repository.commondir()).map_err(|_| worktree_unavailable())?;
+    Ok(RepositoryIdentity {
+        workdir,
+        git_dir,
+        common_dir,
+    })
+}
+
+fn worktree_admin_git_dir(common_dir: &Path, name: &str) -> Result<PathBuf, HookError> {
+    if name.is_empty()
+        || name.len() > MAX_PATH_BYTES
+        || name.chars().any(char::is_control)
+        || Path::new(name).components().count() != 1
+    {
+        return Err(worktrees_unavailable());
+    }
+    let worktrees_path = common_dir.join("worktrees");
+    let metadata = fs::symlink_metadata(&worktrees_path).map_err(|_| worktrees_unavailable())?;
+    if metadata.file_type().is_symlink() {
+        return Err(worktrees_unavailable());
+    }
+    let worktrees = fs::canonicalize(&worktrees_path).map_err(|_| worktrees_unavailable())?;
+    if worktrees.parent() != Some(common_dir) {
+        return Err(worktrees_unavailable());
+    }
+    let candidate = worktrees.join(name);
+    let metadata = fs::symlink_metadata(&candidate).map_err(|_| worktrees_unavailable())?;
+    if metadata.file_type().is_symlink() {
+        return Err(worktrees_unavailable());
+    }
+    let candidate = fs::canonicalize(candidate).map_err(|_| worktrees_unavailable())?;
+    if candidate.parent() != Some(worktrees.as_path()) {
+        return Err(worktrees_unavailable());
+    }
+    Ok(candidate)
+}
+
+fn repository_facts(
+    path: &Path,
+    managed_root: &Path,
+    expected_common_dir: &Path,
+    expected_git_dir: &Path,
+) -> Result<Worktree, HookError> {
+    let canonical = fs::canonicalize(path).map_err(|_| worktree_unavailable())?;
+    let repository = Repository::open(&canonical).map_err(|_| worktree_unavailable())?;
+    let identity = repository_identity(&repository)?;
+    if identity.workdir != canonical
+        || identity.common_dir != expected_common_dir
+        || identity.git_dir != expected_git_dir
+    {
+        return Err(worktrees_unavailable());
+    }
     let head = repository.head().ok();
     let branch = head
         .as_ref()
@@ -275,6 +344,10 @@ fn repository_facts(path: &Path, managed_root: &Path) -> Result<Worktree, HookEr
         .and_then(|value| value.target())
         .map(|id| id.to_string());
     let detached = repository.head_detached().unwrap_or(true);
+    let reopened = Repository::open(&canonical).map_err(|_| worktree_unavailable())?;
+    if repository_identity(&reopened)? != identity {
+        return Err(worktrees_unavailable());
+    }
     Ok(Worktree {
         path: display_path(&canonical)?,
         branch: display_branch(branch.as_deref())?,
@@ -283,6 +356,7 @@ fn repository_facts(path: &Path, managed_root: &Path) -> Result<Worktree, HookEr
         detached,
         prunable: false,
         managed: canonical.starts_with(managed_root),
+        identity: Some(identity),
     })
 }
 
@@ -302,7 +376,47 @@ fn prunable_worktree(path: &Path, managed_root: &Path) -> Result<Worktree, HookE
         detached: true,
         prunable: true,
         managed: projected.starts_with(managed_root),
+        identity: None,
     })
+}
+
+fn revalidate_worktree(worktree: &Worktree) -> Result<(), HookError> {
+    let expected = worktree
+        .identity
+        .as_ref()
+        .ok_or_else(worktrees_unavailable)?;
+    let repository = Repository::open(&expected.workdir).map_err(|_| worktree_unavailable())?;
+    if repository_identity(&repository)? != *expected
+        || repository.is_bare() != worktree.bare
+        || repository.head_detached().unwrap_or(true) != worktree.detached
+    {
+        return Err(worktrees_unavailable());
+    }
+    let head = repository.head().ok();
+    let branch = head
+        .as_ref()
+        .filter(|value| value.is_branch())
+        .and_then(|value| value.shorthand().ok())
+        .map(str::to_string);
+    let head_id = head
+        .as_ref()
+        .and_then(|value| value.target())
+        .map(|id| id.to_string());
+    if branch != worktree.branch || head_id != worktree.head {
+        return Err(worktrees_unavailable());
+    }
+    Ok(())
+}
+
+fn revalidate_worktree_after_observer<F>(
+    worktree: &Worktree,
+    before_revalidate: F,
+) -> Result<(), HookError>
+where
+    F: FnOnce() -> Result<(), HookError>,
+{
+    before_revalidate()?;
+    revalidate_worktree(worktree)
 }
 
 fn inventory(layout: &GitLayout) -> Result<Vec<Worktree>, HookError> {
@@ -320,7 +434,16 @@ fn inventory(layout: &GitLayout) -> Result<Vec<Worktree>, HookError> {
             "workspace recovery repository is unavailable",
         )
     })?;
-    let mut entries = vec![repository_facts(&primary, &managed_root)?];
+    let source_identity = repository_identity(&repository)?;
+    if source_identity.workdir != primary {
+        return Err(worktrees_unavailable());
+    }
+    let mut entries = vec![repository_facts(
+        &primary,
+        &managed_root,
+        &source_identity.common_dir,
+        &source_identity.git_dir,
+    )?];
     let names = repository.worktrees().map_err(|_| {
         unavailable(
             "workspace-recovery-worktrees-unavailable",
@@ -355,7 +478,14 @@ fn inventory(layout: &GitLayout) -> Result<Vec<Worktree>, HookError> {
         entries.push(if prunable {
             prunable_worktree(worktree.path(), &managed_root)?
         } else {
-            repository_facts(worktree.path(), &managed_root)?
+            worktree.validate().map_err(|_| worktrees_unavailable())?;
+            let expected_git_dir = worktree_admin_git_dir(&source_identity.common_dir, name)?;
+            repository_facts(
+                worktree.path(),
+                &managed_root,
+                &source_identity.common_dir,
+                &expected_git_dir,
+            )?
         });
     }
     entries.sort_by(|left, right| left.path.cmp(&right.path));
@@ -380,6 +510,7 @@ fn inspect(
             )
         })?;
     let current_dirty = dirty_entries(&layout)?;
+    revalidate_worktree_after_observer(current, || Ok(()))?;
     let checkout = Checkout {
         path: current.path.clone(),
         branch: current.branch.clone(),
@@ -423,12 +554,14 @@ fn inspect(
                 "workspace recovery handoff checkout is unavailable",
             )
         })?;
-        if !dirty_entries(&candidate_layout)?.is_empty() {
+        let candidate_dirty = dirty_entries(&candidate_layout)?;
+        if !candidate_dirty.is_empty() {
             return Err(HookError::data(
                 "workspace-recovery-handoff-dirty",
                 "workspace recovery handoff checkout is dirty",
             ));
         }
+        revalidate_worktree_after_observer(candidate, || Ok(()))?;
         Some(Handoff {
             status: "verified",
             path: candidate.path.clone(),
@@ -524,4 +657,111 @@ pub(crate) fn run(operation: Operation) -> Result<Outcome, HookError> {
         )
     };
     Ok(Outcome { data, text })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    use super::{
+        repository_facts, repository_identity, revalidate_worktree_after_observer,
+        worktree_admin_git_dir,
+    };
+    use crate::dsh_policy::git_layout;
+
+    fn git(root: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("git command");
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn committed_repository(path: &Path) {
+        fs::create_dir_all(path).expect("repository directory");
+        git(path, &["init", "--quiet"]);
+        git(path, &["config", "user.email", "workspace@example.com"]);
+        git(path, &["config", "user.name", "Workspace Test"]);
+        fs::write(path.join("tracked.txt"), "base\n").expect("tracked file");
+        git(path, &["add", "--all"]);
+        git(path, &["commit", "--quiet", "-m", "test: initial"]);
+    }
+
+    #[test]
+    fn handoff_identity_change_between_scan_and_revalidation_fails_closed() {
+        let temp = TempDir::new().expect("temporary directory");
+        let primary = temp.path().join("primary");
+        let managed_root = temp.path().join("managed");
+        let handoff = managed_root.join("handoff");
+        let foreign = temp.path().join("foreign");
+        committed_repository(&primary);
+        fs::create_dir_all(&managed_root).expect("managed root");
+        git(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "--quiet",
+                "-b",
+                "fix/handoff",
+                handoff.to_str().expect("handoff UTF-8"),
+                "HEAD",
+            ],
+        );
+        committed_repository(&foreign);
+        fs::write(
+            foreign.join("foreign-secret.txt"),
+            "must not be projected\n",
+        )
+        .expect("foreign dirty file");
+
+        let primary_repository = git2::Repository::open(&primary).expect("primary repository");
+        let primary_identity = repository_identity(&primary_repository).expect("primary identity");
+        let names = primary_repository.worktrees().expect("worktree names");
+        let name = names
+            .iter()
+            .next()
+            .and_then(Result::ok)
+            .flatten()
+            .expect("linked worktree name");
+        let expected_git_dir = worktree_admin_git_dir(&primary_identity.common_dir, name)
+            .expect("worktree admin directory");
+        let facts = repository_facts(
+            &handoff,
+            &managed_root,
+            &primary_identity.common_dir,
+            &expected_git_dir,
+        )
+        .expect("initial handoff facts");
+        let layout = git_layout(&handoff).expect("handoff layout");
+        let mut switched = false;
+
+        let dirty = crate::git_inspection::dirty_entries(&layout).expect("initial clean scan");
+        assert!(dirty.is_empty(), "handoff must start clean");
+        let result = revalidate_worktree_after_observer(&facts, || {
+            fs::rename(handoff.join(".git"), handoff.join(".git-before-switch"))
+                .expect("preserve original gitfile");
+            fs::write(
+                handoff.join(".git"),
+                format!("gitdir: {}\n", foreign.join(".git").display()),
+            )
+            .expect("redirect handoff checkout");
+            switched = true;
+            Ok(())
+        });
+
+        assert!(switched, "phase-controlled identity switch was not reached");
+        let error = result.expect_err("identity change must fail closed");
+        assert_eq!(error.code, "workspace-recovery-worktrees-unavailable");
+        assert!(!error.message.contains("foreign-secret"));
+    }
 }

--- a/crates/agent-hook/tests/contracts.rs
+++ b/crates/agent-hook/tests/contracts.rs
@@ -395,6 +395,7 @@ fn cli_help_version_and_completion_surface_are_complete() {
         "recovery",
         "finish-line",
         "workspace-lease",
+        "workspace-recovery",
         "completion",
         "-V, --version",
     ] {
@@ -471,6 +472,28 @@ fn cli_help_version_and_completion_surface_are_complete() {
             .contains("[default: json]")
     );
 
+    let recovery_help = fixture.run(&["workspace-recovery", "--help"], None);
+    assert_eq!(
+        recovery_help.code,
+        0,
+        "stderr={}",
+        recovery_help.stderr_text()
+    );
+    let recovery_help_text = recovery_help.stdout_text();
+    for required in ["inspect", "verify-handoff"] {
+        assert!(
+            recovery_help_text.contains(required),
+            "workspace-recovery help missing {required}: {recovery_help_text}"
+        );
+    }
+    let recovery_inspect_help = fixture.run(&["workspace-recovery", "inspect", "--help"], None);
+    assert_eq!(recovery_inspect_help.code, 0);
+    assert!(
+        recovery_inspect_help
+            .stdout_text()
+            .contains("[default: json]")
+    );
+
     for shell in ["bash", "zsh"] {
         let completion = fixture.run(&["completion", shell], None);
         assert_eq!(completion.code, 0, "shell={shell}");
@@ -481,6 +504,8 @@ fn cli_help_version_and_completion_surface_are_complete() {
         );
         assert!(script.contains("dispatch"), "shell={shell}");
         assert!(script.contains("workspace-lease"), "shell={shell}");
+        assert!(script.contains("workspace-recovery"), "shell={shell}");
+        assert!(script.contains("verify-handoff"), "shell={shell}");
         assert!(script.contains("renew"), "shell={shell}");
         assert!(script.contains("--expected-plan-digest"), "shell={shell}");
         let (scope_start, scope_end) = if shell == "bash" {

--- a/crates/agent-hook/tests/workspace_lease.rs
+++ b/crates/agent-hook/tests/workspace_lease.rs
@@ -1,6 +1,7 @@
 mod support;
 
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -277,6 +278,295 @@ fn dirty_state_refuses_takeover_and_clean_expiry_recovers_with_a_new_generation(
     let refused = bind(&fixture, "session-c", "dirty-takeover", &fixture.root);
     assert_eq!(refused["kind"], "denied");
     assert_eq!(refused["state"], "dirty");
+}
+
+#[test]
+fn dirty_bind_never_executes_repository_clean_filters() {
+    let fixture = fixture();
+    fs::write(
+        fixture.root.join(".gitattributes"),
+        "tracked.txt filter=hostile\n",
+    )
+    .expect("hostile attributes");
+    git(&fixture.root, &["add", ".gitattributes"]);
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-m", "test: hostile filter fixture"],
+    );
+
+    let marker = fixture.root.join("filter-executed");
+    let filter = fixture.root.join("hostile-filter.sh");
+    fs::write(
+        &filter,
+        format!("#!/bin/sh\n: > {}\n/bin/cat\n", marker.to_string_lossy()),
+    )
+    .expect("hostile filter script");
+    fs::set_permissions(&filter, fs::Permissions::from_mode(0o700))
+        .expect("hostile filter permissions");
+    git(
+        &fixture.root,
+        &[
+            "config",
+            "filter.hostile.clean",
+            filter.to_str().expect("filter path UTF-8"),
+        ],
+    );
+    fs::write(fixture.root.join("tracked.txt"), "next\n").expect("dirty tracked file");
+
+    let denied = bind(&fixture, "session-a", "hostile-filter-bind", &fixture.root);
+
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["code"], "WORKSPACE_DIRTY");
+    assert!(
+        !marker.exists(),
+        "workspace dirtiness inspection executed a repository clean filter"
+    );
+}
+
+fn dirty_submodule_denial(ignore_source: Option<&str>, request_id: &str) -> (Value, bool) {
+    let fixture = fixture();
+    let source = ScopedTempDir::with_prefix("agent-hook-submodule-source-");
+    git(source.path(), &["init", "--quiet"]);
+    git(
+        source.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(source.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(source.path().join("tracked.txt"), "base\n").expect("submodule tracked file");
+    fs::write(
+        source.path().join(".gitattributes"),
+        "tracked.txt filter=hostile\n",
+    )
+    .expect("submodule hostile attributes");
+    git(source.path(), &["add", "--all"]);
+    git(source.path(), &["commit", "--quiet", "-m", "test: initial"]);
+
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            source.path().to_str().expect("submodule source UTF-8"),
+            "module",
+        ],
+    );
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-am", "test: add submodule"],
+    );
+    match ignore_source {
+        Some("gitmodules") => {
+            git(
+                &fixture.root,
+                &[
+                    "config",
+                    "-f",
+                    ".gitmodules",
+                    "submodule.module.ignore",
+                    "all",
+                ],
+            );
+            git(
+                &fixture.root,
+                &[
+                    "commit",
+                    "--quiet",
+                    "-am",
+                    "test: ignore submodule dirtiness",
+                ],
+            );
+        }
+        Some("config") => git(&fixture.root, &["config", "diff.ignoreSubmodules", "all"]),
+        None => {}
+        Some(value) => panic!("unsupported submodule ignore source: {value}"),
+    }
+
+    let marker = fixture.state_home.join("submodule-filter-executed");
+    let filter = fixture.state_home.join("submodule-hostile-filter.sh");
+    fs::write(
+        &filter,
+        format!("#!/bin/sh\n: > {}\n/bin/cat\n", marker.to_string_lossy()),
+    )
+    .expect("submodule hostile filter script");
+    fs::set_permissions(&filter, fs::Permissions::from_mode(0o700))
+        .expect("submodule hostile filter permissions");
+    let checkout = fixture.root.join("module");
+    git(
+        &checkout,
+        &[
+            "config",
+            "filter.hostile.clean",
+            filter.to_str().expect("submodule filter UTF-8"),
+        ],
+    );
+    fs::write(checkout.join("tracked.txt"), "next\n").expect("dirty submodule tracked file");
+
+    let denied = bind(&fixture, "session-a", request_id, &fixture.root);
+
+    (denied, marker.exists())
+}
+
+fn nested_dirty_submodule_denial() -> (Value, bool) {
+    let fixture = fixture();
+    let leaf = ScopedTempDir::with_prefix("agent-hook-nested-leaf-");
+    git(leaf.path(), &["init", "--quiet"]);
+    git(
+        leaf.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(leaf.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(leaf.path().join("tracked.txt"), "base\n").expect("nested tracked file");
+    fs::write(
+        leaf.path().join(".gitattributes"),
+        "tracked.txt filter=hostile\n",
+    )
+    .expect("nested hostile attributes");
+    git(leaf.path(), &["add", "--all"]);
+    git(leaf.path(), &["commit", "--quiet", "-m", "test: initial"]);
+
+    let parent = ScopedTempDir::with_prefix("agent-hook-nested-parent-");
+    git(parent.path(), &["init", "--quiet"]);
+    git(
+        parent.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(parent.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(parent.path().join("parent.txt"), "base\n").expect("parent tracked file");
+    git(parent.path(), &["add", "--all"]);
+    git(parent.path(), &["commit", "--quiet", "-m", "test: initial"]);
+    git(
+        parent.path(),
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            leaf.path().to_str().expect("nested leaf source UTF-8"),
+            "leaf",
+        ],
+    );
+    git(
+        parent.path(),
+        &[
+            "config",
+            "-f",
+            ".gitmodules",
+            "submodule.leaf.ignore",
+            "all",
+        ],
+    );
+    git(
+        parent.path(),
+        &[
+            "commit",
+            "--quiet",
+            "-am",
+            "test: add ignored nested submodule",
+        ],
+    );
+
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            parent.path().to_str().expect("nested parent source UTF-8"),
+            "module",
+        ],
+    );
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+        ],
+    );
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-am", "test: add nested submodule"],
+    );
+
+    let marker = fixture.state_home.join("nested-submodule-filter-executed");
+    let filter = fixture
+        .state_home
+        .join("nested-submodule-hostile-filter.sh");
+    fs::write(
+        &filter,
+        format!("#!/bin/sh\n: > {}\n/bin/cat\n", marker.to_string_lossy()),
+    )
+    .expect("nested submodule hostile filter script");
+    fs::set_permissions(&filter, fs::Permissions::from_mode(0o700))
+        .expect("nested submodule hostile filter permissions");
+    let checkout = fixture.root.join("module/leaf");
+    git(
+        &checkout,
+        &[
+            "config",
+            "filter.hostile.clean",
+            filter.to_str().expect("nested submodule filter UTF-8"),
+        ],
+    );
+    fs::write(checkout.join("tracked.txt"), "next\n").expect("dirty nested tracked file");
+
+    let denied = bind(
+        &fixture,
+        "session-a",
+        "nested-gitmodules-ignore-bind",
+        &fixture.root,
+    );
+    (denied, marker.exists())
+}
+
+#[test]
+fn dirty_submodule_bind_stays_closed_without_executing_its_clean_filter() {
+    let (denied, filter_executed) = dirty_submodule_denial(None, "dirty-submodule-bind");
+
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["code"], "WORKSPACE_DIRTY");
+    assert!(
+        !filter_executed,
+        "workspace dirtiness inspection executed a submodule clean filter"
+    );
+}
+
+#[test]
+fn gitmodules_ignore_all_cannot_hide_a_dirty_submodule_from_bind() {
+    let (denied, filter_executed) =
+        dirty_submodule_denial(Some("gitmodules"), "gitmodules-ignore-bind");
+
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["code"], "WORKSPACE_DIRTY");
+    assert!(!filter_executed, "submodule clean filter executed");
+}
+
+#[test]
+fn diff_ignore_submodules_all_cannot_hide_a_dirty_submodule_from_bind() {
+    let (denied, filter_executed) =
+        dirty_submodule_denial(Some("config"), "diff-ignore-submodules-bind");
+
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["code"], "WORKSPACE_DIRTY");
+    assert!(!filter_executed, "submodule clean filter executed");
+}
+
+#[test]
+fn nested_gitmodules_ignore_all_cannot_hide_a_dirty_submodule_from_bind() {
+    let (denied, filter_executed) = nested_dirty_submodule_denial();
+
+    assert_eq!(denied["kind"], "denied");
+    assert_eq!(denied["code"], "WORKSPACE_DIRTY");
+    assert!(!filter_executed, "nested submodule clean filter executed");
 }
 
 #[test]

--- a/crates/agent-hook/tests/workspace_lease.rs
+++ b/crates/agent-hook/tests/workspace_lease.rs
@@ -409,7 +409,7 @@ fn dirty_submodule_denial(ignore_source: Option<&str>, request_id: &str) -> (Val
     (denied, marker.exists())
 }
 
-fn nested_dirty_submodule_denial() -> (Value, bool) {
+fn nested_submodule_bind(dirty: bool, request_id: &str) -> (Value, bool) {
     let fixture = fixture();
     let leaf = ScopedTempDir::with_prefix("agent-hook-nested-leaf-");
     git(leaf.path(), &["init", "--quiet"]);
@@ -517,15 +517,12 @@ fn nested_dirty_submodule_denial() -> (Value, bool) {
             filter.to_str().expect("nested submodule filter UTF-8"),
         ],
     );
-    fs::write(checkout.join("tracked.txt"), "next\n").expect("dirty nested tracked file");
+    if dirty {
+        fs::write(checkout.join("tracked.txt"), "next\n").expect("dirty nested tracked file");
+    }
 
-    let denied = bind(
-        &fixture,
-        "session-a",
-        "nested-gitmodules-ignore-bind",
-        &fixture.root,
-    );
-    (denied, marker.exists())
+    let outcome = bind(&fixture, "session-a", request_id, &fixture.root);
+    (outcome, marker.exists())
 }
 
 #[test]
@@ -562,11 +559,73 @@ fn diff_ignore_submodules_all_cannot_hide_a_dirty_submodule_from_bind() {
 
 #[test]
 fn nested_gitmodules_ignore_all_cannot_hide_a_dirty_submodule_from_bind() {
-    let (denied, filter_executed) = nested_dirty_submodule_denial();
+    let (denied, filter_executed) = nested_submodule_bind(true, "nested-gitmodules-ignore-bind");
 
     assert_eq!(denied["kind"], "denied");
     assert_eq!(denied["code"], "WORKSPACE_DIRTY");
     assert!(!filter_executed, "nested submodule clean filter executed");
+}
+
+#[test]
+fn clean_nested_submodules_remain_leaseable_without_executing_filters() {
+    let (bound, filter_executed) = nested_submodule_bind(false, "clean-nested-submodule-bind");
+
+    assert_eq!(bound["kind"], "bound", "outcome={bound}");
+    assert!(!filter_executed, "nested submodule clean filter executed");
+}
+
+#[test]
+fn missing_submodule_gitdir_cannot_make_nonempty_nested_work_leaseable() {
+    let fixture = fixture();
+    let source = ScopedTempDir::with_prefix("agent-hook-missing-submodule-gitdir-");
+    git(source.path(), &["init", "--quiet"]);
+    git(
+        source.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(source.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(source.path().join("tracked.txt"), "base\n").expect("submodule tracked file");
+    git(source.path(), &["add", "--all"]);
+    git(source.path(), &["commit", "--quiet", "-m", "test: initial"]);
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            source.path().to_str().expect("submodule source UTF-8"),
+            "module",
+        ],
+    );
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-am", "test: add submodule"],
+    );
+    let checkout = fixture.root.join("module");
+    fs::write(checkout.join("private.txt"), "must remain untouched\n")
+        .expect("dirty submodule bytes");
+    let private_before = fs::read(checkout.join("private.txt")).expect("dirty bytes");
+    fs::remove_file(checkout.join(".git")).expect("remove submodule gitfile");
+
+    let (code, envelope) = invoke(
+        &fixture,
+        "bind",
+        bind_request(
+            "foreign-session",
+            "missing-submodule-gitdir-bind",
+            &fixture.root,
+        ),
+    );
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["kind"], "denied", "envelope={envelope}");
+    assert_eq!(envelope["data"]["code"], "WORKSPACE_DIRTY");
+    assert_eq!(
+        fs::read(checkout.join("private.txt")).expect("dirty bytes after bind"),
+        private_before
+    );
 }
 
 #[test]

--- a/crates/agent-hook/tests/workspace_recovery.rs
+++ b/crates/agent-hook/tests/workspace_recovery.rs
@@ -201,6 +201,149 @@ fn verify_handoff_accepts_only_a_different_clean_managed_worktree() {
 }
 
 #[test]
+fn redirected_submodule_gitdir_fails_closed_without_foreign_path_metadata() {
+    let (fixture, _managed) = fixture();
+    let source = ScopedTempDir::with_prefix("workspace-recovery-submodule-source-");
+    git(source.path(), &["init", "--quiet"]);
+    git(
+        source.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(source.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(source.path().join("tracked.txt"), "base\n").expect("submodule tracked file");
+    git(source.path(), &["add", "--all"]);
+    git(source.path(), &["commit", "--quiet", "-m", "test: initial"]);
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            source.path().to_str().expect("submodule source UTF-8"),
+            "module",
+        ],
+    );
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-am", "test: add submodule"],
+    );
+    let foreign = fixture.state_home.join("foreign-submodule");
+    git(
+        &fixture.state_home,
+        &[
+            "clone",
+            "--quiet",
+            source.path().to_str().expect("submodule source UTF-8"),
+            foreign.to_str().expect("foreign clone UTF-8"),
+        ],
+    );
+    fs::write(
+        foreign.join("foreign-secret.txt"),
+        "must not be projected\n",
+    )
+    .expect("foreign dirty file");
+    fs::write(
+        fixture.root.join("module/.git"),
+        format!("gitdir: {}\n", foreign.join(".git").to_string_lossy()),
+    )
+    .expect("redirect submodule gitfile");
+
+    let (code, envelope) = inspect(&fixture);
+
+    assert_eq!(code, 69, "envelope={envelope}");
+    assert_eq!(
+        envelope["error"]["code"],
+        "workspace-inspection-unavailable"
+    );
+    assert!(!envelope.to_string().contains("foreign-secret"));
+}
+
+#[test]
+fn redirected_worktree_admin_gitdir_cannot_verify_an_unrelated_handoff() {
+    let (fixture, managed) = fixture();
+    fs::write(fixture.root.join("notes.txt"), "dirty\n").expect("dirty primary");
+    let foreign = managed.parent().expect("managed parent").join("foreign");
+    fs::create_dir_all(&foreign).expect("foreign repository");
+    git(&foreign, &["init", "--quiet"]);
+    git(&foreign, &["config", "user.email", "workspace@example.com"]);
+    git(&foreign, &["config", "user.name", "Workspace Test"]);
+    fs::write(foreign.join("foreign.txt"), "unrelated\n").expect("foreign tracked file");
+    git(&foreign, &["add", "--all"]);
+    git(&foreign, &["commit", "--quiet", "-m", "test: unrelated"]);
+    let gitfile = fs::read_to_string(managed.join(".git")).expect("managed gitfile");
+    let admin = PathBuf::from(
+        gitfile
+            .trim()
+            .strip_prefix("gitdir: ")
+            .expect("managed gitdir"),
+    );
+    fs::write(
+        admin.join("gitdir"),
+        format!("{}\n", foreign.join(".git").to_string_lossy()),
+    )
+    .expect("redirect worktree admin gitdir");
+
+    let (code, envelope) = verify(&fixture, &foreign);
+
+    assert_eq!(code, 69, "envelope={envelope}");
+    assert_eq!(
+        envelope["error"]["code"],
+        "workspace-recovery-worktrees-unavailable"
+    );
+    assert!(envelope["data"]["handoff"].is_null());
+}
+
+#[test]
+fn clean_linked_handoff_with_initialized_submodule_remains_verifiable() {
+    let (fixture, managed) = fixture();
+    let source = ScopedTempDir::with_prefix("workspace-recovery-linked-submodule-source-");
+    git(source.path(), &["init", "--quiet"]);
+    git(
+        source.path(),
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(source.path(), &["config", "user.name", "Workspace Test"]);
+    fs::write(source.path().join("tracked.txt"), "base\n").expect("submodule tracked file");
+    git(source.path(), &["add", "--all"]);
+    git(source.path(), &["commit", "--quiet", "-m", "test: initial"]);
+    git(
+        &fixture.root,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "--quiet",
+            source.path().to_str().expect("submodule source UTF-8"),
+            "module",
+        ],
+    );
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-am", "test: add submodule"],
+    );
+    git(&managed, &["merge", "--quiet", "master"]);
+    git(
+        &managed,
+        &[
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "update",
+            "--init",
+        ],
+    );
+    fs::write(fixture.root.join("notes.txt"), "dirty primary\n").expect("dirty primary");
+
+    let (code, envelope) = verify(&fixture, &managed);
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["handoff"]["status"], "verified");
+}
+
+#[test]
 fn inspect_never_executes_repository_filters() {
     let (fixture, _managed) = fixture();
     fs::write(

--- a/crates/agent-hook/tests/workspace_recovery.rs
+++ b/crates/agent-hook/tests/workspace_recovery.rs
@@ -1,0 +1,393 @@
+mod support;
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::ffi::OsStringExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use pretty_assertions::assert_eq;
+use serde_json::{Value, json};
+
+use nils_test_support::tempdir::ScopedTempDir;
+use support::Fixture;
+
+const POLICY: &str = r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "workspace-recovery-test"
+version = "2026.08.27.1"
+"#;
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("git command");
+    assert!(
+        output.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn repo_key(repo_root: &Path) -> String {
+    let basename = repo_root
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .to_ascii_lowercase();
+    let basename = basename.trim_matches(['-', '_', '.']);
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in repo_root.as_os_str().as_encoded_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{basename}-{:08x}", hash as u32)
+}
+
+fn fixture() -> (Fixture, PathBuf) {
+    let fixture = Fixture::new(POLICY);
+    git(&fixture.root, &["init", "--quiet"]);
+    git(
+        &fixture.root,
+        &["config", "user.email", "workspace@example.com"],
+    );
+    git(&fixture.root, &["config", "user.name", "Workspace Test"]);
+    fs::write(
+        fixture.root.join(".gitignore"),
+        "/config/\n/data/\n/home/\n/state/\nsession-state/\n",
+    )
+    .expect("fixture ignores");
+    fs::write(fixture.root.join("tracked.txt"), "base\n").expect("tracked file");
+    git(&fixture.root, &["add", "--all"]);
+    git(&fixture.root, &["commit", "--quiet", "-m", "test: initial"]);
+    let managed = fixture
+        .state_home
+        .join("agent-runtime-kit/worktrees")
+        .join(repo_key(&fixture.root))
+        .join("handoff");
+    fs::create_dir_all(managed.parent().expect("managed parent")).expect("managed parent");
+    git(
+        &fixture.root,
+        &[
+            "worktree",
+            "add",
+            "--quiet",
+            "-b",
+            "fix/handoff",
+            managed.to_str().expect("managed UTF-8"),
+            "HEAD",
+        ],
+    );
+    (fixture, managed)
+}
+
+fn inspect(fixture: &Fixture) -> (i32, Value) {
+    let request = json!({
+        "schema_version": "agent-hook.workspace-recovery.inspect.v1",
+        "version": 1,
+        "cwd": fixture.root,
+    });
+    let agent_home = fixture.state_home.join("agent-runtime-kit");
+    let output = fixture.run_with_env(
+        &["workspace-recovery", "inspect", "--format", "json"],
+        Some(&request.to_string()),
+        &[("AGENT_HOME", agent_home.to_str().expect("agent home UTF-8"))],
+    );
+    (output.code, output.stdout_json())
+}
+
+fn verify(fixture: &Fixture, handoff: &Path) -> (i32, Value) {
+    let request = json!({
+        "schema_version": "agent-hook.workspace-recovery.verify-handoff.v1",
+        "version": 1,
+        "cwd": fixture.root,
+        "handoff_path": handoff,
+    });
+    let agent_home = fixture.state_home.join("agent-runtime-kit");
+    let output = fixture.run_with_env(
+        &["workspace-recovery", "verify-handoff", "--format", "json"],
+        Some(&request.to_string()),
+        &[("AGENT_HOME", agent_home.to_str().expect("agent home UTF-8"))],
+    );
+    (output.code, output.stdout_json())
+}
+
+#[test]
+fn inspect_projects_dirty_path_names_and_managed_worktrees_without_mutation() {
+    let (fixture, managed) = fixture();
+    fs::write(fixture.root.join("notes.txt"), "private contents\n").expect("dirty file");
+    let notes_before = fs::read(fixture.root.join("notes.txt")).expect("dirty file bytes");
+    let head_before = fs::read(fixture.root.join(".git/HEAD")).expect("HEAD bytes");
+    let index_before = fs::read(fixture.root.join(".git/index")).expect("index bytes");
+    let config_before = fs::read(fixture.root.join(".git/config")).expect("config bytes");
+
+    let (code, envelope) = inspect(&fixture);
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(
+        envelope["schema_version"],
+        "cli.agent-hook.workspace-recovery-inspect.v1"
+    );
+    let data = &envelope["data"];
+    assert_eq!(
+        data["schema_version"],
+        "agent-hook.workspace-recovery.result.v1"
+    );
+    assert_eq!(data["action"], "inspect");
+    assert_eq!(data["state"], "dirty");
+    assert_eq!(data["checkout"]["dirty_entries"][0]["path"], "notes.txt");
+    assert_eq!(data["checkout"]["dirty_entries"][0]["lossy"], false);
+    let projected = data["worktrees"].as_array().expect("worktrees");
+    let handoff = projected
+        .iter()
+        .find(|entry| entry["path"] == managed.to_string_lossy().as_ref())
+        .expect("managed handoff");
+    assert_eq!(handoff["managed"], true, "data={data}");
+    assert_eq!(handoff["branch"], "fix/handoff");
+    assert!(!envelope.to_string().contains("private contents"));
+    assert_eq!(
+        fs::read(fixture.root.join("notes.txt")).unwrap(),
+        notes_before
+    );
+    assert_eq!(
+        fs::read(fixture.root.join(".git/HEAD")).unwrap(),
+        head_before
+    );
+    assert_eq!(
+        fs::read(fixture.root.join(".git/index")).unwrap(),
+        index_before
+    );
+    assert_eq!(
+        fs::read(fixture.root.join(".git/config")).unwrap(),
+        config_before
+    );
+    assert!(
+        !fixture
+            .state_home
+            .join("agent-hook/workspace-leases")
+            .exists()
+    );
+}
+
+#[test]
+fn verify_handoff_accepts_only_a_different_clean_managed_worktree() {
+    let (fixture, managed) = fixture();
+    fs::write(fixture.root.join("notes.txt"), "dirty\n").expect("dirty file");
+
+    let (code, envelope) = verify(&fixture, &managed);
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["handoff"]["status"], "verified");
+    assert_eq!(envelope["data"]["handoff"]["branch"], "fix/handoff");
+
+    fs::write(managed.join("unfinished.txt"), "dirty\n").expect("dirty handoff");
+    let (code, envelope) = verify(&fixture, &managed);
+    assert_eq!(code, 65, "envelope={envelope}");
+    assert_eq!(
+        envelope["error"]["code"],
+        "workspace-recovery-handoff-dirty"
+    );
+
+    let (code, envelope) = verify(&fixture, &fixture.root);
+    assert_eq!(code, 65, "envelope={envelope}");
+    assert_eq!(
+        envelope["error"]["code"],
+        "workspace-recovery-handoff-ineligible"
+    );
+}
+
+#[test]
+fn inspect_never_executes_repository_filters() {
+    let (fixture, _managed) = fixture();
+    fs::write(
+        fixture.root.join(".gitattributes"),
+        "tracked.txt filter=hostile\n",
+    )
+    .expect("hostile attributes");
+    git(&fixture.root, &["add", ".gitattributes"]);
+    git(
+        &fixture.root,
+        &["commit", "--quiet", "-m", "test: hostile filter fixture"],
+    );
+    let marker = fixture.root.join("filter-executed");
+    let filter = fixture.root.join("hostile-filter.sh");
+    fs::write(
+        &filter,
+        format!("#!/bin/sh\n: > {}\n/bin/cat\n", marker.to_string_lossy()),
+    )
+    .expect("hostile filter");
+    fs::set_permissions(&filter, fs::Permissions::from_mode(0o700)).expect("filter mode");
+    git(
+        &fixture.root,
+        &[
+            "config",
+            "filter.hostile.clean",
+            filter.to_str().expect("filter UTF-8"),
+        ],
+    );
+    fs::write(fixture.root.join("tracked.txt"), "next\n").expect("dirty tracked file");
+
+    let (code, envelope) = inspect(&fixture);
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    assert_eq!(envelope["data"]["state"], "dirty");
+    assert!(!marker.exists(), "inspection executed a repository filter");
+}
+
+#[test]
+fn inspect_marks_lossy_dirty_paths_without_exposing_file_contents() {
+    let (fixture, _managed) = fixture();
+    let path = fixture
+        .root
+        .join(OsString::from_vec(b"opaque-\xff.txt".to_vec()));
+    fs::write(&path, "must not appear in output\n").expect("non-UTF-8 dirty path");
+
+    let (code, envelope) = inspect(&fixture);
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    let entries = envelope["data"]["checkout"]["dirty_entries"]
+        .as_array()
+        .expect("dirty entries");
+    let projected = entries
+        .iter()
+        .find(|entry| {
+            entry["path"]
+                .as_str()
+                .is_some_and(|value| value.starts_with("opaque-"))
+        })
+        .expect("lossy path projection");
+    assert_eq!(projected["lossy"], true);
+    assert!(!envelope.to_string().contains("must not appear in output"));
+}
+
+#[test]
+fn inspect_projects_stale_worktrees_as_prunable_and_never_as_handoffs() {
+    let (fixture, managed) = fixture();
+    fs::remove_dir_all(&managed).expect("remove linked worktree checkout only");
+
+    let (code, envelope) = inspect(&fixture);
+
+    assert_eq!(code, 0, "envelope={envelope}");
+    let projected = envelope["data"]["worktrees"].as_array().expect("worktrees");
+    let stale = projected
+        .iter()
+        .find(|entry| entry["path"] == managed.to_string_lossy().as_ref())
+        .expect("prunable managed worktree");
+    assert_eq!(stale["managed"], true);
+    assert_eq!(stale["prunable"], true);
+    assert_eq!(stale["branch"], Value::Null);
+    assert_eq!(stale["head"], Value::Null);
+
+    let (verify_code, denied) = verify(&fixture, &managed);
+    assert_eq!(verify_code, 65, "envelope={denied}");
+    assert_eq!(
+        denied["error"]["code"],
+        "workspace-recovery-handoff-invalid"
+    );
+}
+
+#[test]
+fn strict_wire_rejects_ambiguous_and_duplicate_requests() {
+    let (fixture, _managed) = fixture();
+    let unknown = json!({
+        "schema_version": "agent-hook.workspace-recovery.inspect.v1",
+        "version": 1,
+        "cwd": fixture.root,
+        "handoff_path": fixture.root,
+    });
+    let output = fixture.run(
+        &["workspace-recovery", "inspect", "--format", "json"],
+        Some(&unknown.to_string()),
+    );
+    assert_eq!(output.code, 65);
+    assert_eq!(
+        output.stdout_json()["error"]["code"],
+        "workspace-recovery-wire-invalid"
+    );
+
+    let duplicate = format!(
+        r#"{{"schema_version":"agent-hook.workspace-recovery.inspect.v1","version":1,"version":1,"cwd":{}}}"#,
+        serde_json::to_string(&fixture.root).unwrap()
+    );
+    let output = fixture.run(
+        &["workspace-recovery", "inspect", "--format", "json"],
+        Some(&duplicate),
+    );
+    assert_eq!(output.code, 65);
+    assert_eq!(
+        output.stdout_json()["error"]["code"],
+        "workspace-recovery-wire-invalid"
+    );
+}
+
+#[test]
+fn unavailable_checkout_has_bounded_typed_recovery_details_without_path_leakage() {
+    let (fixture, _) = fixture();
+    let missing = ScopedTempDir::outside_git_ancestry("workspace-recovery-missing-");
+    let request = json!({
+        "schema_version": "agent-hook.workspace-recovery.inspect.v1",
+        "version": 1,
+        "cwd": missing.path().join("missing-checkout"),
+    });
+
+    let output = fixture.run(
+        &["workspace-recovery", "inspect", "--format", "json"],
+        Some(&request.to_string()),
+    );
+    let envelope = output.stdout_json();
+
+    assert_eq!(output.code, 69, "envelope={envelope}");
+    assert_eq!(
+        envelope["error"]["code"],
+        "workspace-recovery-checkout-unavailable"
+    );
+    assert_eq!(envelope["error"]["details"]["retryable"], true);
+    assert_eq!(
+        envelope["error"]["details"]["next_action"],
+        "verify-checkout-and-retry"
+    );
+    assert_eq!(
+        envelope["error"]["details"]["recovery"]["kind"],
+        "bounded-retry"
+    );
+    assert_eq!(envelope["error"]["details"]["recovery"]["max_attempts"], 1);
+    assert!(!envelope.to_string().contains("missing-checkout"));
+}
+
+#[test]
+fn inspect_truncates_large_projections_with_typed_omitted_counts() {
+    let (fixture, _) = fixture();
+    for index in 0..1_400 {
+        let name = format!("{index:04}-{}", "x".repeat(180));
+        fs::write(fixture.root.join(name), []).expect("large dirty projection fixture");
+    }
+    let request = json!({
+        "schema_version": "agent-hook.workspace-recovery.inspect.v1",
+        "version": 1,
+        "cwd": fixture.root,
+    });
+    let agent_home = fixture.state_home.join("agent-runtime-kit");
+
+    let output = fixture.run_with_env(
+        &["workspace-recovery", "inspect", "--format", "json"],
+        Some(&request.to_string()),
+        &[("AGENT_HOME", agent_home.to_str().expect("agent home UTF-8"))],
+    );
+    let envelope = output.stdout_json();
+    let data = &envelope["data"];
+    let displayed = data["checkout"]["dirty_entries"]
+        .as_array()
+        .expect("dirty entries")
+        .len();
+    let omitted = data["checkout"]["dirty_entries_omitted"]
+        .as_u64()
+        .expect("dirty entries omitted") as usize;
+
+    assert_eq!(output.code, 0, "envelope={envelope}");
+    assert!(omitted > 0, "large projection must be truncated");
+    assert_eq!(displayed + omitted, 1_400);
+    assert!(serde_json::to_vec(data).unwrap().len() <= 192 * 1024);
+    assert!(output.stdout_text().len() <= 256 * 1024);
+    assert!(data["worktrees_omitted"].is_u64());
+}

--- a/crates/agent-hook/tests/workspace_recovery.rs
+++ b/crates/agent-hook/tests/workspace_recovery.rs
@@ -1,11 +1,14 @@
 mod support;
 
-use std::ffi::OsString;
 use std::fs;
-use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+#[cfg(target_os = "linux")]
+use std::ffi::OsString;
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStringExt;
 
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -236,6 +239,7 @@ fn inspect_never_executes_repository_filters() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn inspect_marks_lossy_dirty_paths_without_exposing_file_contents() {
     let (fixture, _managed) = fixture();
     let path = fixture


### PR DESCRIPTION
## Summary

Add a bounded, read-only workspace recovery contract to `agent-hook` so DSH can explain a dirty bootstrap failure and verify a clean managed handoff without granting a lease, executing repository-controlled Git behavior, or weakening fail-closed ownership rules.

## Problem

- Expected: a dirty workspace remains blocked while automation can obtain privacy-safe recovery facts and later prove that a managed checkout is clean.
- Actual: `WORKSPACE_DIRTY` stopped DSH before runtime context, skills, or ordinary CLI were available, leaving no admitted path to diagnose or hand off the checkout.
- Impact: a recoverable dirty bootstrap could strand an external DSH session even though the correct repair is to preserve user changes and move work into a clean managed checkout.

## Reproduction

1. Start authenticated DSH admission in a repository with tracked or untracked changes.
2. Observe `WORKSPACE_DIRTY` before project context or skills can load.
3. Attempt to inspect the blocked checkout or verify a clean handoff through the existing `agent-hook` surface; no bounded recovery command exists.

## Issues Found

- Refs sympoies/dsh-runtime-kit#102
- Supports serenvia/sympoies-infra#213; this PR does not close either downstream acceptance tracker.

## Fix Approach

- Add strict `workspace-recovery inspect` and `verify-handoff` request/response contracts with bounded output and stable recovery metadata.
- Inspect dirtiness in-process with libgit2, explicitly including recursively dirty submodules while ignoring repository-controlled filter and ignore settings.
- Authenticate exact primary, linked-worktree, and submodule Git identities; bind nested status to already-open trusted repository handles and revalidate identities after scans.
- Keep recovery read-only and non-authoritative: it cannot bind, mutate, terminalize an unknown operation, or override foreign-owner and dirty-worktree protection.
- Refresh the public specification, completions, dependency receipts, and regression coverage.

## Test-First Evidence

- RED: the old status path executed a hostile clean filter, and top-level or nested ignore settings hid dirty submodules.
- RED: missing or redirected submodule metadata could appear clean, and redirected linked-worktree administration could verify an unrelated handoff.
- RED: deterministic post-scan identity switches were not covered; both phase-controlled tests failed before the production revalidation seam was wired.
- RED: a temporary submodule gitfile retarget changed projected status despite matching pre/post identities, and a legitimate initialized linked-worktree submodule was rejected by the wrong Git-dir basis.
- GREEN: exact identity authentication, worktree-specific `$GIT_DIR/modules`, bound nested status, TOCTOU, clean nested/linked positives, and privacy assertions all pass; durable evidence is complete and bound to signed head `55514e0`.

## Test plan

- Focused final security and positive regressions — 10/10 passed.
- `cargo nextest run -p nils-agent-hook --lib --test workspace_lease --test workspace_recovery` — 96/96 passed.
- `cargo clippy -p nils-agent-hook --all-targets --all-features -- -D warnings` — passed.
- Packed native dsh-runtime-kit consumer smoke — passed with byte/hash preservation, mutation denial, and no lease state.
- `./.agents/scripts/pre-pr.sh` — 8,738/8,738 tests plus doctests and all repository audits passed; one policy-managed flaky retry converged.

## Risk / Notes

- Medium: this changes workspace dirtiness inspection at a security boundary. Strict schemas, bounded recursion/output, exact repository identities, hostile-filter and TOCTOU RED/GREEN coverage, and unchanged fail-closed lease ownership constrain the risk.
