### PR TITLE
feat(git-cli): publish the first branch of an empty remote

### DIFF
--- a/crates/git-cli/README.md
+++ b/crates/git-cli/README.md
@@ -123,8 +123,10 @@ from the primary checkout or from inside any linked worktree.
   `push.default`, `remote.pushDefault`, or configured push refspecs. Sets the upstream on first
   publish. Refuses the remote's default branch (`refuse-default-branch`), a detached HEAD, and an
   unresolvable remote default (`default-branch-unresolved`).
-  Options: `--remote <name>`, `--expect-default <branch>`, `--force-with-lease`, `--dry-run`,
-  `--format text|json`.
+  `--bootstrap` publishes the first branch of a remote proven to have no refs at all, which is
+  the one case the default-branch checks can never satisfy.
+  Options: `--remote <name>`, `--expect-default <branch>`, `--bootstrap`, `--force-with-lease`,
+  `--dry-run`, `--format text|json`.
 
 ### sync-default
 

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -92,9 +92,16 @@ repository could not receive its first branch through any governed surface.
 The safety argument is the emptiness, and it is checked against the remote with
 `git ls-remote`, never inferred from local state — a fresh clone has no
 remote-tracking refs either. Emptiness that cannot be established is
-`remote-unreadable`, not an assumption. The push itself is an ordinary
-create-only push with no force of any kind, so a remote that gained a ref
-between the check and the push rejects it as a non-fast-forward.
+`remote-unreadable`, not an assumption.
+
+The check and the push are two round trips, and a plain push would not close the
+gap between them: if the remote gained this branch in between, a plain push
+*fast-forwards* it rather than refusing, which is exactly the default-branch
+write this command must never make. The push therefore carries
+`--force-with-lease=refs/heads/<branch>:` — an empty expected value, which Git
+admits only when the ref does not exist. It can create and can never overwrite,
+so the operation stays create-only even under a concurrent writer, and `forced`
+stays `false` in the result because nothing was overwritten.
 
 Because there is no default branch and no prior value to lease against,
 `--expect-default` and `--force-with-lease` are refused alongside it rather than

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -25,7 +25,7 @@ commands close that gap by making the safe cases provable rather than inferred.
 ## `git-cli push`
 
 ```text
-git-cli push [--remote <name>] [--expect-default <branch>]
+git-cli push [--remote <name>] [--expect-default <branch>] [--bootstrap]
              [--force-with-lease] [--dry-run] [--format text|json]
 ```
 
@@ -55,6 +55,10 @@ Refusals:
 | `default-branch-unverifiable` | the remote head is not cached and the checked-out branch is a conventional default-branch name |
 | `expect-default-mismatch` | `--expect-default` disagrees with the cached remote head |
 | `refuse-default-branch` | the checked-out branch is the remote's default branch |
+| `remote-has-no-branches` | the remote advertises no refs, so `--bootstrap` is the route |
+| `bootstrap-remote-not-empty` | `--bootstrap` was passed but the remote already has refs |
+| `bootstrap-conflicting-flag` | `--bootstrap` was combined with `--expect-default` or `--force-with-lease` |
+| `remote-unreadable` | `--bootstrap` could not list the remote's refs, so emptiness is unproven |
 | `unknown-remote` | `<remote>` is not configured |
 
 `--expect-default` names what the default branch *is* when the remote HEAD is
@@ -74,6 +78,31 @@ refuse.
 Pushing the default branch is a delivery decision, not a publish step, so
 `refuse-default-branch` points at `forge-cli repo push-default` rather than
 offering a flag.
