### PR TITLE
fix(agent-hook): admit read-only remote queries

### DIFF
--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -2598,7 +2598,7 @@ fn unsafe_default_delivery(
     Ok(false)
 }
 
-fn read_only_git_invocation(subcommand: &str, _action: &[String]) -> bool {
+fn read_only_git_invocation(subcommand: &str, action: &[String]) -> bool {
     matches!(
         subcommand,
         "blame"
@@ -2628,7 +2628,33 @@ fn read_only_git_invocation(subcommand: &str, _action: &[String]) -> bool {
             | "verify-commit"
             | "verify-tag"
             | "whatchanged"
-    )
+    ) || (subcommand == "remote" && read_only_git_remote_invocation(action))
+}
+
+fn read_only_git_remote_invocation(action: &[String]) -> bool {
+    if action
+        .iter()
+        .all(|word| matches!(word.as_str(), "-v" | "--verbose"))
+    {
+        return true;
+    }
+    let Some(("get-url", query)) = action
+        .split_first()
+        .map(|(command, rest)| (command.as_str(), rest))
+    else {
+        return false;
+    };
+    let mut names = 0;
+    for word in query {
+        if matches!(word.as_str(), "--push" | "--all") {
+            continue;
+        }
+        if word.starts_with('-') {
+            return false;
+        }
+        names += 1;
+    }
+    names == 1
 }
 
 fn branch_reset_targets_default(subcommand: &str, action: &[String], default: &str) -> bool {

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -1694,6 +1694,64 @@ fn unsafe_default_delivery_blocks_default_branch_and_allows_feature_refs() {
 }
 
 #[test]
+fn unsafe_default_delivery_allows_read_only_remote_queries_without_default_evidence() {
+    let fixture = Fixture::new(&policy("block-unsafe-default-delivery", "dsh"));
+    git(&fixture, &["init", "--quiet", "--initial-branch=main"]);
+    git(
+        &fixture,
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://example.com/sympoies/example.git",
+        ],
+    );
+
+    for command in [
+        "git remote",
+        "git remote -v",
+        "git remote --verbose",
+        "git remote get-url origin",
+        "git remote get-url --push --all origin",
+    ] {
+        let output = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request(&fixture, "bash", json!({"command": command}))),
+        );
+
+        assert_eq!(
+            output.code,
+            0,
+            "read-only remote query must not require default-branch evidence: command={command} envelope={}",
+            output.stdout_text()
+        );
+        assert_eq!(output.stdout_json()["data"]["action"], "allow");
+    }
+
+    for command in [
+        "git remote add backup https://example.com/sympoies/backup.git",
+        "git remote remove origin",
+        "git remote rename origin upstream",
+        "git remote set-url origin https://example.com/sympoies/other.git",
+        "git remote prune origin",
+        "git remote update",
+    ] {
+        let output = fixture.run(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request(&fixture, "bash", json!({"command": command}))),
+        );
+
+        assert_eq!(
+            output.code,
+            1,
+            "remote mutation must remain fail-closed without default-branch evidence: command={command} envelope={}",
+            output.stdout_text()
+        );
+        assert_eq!(output.stdout_json()["data"]["action"], "block");
+    }
+}
+
+#[test]
 fn unsafe_default_delivery_preserves_governed_recovery_and_feature_worktrees() {
     let fixture = Fixture::new(&policy("block-unsafe-default-delivery", "dsh"));
     git(&fixture, &["init", "--quiet", "--initial-branch=main"]);


### PR DESCRIPTION
## Summary

Classify the commonly used `git remote` listing and constrained `get-url` forms as read-only so DSH repository inspection is not stopped by the protected-default delivery guard.

## Problem

- Expected: `git remote`, `git remote -v`, and constrained `git remote get-url` queries are admitted as read-only inspection without protected-default delivery evidence.
- Actual: the whole `remote` subcommand was treated as potentially mutating, so a fresh DSH baseline command failed before dispatch.
- Impact: agents could not complete ordinary repository inspection and had to infer whether the failure was about inspection, delivery, or workspace ownership.

## Reproduction

1. Initialize a repository whose protected default cannot be inferred from remote evidence.
2. Dispatch `git remote -v` through the DSH agent-hook policy.
3. Observe `agent-hook:block-unsafe-default-delivery` before command dispatch.

## Issues Found

- Refs serenvia/sympoies-infra#213

## Fix Approach

- Admit only remote listing, `-v` / `--verbose`, and `get-url` with one remote name plus optional `--push` / `--all` flags.
- Keep `add`, `remove`, `rename`, `set-url`, `prune`, `update`, unknown flags, and other remote forms fail-closed.

## Test-First Evidence

- RED: the new focused regression failed with exit 101 because `git remote` returned `agent-hook:block-unsafe-default-delivery`.
- GREEN: the focused regression passes for safe query forms and proves the listed mutation forms remain blocked.
- Durable evidence is bound to baseline `c67c92fb499b8525c4a11a3951c4e9acc6c065ea` and delivered head `96466f0926b18582bff3f0d07e5619790dc8b1bd`.

## Test plan

- `cargo test -p nils-agent-hook unsafe_default_delivery_allows_read_only_remote_queries_without_default_evidence -- --nocapture`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- Public repository CI through the normal GitHub Actions workflow.

## Risk / Notes

- Low and bounded: the parser admits an explicit set of non-mutating forms; unrecognized or mutating remote operations remain denied.
