### PR TITLE
fix(agent-session): preserve auto-resume on Codex imports

### DIFF
--- a/crates/agent-session/docs/runbooks/serve-daemon.md
+++ b/crates/agent-session/docs/runbooks/serve-daemon.md
@@ -131,7 +131,10 @@ history. When a profile is selected, it must advertise import support and
 discovery is confined to that profile's provider root. In either import mode,
 omit `cwd`, `prompt`, `agent_args`, and `codex_account`; the daemon resolves the
 original working directory and exact provider metadata from the selected
-history source.
+history source. A capable Codex import uses the same daemon-managed app-server
+runtime as a fresh Codex session, preserving account and auto-resume controls;
+an unsupported or explicitly raw Codex runtime keeps the standalone resume
+fallback.
 
 The server owns executable paths, provider configuration roots, readiness
 commands, and auto-resume capability. Clients select only advertised safe IDs

--- a/crates/agent-session/docs/specs/serve-api-v1.md
+++ b/crates/agent-session/docs/specs/serve-api-v1.md
@@ -378,9 +378,11 @@ recorded in `sympoies/nils-cli#1409`.
   binding before submitting that prompt. `codex_account` is rejected for other
   providers and for provider-import mode. When `provider_resume_id` is present (alias: `resume_id`), the daemon imports an existing Codex or
   Claude provider conversation instead: it resolves the original cwd from the selected local provider history, persists exact
-  `provider_resume` metadata, and starts tmux with the canonical resume command. In resume-id mode, omit `cwd`, `prompt`,
+  `provider_resume` metadata, and starts tmux with the canonical resume command. A capable Codex import uses the daemon-managed
+  app-server transport so account and auto-resume controls remain available; unsupported or explicitly raw Codex runtimes retain
+  the standalone resume fallback. In resume-id mode, omit `cwd`, `prompt`,
   and `agent_args`; invalid, missing, ambiguous, or unsupported provider ids return structured errors.
-  For a fresh serve-managed Codex session, `agent-session` probes bounded
+  For a serve-managed Codex session, including provider imports, `agent-session` probes bounded
   `codex --version` and `codex app-server --help` process groups. App-server
   transport requires Codex `>= 0.144.1` and advertised Unix `--listen` support.
   Exact protocol-attention authority is audited only for Codex `0.144.1` and

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -2423,19 +2423,40 @@ pub(crate) fn start_provider_resume_session(
         args.codex_usage_account.as_deref(),
     )?;
 
+    if let Err(err) =
+        codex_app_server::configure_runtime(context, &agent_bin, &mut created.record, true)
+    {
+        cleanup_created_record(context, &created);
+        return Err(err);
+    }
+    let app_server_managed = codex_app_server::runtime_is_supported(&created.record);
+
     advance_owned_startup_stage(context, &mut created.record, "tmux")?;
     if let Err(err) = created.validate_session_storage() {
         cleanup_created_record(context, &created);
         return Err(err);
     }
 