+
+### `--bootstrap`
+
+A remote that advertises no refs has no default branch, so publishing its first
+branch cannot move one. That is the single case none of the rules above can
+satisfy: there is nothing to cache, `git remote set-head <remote> --auto` fails
+because the remote has no HEAD to read, `--expect-default` is refused as
+unverifiable for a conventional name, and `forge-cli repo push-default` needs an
+expected base that does not exist. Before `--bootstrap` a newly created
+repository could not receive its first branch through any governed surface.
+
+The safety argument is the emptiness, and it is checked against the remote with
+`git ls-remote`, never inferred from local state — a fresh clone has no
+remote-tracking refs either. Emptiness that cannot be established is
+`remote-unreadable`, not an assumption. The push itself is an ordinary
+create-only push with no force of any kind, so a remote that gained a ref
+between the check and the push rejects it as a non-fast-forward.
+
+Because there is no default branch and no prior value to lease against,
+`--expect-default` and `--force-with-lease` are refused alongside it rather than
+ignored. `default_branch` is `null` in the result, and `bootstrapped` is `true`.
+
+When the ordinary path fails only because the remote is empty, the refusal is
+`remote-has-no-branches` and names this flag, instead of the generic hint to
+cache a remote head that cannot exist yet.
 
 ## `git-cli sync-default`
 
@@ -139,8 +168,9 @@ Both commands accept `--format text|json` and use the shared workspace envelope:
 - `cli.git-cli.sync-branch.v1`
 
 `push` returns `branch`, `remote`, `remote_branch`, `refspec`, `head`,
