### PR TITLE
fix(agent-session): bound serve send-key and title-ref allocations

### DIFF
--- a/crates/agent-session/docs/specs/serve-api-v1.md
+++ b/crates/agent-session/docs/specs/serve-api-v1.md
@@ -452,6 +452,11 @@ recorded in `sympoies/nils-cli#1409`.
   structured state if an older writer changed only the compatibility title.
   Session and glance responses advertise `title_state_supported: true` independently of whether that session already
   has structured state, allowing upgraded clients to migrate title-only records conservatively.
+- `POST /sessions/{id}/send` accepts at most 64 entries in `keys`; a longer list is
+  rejected with `400 too-many-keys` and a `limit` detail before the daemon sizes any
+  allocation from the request. Every accepted name resolves to one of the nine
+  canonical `SpecialKey` values, so the bound is far above any real caller. An
+  unknown name still fails the whole request with `400 invalid-key`.
 - Attachment upload uses a raw binary request body (not multipart), capped at 25 MiB. The daemon writes the file under the
   session's private `attachments/` directory with a sanitized filename and returns the remote path in the serve envelope.
   Empty or null titles clear the custom session title so clients can fall back to the session id.

--- a/crates/agent-session/src/lib.rs
+++ b/crates/agent-session/src/lib.rs
@@ -10389,7 +10389,7 @@ fn normalize_title_state(mut state: SessionTitleState) -> Result<SessionTitleSta
             Some(json!({ "field": "title_state.references" })),
         ));
     }
-    let mut normalized_references = Vec::with_capacity(state.references.len());
+    let mut normalized_references = Vec::with_capacity(SESSION_TITLE_MAX_REFERENCES);
     for reference in state.references {
         let reference = reference.trim_matches(is_javascript_whitespace).to_string();
         let number = reference.strip_prefix('#').unwrap_or_default();
@@ -18951,6 +18951,29 @@ exit 97
 
         assert_eq!(err.0.code, "invalid-title-state");
         assert_eq!(consumed.get(), super::SESSION_TITLE_MAX_CHARS + 1);
+    }
+
+    /// The reference list is remote input on `POST /sessions`, and the
+    /// normalized-reference allocation is sized from
+    /// `SESSION_TITLE_MAX_REFERENCES`. Keep the guard that makes that bound
+    /// true under test. `sympoies/nils-cli#1542`.
+    #[test]
+    fn structured_title_rejects_references_past_the_supported_bound() {
+        let references = (0..=super::SESSION_TITLE_MAX_REFERENCES)
+            .map(|index| format!("#{}", index + 1))
+            .collect::<Vec<_>>();
+        let state = super::SessionTitleState {
+            topic: None,
+            topic_source: super::SessionTitleTopicSource::None,
+            references,
+            activity: None,
+            extra: std::collections::BTreeMap::new(),
+        };
+
+        let err = super::normalize_title_state(state)
+            .expect_err("one reference past the bound must be rejected");
+
+        assert_eq!(err.0.code, "invalid-title-state");
     }
 
     #[test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -110,6 +110,13 @@ const PROVIDER_PROMPT_DISCOVERY_MAX_CONCURRENT_SCANS: usize = 4;
 const PROVIDER_PROMPT_RECOVERY_MAX_CONCURRENT_SCANS: usize = 2;
 const MAX_CONCURRENT_AUTO_RESUME_TICKS: usize = 4;
 const MAX_AGENT_LAUNCH_PROFILES: usize = 16;