-    let launch_identity = match start_resume_tmux(
-        &tmux_bin,
-        &agent_bin,
-        &context.state_dir,
-        &created.record,
-        &provider_resume.resume_args,
-    ) {
+    let launch = if app_server_managed {
+        start_interactive_tmux(
+            &tmux_bin,
+            &agent_bin,
+            args.agent,
+            &context.state_dir,
+            &created.record,
+            &provider_resume.resume_args,
+            &created.record.agent_args,
+        )
+    } else {
+        start_resume_tmux(
+            &tmux_bin,
+            &agent_bin,
+            &context.state_dir,
+            &created.record,
+            &provider_resume.resume_args,
+        )
+    };
+    let launch_identity = match launch {
         Ok(identity) => identity,
         Err(err) => {
             // The launch already failed, so cleanup is secondary state and must

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -15405,6 +15405,11 @@ esac
             "XDG_RUNTIME_DIR",
             runtime_dir.path().to_str().unwrap(),
         );
+        let _broker = EnvGuard::set(
+            &lock,
+            "AGENT_SESSION_CODEX_ACCOUNT_BROKER",
+            r#"["/bin/false"]"#,
+        );
         let st = state(tmp.path(), Some(TOKEN), tmux);
 
         let (status, body) = call(

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -15400,6 +15400,7 @@ esac
         );
         let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
         let _codex_bin = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_BIN", codex.to_str().unwrap());
+        let _runtime_preference = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_RUNTIME", "auto");
         let _runtime_dir = EnvGuard::set(
             &lock,
             "XDG_RUNTIME_DIR",
@@ -15502,6 +15503,7 @@ esac
         let codex = fake_agent(tmp.path(), "codex");
         let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
         let _codex_bin = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_BIN", codex.to_str().unwrap());
+        let _runtime_preference = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_RUNTIME", "auto");
         let st = state(tmp.path(), Some(TOKEN), tmux);
 
         let (status, body) = call(

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -15383,15 +15383,28 @@ esac
     async fn create_imports_codex_session_from_provider_resume_id() {
         let lock = GlobalStateLock::new();
         let tmp = tempfile::TempDir::new().unwrap();
+        let runtime_dir = tempfile::Builder::new()
+            .prefix("cx-")
+            .tempdir_in("/tmp")
+            .unwrap();
         let cwd = tmp.path().join("repo");
         let codex_home = tmp.path().join("codex-home");
+        fs::set_permissions(runtime_dir.path(), fs::Permissions::from_mode(0o700)).unwrap();
         std::fs::create_dir_all(&cwd).unwrap();
         write_codex_session_meta(&codex_home, "external-codex-id", &cwd);
         let log = tmp.path().join("tmux.log");
         let tmux = logging_tmux(tmp.path(), &log);
-        let codex = fake_agent(tmp.path(), "codex");
+        let codex = executable(
+            &tmp.path().join("codex"),
+            "#!/usr/bin/env sh\nif [ \"$1\" = --version ]; then printf '%s\\n' 'codex-cli 0.145.0'; exit 0; fi\nif [ \"$1\" = app-server ] && [ \"$2\" = --help ]; then printf '%s\\n' '  --listen <URL>  unix://'; exit 0; fi\nexit 1\n",
+        );
         let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
         let _codex_bin = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_BIN", codex.to_str().unwrap());
+        let _runtime_dir = EnvGuard::set(
+            &lock,
+            "XDG_RUNTIME_DIR",
+            runtime_dir.path().to_str().unwrap(),
+        );
         let st = state(tmp.path(), Some(TOKEN), tmux);
 
         let (status, body) = call(
@@ -15424,6 +15437,8 @@ esac
         assert_eq!(session["cwd"], cwd.to_string_lossy().as_ref());
         assert_eq!(session["status"], "running");
         assert_eq!(session["resumable"], true);
+        assert_eq!(session["auto_resume"]["supported"], true);
+        assert_eq!(session["codex_account"]["supported"], true);
         assert_eq!(
             session["provider_resume"]["session_id"],
             "external-codex-id"
@@ -15458,6 +15473,61 @@ esac
                 .is_file(),
             "import must persist durable resume metadata"
         );
+        let record: Value = serde_json::from_slice(
+            &fs::read(tmp.path().join("sessions/imported-codex/session.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(record["runtime"]["kind"], codex_app_server::RUNTIME_KIND);
+        assert_eq!(
+            record["runtime"][codex_app_server::PROTOCOL_KEY],
+            codex_app_server::PROTOCOL_VERSION
+        );
+    }
+
+    #[tokio::test]
+    async fn create_imports_unsupported_codex_session_with_standalone_resume() {
+        let lock = GlobalStateLock::new();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let cwd = tmp.path().join("repo");
+        let codex_home = tmp.path().join("codex-home");
+        std::fs::create_dir_all(&cwd).unwrap();
+        write_codex_session_meta(&codex_home, "standalone-codex-id", &cwd);
+        let log = tmp.path().join("tmux.log");
+        let tmux = logging_tmux(tmp.path(), &log);
+        let codex = fake_agent(tmp.path(), "codex");
+        let _codex_home = EnvGuard::set(&lock, "CODEX_HOME", codex_home.to_str().unwrap());
+        let _codex_bin = EnvGuard::set(&lock, "AGENT_SESSION_CODEX_BIN", codex.to_str().unwrap());
+        let st = state(tmp.path(), Some(TOKEN), tmux);
+
+        let (status, body) = call(
+            router(st),
+            post_json(
+                "/sessions",
+                Some(TOKEN),
+                json!({
+                    "agent": "codex",
+                    "id": "standalone-codex",
+                    "provider_resume_id": "standalone-codex-id"
+                }),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        let session = &body["data"]["session"];
+        assert_eq!(session["auto_resume"]["supported"], false);
+        assert_eq!(session["codex_account"]["supported"], false);
+        let record: Value = serde_json::from_slice(
+            &fs::read(tmp.path().join("sessions/standalone-codex/session.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(record["runtime"]["kind"], "tmux");
+        let calls = fs::read_to_string(log).unwrap();
+        assert!(
+            calls.contains("resume standalone-codex-id"),
+            "unsupported import must retain the standalone provider resume path: {calls:?}"
+        );
+        assert!(!calls.contains("agent-session-codex-app-server"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix Codex sessions imported from provider history so app-server-capable installations retain Agent Console account and auto-resume controls, while preserving the standalone resume fallback for unsupported or explicitly raw runtimes.

## Problem

- Expected: importing an existing Codex conversation through `provider_resume_id` uses the same managed runtime capabilities as a fresh serve-created Codex session.
- Actual: the import path always launched the standalone TUI and projected `auto_resume.supported=false`.
- Impact: Agent Console rendered the auto-resume control disabled for sessions that had been closed and imported again.

## Reproduction

1. Import an existing Codex conversation through the serve API with `provider_resume_id`.
2. Read the returned session projection.
3. Observe that an app-server-capable Codex installation still reports `auto_resume.supported=false` and a raw tmux runtime.

## Issues Found

- No linked tracking issue; the defect was reproduced from live Agent Console behavior.

## Fix Approach

- Probe and configure the managed Codex app-server runtime during provider import.
- Launch through the managed interactive wrapper only when the capability probe succeeds.
- Preserve standalone `codex resume` behavior when app-server transport is unavailable or raw mode is selected.
- Document the provider-import capability contract.

## Test-First Evidence

- Added managed-runtime capability assertions to the existing Codex provider-import test before the production fix.
- Captured the expected failing assertion: `auto_resume.supported` was false instead of true.
- Added a separate unsupported-runtime test to protect the standalone fallback.

## Test plan

- `cargo test -p nils-agent-session create_imports_ -- --nocapture` — passed all five provider-import tests.
- `.agents/scripts/pre-pr.sh` — passed docs and contract audits, formatting, clippy, 1184 package tests, and doc tests.
- `git diff --check` — passed.

## Risk / Notes

- Managed transport is selected only after the existing bounded Codex capability probe succeeds.
- Claude imports and unsupported/raw Codex imports keep their prior standalone launch path.
- No authentication, provider-history lookup, or caller-controlled executable boundary changes.