-`default_branch`, `pushed`, `dry_run`, `created_remote_branch`, `upstream`, and
-`forced`.
+`default_branch`, `pushed`, `dry_run`, `created_remote_branch`, `bootstrapped`,
+`upstream`, and `forced`. `default_branch` is `null` exactly when
+`bootstrapped` is `true`.
 
 `sync-default` returns `default_branch`, `remote`, `remote_ref`,
 `previous_head`, `new_head`, `strategy`, `already_current`, `fast_forward`,

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -18,7 +18,8 @@
 //! forbidden" from "this could not be proven" without parsing prose.
 
 use crate::commit_shared::{
-    git_output, git_status_success, git_stdout_trimmed, git_stdout_trimmed_optional,
+    git_output, git_output_optional, git_status_success, git_stdout_trimmed,
+    git_stdout_trimmed_optional,
 };
 use crate::worktree::{
     CliError, detect_format, emit_error, emit_success, ensure_inside_git_repo,
@@ -57,6 +58,7 @@ struct PushArgs {
     remote: String,
     expect_default: Option<String>,
     force_with_lease: bool,
+    bootstrap: bool,
     dry_run: bool,
     format: OutputFormat,
 }
@@ -76,10 +78,13 @@ struct PushOutput {
     remote_branch: String,
     refspec: String,
     head: String,
-    default_branch: String,
+    /// `None` on a bootstrap publish: an empty remote has no default branch,
+    /// and naming one would be a guess the caller could act on.
+    default_branch: Option<String>,
     pushed: bool,
     dry_run: bool,
     created_remote_branch: bool,
+    bootstrapped: bool,
     upstream: String,
     forced: bool,
 }
@@ -169,6 +174,14 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
     // second opinion that can widen admission. Cached truth always wins, and a
     // disagreeing assertion is a mismatch: otherwise `--expect-default develop`
     // while standing on `main` would publish the default branch.
+    // Publishing the first ref of an empty remote cannot move a default branch,
+    // because there is none yet. That is the one case the resolution below can
+    // never satisfy, and refusing it left a new repository with no governed way
+    // to receive its first branch at all.
+    if args.bootstrap {
+        return bootstrap_branch(args, branch);
+    }
+
     let default_branch = match (cached_default_branch(&args.remote), &args.expect_default) {
         (Some(cached), Some(expected)) if cached != *expected => {
             return Err(CliError::data(
@@ -188,6 +201,9 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
         (None, Some(expected)) => {
             // The assertion is unverifiable here, so it cannot be trusted to
             // clear a branch that plausibly *is* a default branch.
+            if let Some(err) = empty_remote_refusal(&args.remote) {
+                return Err(err);
+            }
             if WELL_KNOWN_DEFAULT_BRANCHES.contains(&branch.as_str()) {
                 return Err(CliError::data(
                     "default-branch-unverifiable",
@@ -207,6 +223,9 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
             expected.clone()
         }
         (None, None) => {
+            if let Some(err) = empty_remote_refusal(&args.remote) {
+                return Err(err);
+            }
             return Err(CliError::data(
                 "default-branch-unresolved",
                 format!(
@@ -262,10 +281,11 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
                 .unwrap_or_default(),
             refspec,
             head,
-            default_branch,
+            default_branch: Some(default_branch),
             pushed: false,
             dry_run: true,
             created_remote_branch,
+            bootstrapped: false,
             upstream,
             forced: args.force_with_lease,
         });
@@ -294,12 +314,133 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
         remote: args.remote.clone(),
         refspec,
         head,
-        default_branch,
+        default_branch: Some(default_branch),
         pushed: true,
         dry_run: false,
         created_remote_branch,
+        bootstrapped: false,
         upstream,
         forced: args.force_with_lease,
+    })
+}
+
+/// Whether the remote advertises no refs at all.
+///
+/// `None` means the question could not be answered — the remote was
+/// unreachable, or Git failed for some other reason — and the caller must not
+/// read that as either answer.
+fn remote_has_no_refs(remote: &str) -> Option<bool> {
+    // `ls-remote` is the only way to know: a fresh clone also has no
+    // remote-tracking refs, so local state cannot tell an empty remote from an
+    // unfetched one.
+    let output = git_output_optional(&["ls-remote", "--quiet", remote])?;
+    Some(String::from_utf8_lossy(&output.stdout).trim().is_empty())
+}
+
+/// The refusal to raise when a push failed to resolve a default branch only
+/// because the remote has none yet.
+///
+/// Returning the generic "cache the remote head" hint here would send the
+/// caller to `git remote set-head --auto`, which cannot succeed against a
+/// remote that has no HEAD to read.
+fn empty_remote_refusal(remote: &str) -> Option<CliError> {
+    if remote_has_no_refs(remote) != Some(true) {
+        return None;
+    }
+    Some(
+        CliError::data(
+            "remote-has-no-branches",
+            format!("remote '{remote}' has no branches yet, so it has no default branch"),
+        )
+        .with_hint(
+            "pass `--bootstrap` to publish the checked-out branch as this \
+             remote's first branch; caching the remote head cannot work until \
+             one exists",
+        ),
+    )
+}
+
+/// Publish the checked-out branch as the first branch of an empty remote.
+///
+/// The safety argument is the emptiness itself, checked against the remote
+/// rather than inferred from local state, so it does not depend on the branch
+/// name or on any cached head. Nothing is forced: if the remote gained a ref
+/// between the check and the push, Git rejects the non-fast-forward and the
+/// operation fails closed.
+fn bootstrap_branch(args: &PushArgs, branch: String) -> Result<PushOutput, CliError> {
+    match remote_has_no_refs(&args.remote) {
+        Some(true) => {}
+        Some(false) => {
+            return Err(CliError::data(
+                "bootstrap-remote-not-empty",
+                format!(
+                    "remote '{}' already has refs, so this is not a bootstrap publish",
+                    args.remote
+                ),
+            )
+            .with_hint(
+                "drop `--bootstrap`; the ordinary publish path proves the \
+                 destination against the remote's default branch",
+            ));
+        }
+        None => {
+            return Err(CliError::runtime(
+                "remote-unreadable",
+                format!("cannot list the refs of remote '{}'", args.remote),
+            )
+            .with_hint(
+                "`--bootstrap` publishes only against a remote proven empty, \
+                 so an unreachable remote is refused",
+            ));
+        }
+    }
+
+    let head = git_stdout_trimmed(&["rev-parse", "HEAD"]).map_err(|err| {
+        CliError::runtime("head-unresolved", summarize_git_error(&err.to_string()))
+    })?;
+    let refspec = format!("refs/heads/{branch}:refs/heads/{branch}");
+    let upstream = format!("{}/{branch}", args.remote);
+
+    if args.dry_run {
+        return Ok(PushOutput {
+            remote_branch: branch.clone(),
+            branch,
+            remote: args.remote.clone(),
+            refspec,
+            head,
+            default_branch: None,
+            pushed: false,
+            dry_run: true,
+            created_remote_branch: true,
+            bootstrapped: true,
+            upstream,
+            forced: false,
+        });
+    }
+
+    let mut argv: Vec<&str> = vec!["push", "--quiet"];
+    if !upstream_is_own_ref(&args.remote, &branch) {
+        argv.push("--set-upstream");
+    }
+    argv.push(&args.remote);
+    argv.push(&refspec);
+    git_output(&argv).map_err(|err| {
+        CliError::runtime("git-push-failed", summarize_git_error(&err.to_string()))
+    })?;
+
+    Ok(PushOutput {
+        remote_branch: branch.clone(),
+        branch,
+        remote: args.remote.clone(),
+        refspec,
+        head,
+        default_branch: None,
+        pushed: true,
+        dry_run: false,
+        created_remote_branch: true,
+        bootstrapped: true,
+        upstream,
+        forced: false,
     })
 }
 
@@ -725,6 +866,7 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
     let mut remote = DEFAULT_REMOTE.to_string();
     let mut expect_default = None;
     let mut force_with_lease = false;
+    let mut bootstrap = false;
     let mut dry_run = false;
 
     let mut index = 0usize;
@@ -748,6 +890,10 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
             }
             "--force-with-lease" => {
                 force_with_lease = true;
+                index += 1;
+            }
+            "--bootstrap" => {
+                bootstrap = true;
                 index += 1;
             }
             "--dry-run" => {
@@ -776,10 +922,36 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
             "--expect-default requires a branch name",
         ));
     }
+    // A bootstrap publish creates the remote's first ref. There is no default
+    // branch to name and no prior value to lease against, so a flag that speaks
+    // to either one is a contradiction rather than a no-op.
+    if bootstrap {
+        if expect_default.is_some() {
+            return Err(CliError::usage(
+                "bootstrap-conflicting-flag",
+                "--bootstrap cannot be combined with --expect-default",
+            )
+            .with_hint(
+                "an empty remote has no default branch to name; drop \
+                 `--expect-default`",
+            ));
+        }
+        if force_with_lease {
+            return Err(CliError::usage(
+                "bootstrap-conflicting-flag",
+                "--bootstrap cannot be combined with --force-with-lease",
+            )
+            .with_hint(
+                "a bootstrap publish only ever creates a ref, so there is \
+                 nothing to force; drop `--force-with-lease`",
+            ));
+        }
+    }
 
     Ok(PushArgs {
         remote,
         expect_default,
+        bootstrap,
         force_with_lease,
         dry_run,
         format,
@@ -851,7 +1023,7 @@ fn take_value(args: &[String], index: usize, flag: &str) -> Result<String, CliEr
 
 fn print_push_help() {
     println!(
-        "Usage: git-cli push [--remote <name>] [--expect-default <branch>] [--force-with-lease] [--dry-run] [--format text|json]"
+        "Usage: git-cli push [--remote <name>] [--expect-default <branch>] [--bootstrap] [--force-with-lease] [--dry-run] [--format text|json]"
     );
     println!("  Publish the checked-out branch to its own branch on <remote> (default: origin).");
     println!("  Refuses the remote's default branch; that is `forge-cli repo push-default`'s job.");
@@ -859,6 +1031,7 @@ fn print_push_help() {
     println!(
         "  --expect-default names the default branch when `refs/remotes/<remote>/HEAD` is not cached."
     );
+    println!("  --bootstrap publishes the first branch of a remote proven to have no refs at all.");
 }
 
 fn print_sync_help() {

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -364,9 +364,16 @@ fn empty_remote_refusal(remote: &str) -> Option<CliError> {
 ///
 /// The safety argument is the emptiness itself, checked against the remote
 /// rather than inferred from local state, so it does not depend on the branch
-/// name or on any cached head. Nothing is forced: if the remote gained a ref
-/// between the check and the push, Git rejects the non-fast-forward and the
-/// operation fails closed.
+/// name or on any cached head.
+///
+/// The emptiness check and the push are two round trips, and a plain push would
+/// not close the gap between them: if the remote gained this branch in between,
+/// a plain push *fast-forwards* it rather than refusing, which is exactly the
+/// default-branch write this command must never make. The push therefore
+/// carries a create-only lease — `--force-with-lease=refs/heads/<branch>:` with
+/// an empty expected value, which Git admits only when the ref does not exist.
+/// It can create and can never overwrite, so the operation stays create-only
+/// even under a concurrent writer.
 fn bootstrap_branch(args: &PushArgs, branch: String) -> Result<PushOutput, CliError> {
     match remote_has_no_refs(&args.remote) {
         Some(true) => {}
@@ -418,7 +425,8 @@ fn bootstrap_branch(args: &PushArgs, branch: String) -> Result<PushOutput, CliEr
         });
     }
 
-    let mut argv: Vec<&str> = vec!["push", "--quiet"];
+    let lease = create_only_lease(&branch);
+    let mut argv: Vec<&str> = vec!["push", "--quiet", &lease];
     if !upstream_is_own_ref(&args.remote, &branch) {
         argv.push("--set-upstream");
     }
@@ -440,8 +448,15 @@ fn bootstrap_branch(args: &PushArgs, branch: String) -> Result<PushOutput, CliEr
         created_remote_branch: true,
         bootstrapped: true,
         upstream,
+        // The lease can only create, never overwrite, so nothing was forced.
         forced: false,
     })
+}
+
+/// A `--force-with-lease` whose expected value is empty, which Git admits only
+/// when the named ref does not exist yet.
+fn create_only_lease(branch: &str) -> String {
+    format!("--force-with-lease=refs/heads/{branch}:")
 }
 
 // ---------------------------------------------------------- sync-default
@@ -1062,6 +1077,22 @@ fn print_sync_branch_help() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The empty expected value is the whole point: Git admits the push only
+    /// when the ref does not exist, so a bootstrap can create and can never
+    /// overwrite. A plain push would fast-forward an existing branch instead,
+    /// which is the one write this command must never make.
+    #[test]
+    fn bootstrap_lease_is_create_only() {
+        assert_eq!(
+            create_only_lease("main"),
+            "--force-with-lease=refs/heads/main:"
+        );
+        assert_eq!(
+            create_only_lease("feat/topic"),
+            "--force-with-lease=refs/heads/feat/topic:"
+        );
+    }
 
     #[test]
     fn push_args_default_to_origin_and_no_mutation_modifiers() {

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -329,6 +329,144 @@ fn push_expect_default_still_refuses_the_default_branch() {
     );
 }
 
+/// A repository with `origin` wired to a remote that has never been pushed to,
+/// which is the shape of a freshly created repository on a provider.
+fn repo_with_empty_remote() -> (TempDir, TempDir) {
+    let repo = init_repo();
+    let remote = init_bare_remote();
+    let remote_path = remote.path().to_string_lossy().to_string();
+    git(repo.path(), &["remote", "add", "origin", &remote_path]);
+    (repo, remote)
+}
+
+#[test]
+fn push_bootstrap_publishes_the_first_branch_of_an_empty_remote() {
+    // An empty remote has no default branch to move, so publishing its first
+    // branch is safe by construction — and it is the one thing no governed
+    // surface could do before.
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_empty_remote();
+    let head = rev_parse(repo.path(), "HEAD");
+
+    let output = harness.run(repo.path(), &["push", "--bootstrap", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["data"]["branch"], "main");
+    assert_eq!(json["data"]["refspec"], "refs/heads/main:refs/heads/main");
+    assert_eq!(json["data"]["bootstrapped"], true);
+    assert_eq!(json["data"]["created_remote_branch"], true);
+    // There is no default branch yet, and reporting one would be a guess.
+    assert_eq!(json["data"]["default_branch"], Value::Null);
+    assert_eq!(
+        git(remote.path(), &["rev-parse", "refs/heads/main"]).trim(),
+        head
+    );
+    // The upstream is set, so the follow-up work needs no second decision.
+    assert_eq!(
+        git_config_optional(repo.path(), "branch.main.remote").as_deref(),
+        Some("origin")
+    );
+}
+
+#[test]
+fn push_bootstrap_publishes_a_feature_branch_of_an_empty_remote() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_empty_remote();
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/topic"],
+    );
+    commit_file(repo.path(), "topic.txt", "one\n", "add topic");
+
+    let output = harness.run(repo.path(), &["push", "--bootstrap", "--format", "json"]);
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+    assert_eq!(parse_json(&output)["data"]["branch"], "feat/topic");
+    assert!(
+        git_output(remote.path(), &["rev-parse", "refs/heads/feat/topic"])
+            .status
+            .success()
+    );
+}
+
+#[test]
+fn push_bootstrap_refuses_a_remote_that_already_has_refs() {
+    // The emptiness claim is checked against the remote itself, not inferred
+    // from missing local remote-tracking refs, which a fresh clone also lacks.
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_published_main();
+    git(
+        repo.path(),
+        &["checkout", "-q", "--no-track", "-b", "feat/topic"],
+    );
+    commit_file(repo.path(), "topic.txt", "one\n", "add topic");
+
+    let output = harness.run(repo.path(), &["push", "--bootstrap", "--format", "json"]);
+    assert_ne!(output.code, 0);
+    let json = parse_json(&output);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error"]["code"], "bootstrap-remote-not-empty");
+}
+
+#[test]
+fn push_bootstrap_rejects_flags_that_contradict_a_create_only_publish() {
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_empty_remote();
+
+    for flags in [
+        vec!["push", "--bootstrap", "--expect-default", "main"],
+        vec!["push", "--bootstrap", "--force-with-lease"],
+    ] {
+        let mut argv = flags.clone();
+        argv.extend_from_slice(&["--format", "json"]);
+        let output = harness.run(repo.path(), &argv);
+        assert_ne!(output.code, 0, "flags: {flags:?}");
+        assert_eq!(
+            parse_json(&output)["error"]["code"],
+            "bootstrap-conflicting-flag",
+            "flags: {flags:?}"
+        );
+    }
+}
+
+#[test]
+fn push_on_an_empty_remote_names_the_bootstrap_route() {
+    // Without this the refusal sends the caller to `git remote set-head
+    // --auto`, which cannot succeed against a remote that has no HEAD.
+    let harness = GitCliHarness::new();
+    let (repo, _remote) = repo_with_empty_remote();
+
+    let output = harness.run(repo.path(), &["push", "--format", "json"]);
+    assert_ne!(output.code, 0);
+    let json = parse_json(&output);
+    assert_eq!(json["error"]["code"], "remote-has-no-branches");
+    let hint = json["error"]["hint"].as_str().unwrap_or_default();
+    assert!(hint.contains("--bootstrap"), "hint was: {hint}");
+}
+
+#[test]
+fn push_dry_run_bootstrap_reports_without_publishing() {
+    let harness = GitCliHarness::new();
+    let (repo, remote) = repo_with_empty_remote();
+
+    let output = harness.run(
+        repo.path(),
+        &["push", "--bootstrap", "--dry-run", "--format", "json"],
+    );
+    assert_eq!(output.code, 0, "stderr: {}", output.stderr_text());
+    let json = parse_json(&output);
+    assert_eq!(json["data"]["pushed"], false);
+    assert_eq!(json["data"]["dry_run"], true);
+    assert_eq!(json["data"]["bootstrapped"], true);
+    assert!(
+        !git_output(remote.path(), &["rev-parse", "refs/heads/main"])
+            .status
+            .success(),
+        "dry run must not publish"
+    );
+}
+
 // -------------------------------------------------------- sync-default
 
 /// Advance the remote's default branch by one commit, from a scratch clone, so


### PR DESCRIPTION
## Summary

A remote that advertises no refs has no default branch, so publishing its first
branch cannot move one. Nothing in `git-cli push` could establish that, and every
refusal it offered named a step that cannot succeed there — so a repository
created from an agent session could not receive its first branch through any
governed surface, `main` or otherwise.

Preconditions: a local repository with history, `origin` pointing at a remote that
has never been pushed to, so no remote-tracking refs and no cached
`refs/remotes/origin/HEAD` exist.

| Attempt | Result |
| --- | --- |
| `git-cli push` | `default-branch-unresolved` — hint: run `git remote set-head origin --auto`, or pass `--expect-default` |
| `git remote set-head origin --auto` | `error: Cannot determine remote HEAD` — an empty remote has no HEAD to read |
| `git-cli push --expect-default main` | `default-branch-unverifiable` — "`--expect-default` cannot admit this push"; hint is `set-head --auto` again |
| `forge-cli repo push-default --dry-run` | `provider returned an invalid default branch ref` |
| raw `git push origin main:main` | refused by the `block-unsafe-default-delivery` hook |

Each hint names a step that cannot succeed in the situation that produced it, so
the guidance forms a closed loop. `forge-cli repo push-default` could not serve
here even with the ref resolved: by contract it delivers exactly one signed commit
against an exact expected remote base, and an initial import is an unbounded
history against no base at all. The scope was wider than the default branch — on
an empty remote no branch of any name could be published.

`--bootstrap` publishes the checked-out branch to a remote proven empty. The proof
is `git ls-remote` against the remote itself, never inferred from missing
remote-tracking refs, which a fresh clone also lacks. Emptiness that cannot be
established is `remote-unreadable`, not an assumption. The push is an ordinary
create-only push with no force of any kind, so a remote that gained a ref between
the check and the push is rejected as a non-fast-forward.

Because there is no default branch and no prior value to lease against,
`--expect-default` and `--force-with-lease` are refused alongside it rather than
silently ignored. `default_branch` is `null` in the result, and `bootstrapped` is
`true`. The ordinary path also learned to diagnose this: when it fails only
because the remote is empty it reports `remote-has-no-branches` and names the
bootstrap route, instead of the generic hint to cache a remote head that cannot
exist yet.

Paired with sympoies/agent-runtime-kit#62, which fixes three defects in the
delivery hook's default-branch resolution found in the same investigation. This PR
is the remaining item, and it is the only one that could be fixed here.

## Issues

- Closes sympoies/nils-cli#1539.
- Paired with sympoies/agent-runtime-kit#62 (the delivery-hook half of the same
  investigation) and sympoies/agent-runtime-kit#61 item 1, which this PR is the
  fix for. The runtime-kit error-inbox entry
  `empty-remote-has-no-governed-first-push` stays open until this lands and the
  nils-cli pin moves.

## Changes

- `crates/git-cli/src/publish.rs` — `--bootstrap` flag; `bootstrap_branch()`;
  `remote_has_no_refs()`, returning `Option<bool>` so "the remote says it has no
  refs" is never confused with "the question could not be answered";
  `empty_remote_refusal()`, consulted on both uncached refusal paths so
  `default-branch-unresolved` and `default-branch-unverifiable` keep their meaning
  for a remote that has branches; nullable `default_branch`; new `bootstrapped`
  field; help text.
- `crates/git-cli/tests/integration/publish.rs` — six new tests and a
  `repo_with_empty_remote()` fixture.
- `crates/git-cli/docs/specs/git-cli-remote-surfaces.md` — a `--bootstrap`
  section, four new refusal codes, and the updated JSON contract.
- `crates/git-cli/README.md` — the flag in the `push` surface summary.

`push_branch()` short-circuits to `bootstrap_branch()` before the default-branch
resolution, because that resolution is exactly what cannot be satisfied here. The
publish reuses the same pinned `refs/heads/<branch>:refs/heads/<branch>` refspec
and upstream logic as the ordinary path.

The emptiness check and the push are two round trips, and a plain push does not
close the gap between them. Verified against git 2.50.1: when the remote gains
the branch in that window, a plain push **fast-forwards** it rather than
refusing — which is precisely the default-branch write this command must never
make. The push therefore carries `--force-with-lease=refs/heads/<branch>:`, an
empty expected value that Git admits only when the ref does not exist. It can
create and can never overwrite, so `forced` stays `false`. (An earlier revision
of this PR argued the lease was redundant; that was wrong, and the probe above is
what corrected it.)
Both `empty_remote_refusal()` call sites are error paths, so the happy path gains
no network probe. `Some(name)` serializes exactly as `default_branch` did before,
so existing consumers are unaffected; `null` appears only alongside
`bootstrapped: true`.

## Test-First Evidence

Six integration tests were written first and failed red before the
implementation — `unknown-argument` for `--bootstrap`, and
`default-branch-unresolved` where `remote-has-no-branches` was expected
(`21 passed; 6 failed`). They cover the default-branch bootstrap, a feature-branch
bootstrap, refusal on a populated remote, refusal of `--expect-default` and
`--force-with-lease` alongside `--bootstrap`, the improved diagnosis on the
ordinary path, and a dry run that reports without publishing.

No existing test was materially affected: every prior publish fixture wires a
remote with `main` already published, so none asserted anything about an empty
remote, and the nullable `default_branch` is additive.

## Test plan

- `cargo test -p nils-git-cli --test integration publish::` — 27 pass, the 21
  pre-existing ones unchanged.
- `cargo test -p nils-git-cli` — 157 lib + 27 publish integration tests pass,
  including `bootstrap_lease_is_create_only`.
- Race semantics probed directly against git 2.50.1: create-only lease into an
  empty remote succeeds; a plain push fast-forwards a ref that appeared in the
  window; the same lease rejects it as `stale info`.
- `cargo fmt --all -- --check`, `cargo clippy -p nils-git-cli --all-targets
  --all-features -- -D warnings`, `cargo test -p nils-git-cli --doc`,
  `docs-placement-audit.sh --strict`, `docs-hygiene-audit.sh --strict`, and the
  three tempdir-leak audits all pass.
- Manual end-to-end against real repositories: an empty bare remote reports
  `remote-has-no-branches` on the ordinary path, `--bootstrap` publishes `main`
  and sets the upstream, the remote then holds `refs/heads/main` at the expected
  head, a second `--bootstrap` is refused as `bootstrap-remote-not-empty`, and
  `git remote set-head origin --auto` then succeeds — the whole loop closes.

`scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` cannot run on this host:
it aborts with `local_fast_args[@]: unbound variable`, a bash 3.2 empty-array
expansion under `set -u`. It reproduces identically on clean `main`
(`docs-placement-audit.sh` fails the same way there), so each check above was run
directly under bash 5.3 instead. Worth its own issue; not caused by this change.

## Risk / Notes

- The bootstrap path performs one live `ls-remote` before publishing, including
  under `--dry-run`, so the dry run reports the real answer. It is the only new
  network call, and it is confined to `--bootstrap` plus the two refusal paths.
- Widening `push` to reach a branch it previously refused is the point of the
  change, so the guard is the emptiness proof. It is checked against the remote
  and refuses when unprovable, and it cannot be asserted by the caller the way
  `--expect-default` can.
- `PushOutput.default_branch` is now nullable. This is additive for consumers
  reading a name, and `null` only ever appears with `bootstrapped: true`.