+/// Upper bound on the `keys` list a single `send` request may carry.
+///
+/// The list is remote input whose length is otherwise bounded only by the Axum
+/// body limit, and it is what sizes the handler's key allocation. Every accepted
+/// name resolves to one of nine `SpecialKey` variants, so this is far above any
+/// real caller while keeping the allocation bounded by a constant.
+const MAX_SEND_KEYS: usize = 64;
 const AGENT_LAUNCH_PROFILE_READINESS_TIMEOUT: Duration = Duration::from_secs(2);
 #[cfg(test)]
 std::thread_local! {
@@ -4539,7 +4546,14 @@ async fn send_handler(
     if let Some(resp) = deny_unauthorized(&state, &headers) {
         return resp;
     }
-    let mut keys = Vec::with_capacity(body.keys.len());
+    if body.keys.len() > MAX_SEND_KEYS {
+        return envelope_err(CliError::usage(
+            "too-many-keys",
+            format!("send accepts at most {MAX_SEND_KEYS} keys per request"),
+            Some(json!({ "limit": MAX_SEND_KEYS })),
+        ));
+    }
+    let mut keys = Vec::with_capacity(MAX_SEND_KEYS.min(body.keys.len()));
     for name in &body.keys {
         match SpecialKey::from_name(name) {
             Some(key) => keys.push(key),
@@ -16019,6 +16033,57 @@ esac
         .await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert_eq!(body["error"]["code"], "invalid-key");
+    }
+
+    /// A `send` body's key list is remote input whose length is bounded only by
+    /// the Axum body limit, so the handler must reject an oversized list before
+    /// it sizes any allocation from it. Every accepted name maps to one of nine
+    /// `SpecialKey` variants, so a request carrying more than
+    /// `MAX_SEND_KEYS` names is never a real caller.
+    /// `sympoies/nils-cli#1542`.
+    #[tokio::test]
+    async fn send_rejects_a_key_list_past_the_allocation_bound() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let tmux = minimal_tmux(tmp.path());
+        seed_session(tmp.path(), "steer", "codex", "hs-codex-steer");
+        let st = state(tmp.path(), Some(TOKEN), tmux);
+
+        let keys = vec![json!("enter"); MAX_SEND_KEYS + 1];
+        let (status, body) = call(
+            router(st.clone()),
+            post_json("/sessions/steer/send", Some(TOKEN), json!({ "keys": keys })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "body={body}");
+        assert_eq!(body["error"]["code"], "too-many-keys");
+        assert_eq!(body["error"]["details"]["limit"], MAX_SEND_KEYS);
+    }
+
+    /// The bound must admit the whole documented range: a request at exactly the
+    /// limit is still a legitimate caller. `sympoies/nils-cli#1542`.
+    #[tokio::test]
+    async fn send_admits_a_key_list_at_the_allocation_bound() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let tmux = minimal_tmux(tmp.path());
+        seed_session(tmp.path(), "steer", "codex", "hs-codex-steer");
+        let st = state(tmp.path(), Some(TOKEN), tmux);
+
+        let keys = vec![json!("enter"); MAX_SEND_KEYS];
+        let (status, body) = call(
+            router(st.clone()),
+            post_json("/sessions/steer/send", Some(TOKEN), json!({ "keys": keys })),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "body={body}");
+        assert_eq!(
+            body["data"]["sent"]["keys"]
+                .as_array()
+                .map(Vec::len)
+                .unwrap_or_default(),
+            MAX_SEND_KEYS
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Resolves the two real findings from the CodeQL triage in #1542. Both are
`rust/uncontrolled-allocation-size` on `agent-session`; the other 48 alerts are
verified false positives and are dismissed against the triage table recorded in that
issue.

### `POST /sessions/{id}/send` — unbounded allocation from a remote array length

`send_handler` sized its key allocation from `body.keys.len()`. That length is remote
input on a bearer-gated write route, bounded only by Axum's default 2 MiB body limit,
so a single request could force a large allocation. Every accepted name resolves to
one of nine `SpecialKey` variants, so the useful result was never large even when the
capacity was.

The handler now rejects a list past `MAX_SEND_KEYS` (64) with `400 too-many-keys` and
a `limit` detail *before* sizing anything, and derives the capacity from that bound.
64 is far above any real caller — the common case is a single `enter`.

This adds one client-visible error code to a documented route, so
`serve-api-v1.md` records the bound alongside the existing 25 MiB attachment cap.

### Title-state references — bound not local to the allocation

`normalize_title_state` allocated `Vec::with_capacity(state.references.len())` nine
lines after the guard that rejects `state.references.len() > SESSION_TITLE_MAX_REFERENCES`
(= 2). Not exploitable, but the bound was not visible at the allocation site. The
capacity now comes from the constant.

## Test plan

- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — 1187 tests pass.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --docs-only` — docs placement,
  hygiene, markdownlint, CLI output contract all pass.
- New coverage, each written before the fix:
  - `send_rejects_a_key_list_past_the_allocation_bound` — captured the defect first:
    at `MAX_SEND_KEYS + 1` the pre-fix handler answered `200 OK` and forwarded all 65
    keys to tmux. Now `400 too-many-keys` with `details.limit`.
  - `send_admits_a_key_list_at_the_allocation_bound` — exactly `MAX_SEND_KEYS`
    is still delivered, so the bound does not clip a legitimate caller.
  - `structured_title_rejects_references_past_the_supported_bound` — the guard the
    reference allocation now depends on had no direct test; it does now.
- CodeQL re-runs on this head. Alerts #82 and #83 must not reappear.

## Notes for the reviewer

- The title-state change is a no-op on behavior: the guard above it already made
  `references.len() <= 2` true at that point. It has no separate regression test
  because there is no reachable behavior delta to capture; the new test covers the
  guard that makes the constant correct.
- **Adjacent case, deliberately not in scope.** The attach WebSocket control-frame
  path (`serve.rs`, the `{ "text", "key", "keys", "resize" }` handler) also builds a
  `Vec<SpecialKey>` from an untrusted `keys` array. It differs from the fixed defect —
  it uses `filter_map(...).collect()` with no `with_capacity`, so it grows only for
  names that actually parse, and CodeQL does not flag it — but its length is bounded
  only by the tungstenite message limit rather than by a domain bound. Left alone here
  to keep this PR to the two triaged alerts; noted on #1542 so it can be decided on
  its own.

Refs #1542
