### PR TITLE
refactor(git-cli): resolve the default branch only from evidence

### DIFF
--- a/crates/git-cli/README.md
+++ b/crates/git-cli/README.md
@@ -125,8 +125,8 @@ from the primary checkout or from inside any linked worktree.
   unresolvable remote default (`default-branch-unresolved`).
   `--bootstrap` publishes the first branch of a remote proven to have no refs at all, which is
   the one case the default-branch checks can never satisfy.
-  Options: `--remote <name>`, `--expect-default <branch>`, `--bootstrap`, `--force-with-lease`,
-  `--dry-run`, `--format text|json`.
+  Options: `--remote <name>`, `--bootstrap`, `--force-with-lease`, `--dry-run`,
+  `--format text|json`.
 
 ### sync-default
 

--- a/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
+++ b/crates/git-cli/docs/specs/git-cli-remote-surfaces.md
@@ -25,8 +25,8 @@ commands close that gap by making the safe cases provable rather than inferred.
 ## `git-cli push`
 
 ```text
-git-cli push [--remote <name>] [--expect-default <branch>] [--bootstrap]
-             [--force-with-lease] [--dry-run] [--format text|json]
+git-cli push [--remote <name>] [--bootstrap] [--force-with-lease]
+             [--dry-run] [--format text|json]
 ```
 
 Publishes the checked-out branch to the same-named branch on `<remote>`
@@ -51,29 +51,25 @@ Refusals:
 | `error.code` | Condition |
 | --- | --- |
 | `detached-head` | HEAD is not attached to a branch |
-| `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached and no `--expect-default` was given |
-| `default-branch-unverifiable` | the remote head is not cached and the checked-out branch is a conventional default-branch name |
-| `expect-default-mismatch` | `--expect-default` disagrees with the cached remote head |
+| `default-branch-unresolved` | `refs/remotes/<remote>/HEAD` is not cached |
 | `refuse-default-branch` | the checked-out branch is the remote's default branch |
 | `remote-has-no-branches` | the remote advertises no refs, so `--bootstrap` is the route |
 | `bootstrap-remote-not-empty` | `--bootstrap` was passed but the remote already has refs |
-| `bootstrap-conflicting-flag` | `--bootstrap` was combined with `--expect-default` or `--force-with-lease` |
+| `bootstrap-conflicting-flag` | `--bootstrap` was combined with `--force-with-lease` |
 | `remote-unreadable` | `--bootstrap` could not list the remote's refs, so emptiness is unproven |
 | `unknown-remote` | `<remote>` is not configured |
 
-`--expect-default` names what the default branch *is* when the remote HEAD is
-not cached locally, which is the offline path. It is an escape hatch, never a
-second opinion, so it can only ever *add* a refusal:
+The cached remote head is the only admissible source for the default branch.
+A caller-supplied `--expect-default` was accepted here once, for the offline case
+where the head is not cached, guarded by a list of conventional default names.
+That guard only ever stopped the honest caller: `--expect-default main` was
+refused as unverifiable while `--expect-default trunk` cleared the very same
+push, and the caller chose the name. It has been removed rather than hardened,
+because a longer list of names cannot fix an assertion the caller controls.
 
-- when the remote head **is** cached, cached truth wins and a disagreeing
-  assertion is `expect-default-mismatch`;
-- when it is **not** cached, the assertion cannot clear a branch whose name is
-  conventionally a default (`main`, `master`, `trunk`, `develop`,
-  `development`, `default`) — that is `default-branch-unverifiable`.
-
-Without those two rules `--expect-default develop` while standing on `main`
-would publish the default branch, which is the thing this command exists to
-refuse.
+Nothing is lost. An empty remote is `--bootstrap`, and a populated one always has
+a HEAD for `git remote set-head <remote> --auto` to read, so every case the
+escape hatch covered is now either verifiable or explicitly governed.
 
 Pushing the default branch is a delivery decision, not a publish step, so
 `refuse-default-branch` points at `forge-cli repo push-default` rather than
@@ -84,9 +80,8 @@ offering a flag.
 A remote that advertises no refs has no default branch, so publishing its first
 branch cannot move one. That is the single case none of the rules above can
 satisfy: there is nothing to cache, `git remote set-head <remote> --auto` fails
-because the remote has no HEAD to read, `--expect-default` is refused as
-unverifiable for a conventional name, and `forge-cli repo push-default` needs an
-expected base that does not exist. Before `--bootstrap` a newly created
+because the remote has no HEAD to read, and `forge-cli repo push-default` needs
+an expected base that does not exist. Before `--bootstrap` a newly created
 repository could not receive its first branch through any governed surface.
 
 The safety argument is the emptiness, and it is checked against the remote with
@@ -103,8 +98,8 @@ admits only when the ref does not exist. It can create and can never overwrite,
 so the operation stays create-only even under a concurrent writer, and `forced`
 stays `false` in the result because nothing was overwritten.
 
-Because there is no default branch and no prior value to lease against,
-`--expect-default` and `--force-with-lease` are refused alongside it rather than
+A bootstrap publish only ever creates a ref, so a caller-supplied
+`--force-with-lease` is a contradiction and is refused alongside it rather than
 ignored. `default_branch` is `null` in the result, and `bootstrapped` is `true`.
 
 When the ordinary path fails only because the remote is empty, the refusal is

--- a/crates/git-cli/src/publish.rs
+++ b/crates/git-cli/src/publish.rs
@@ -39,16 +39,6 @@ pub fn dispatch(cmd: &str, args: &[String]) -> Option<i32> {
 }
 
 const DEFAULT_REMOTE: &str = "origin";
-/// Branch names conventionally used as a repository default. Used only to refuse
-/// an *unverifiable* push, never to admit one.
-const WELL_KNOWN_DEFAULT_BRANCHES: &[&str] = &[
-    "main",
-    "master",
-    "trunk",
-    "develop",
-    "development",
-    "default",
-];
 const PUSH_DEFAULT_HINT: &str = "pushing the default branch is a delivery decision, not a publish step; use \
      `forge-cli repo push-default` with the expected base and reason file when \
      direct-main delivery was explicitly authorized";
@@ -56,7 +46,6 @@ const PUSH_DEFAULT_HINT: &str = "pushing the default branch is a delivery decisi
 #[derive(Debug)]
 struct PushArgs {
     remote: String,
-    expect_default: Option<String>,
     force_with_lease: bool,
     bootstrap: bool,
     dry_run: bool,
@@ -170,10 +159,6 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
     // default branch is the single fact that has to be established before any
     // mutation, and failing to establish it is a refusal, not a warning.
     //
-    // `--expect-default` is an escape hatch for an uncached remote head, never a
-    // second opinion that can widen admission. Cached truth always wins, and a
-    // disagreeing assertion is a mismatch: otherwise `--expect-default develop`
-    // while standing on `main` would publish the default branch.
     // Publishing the first ref of an empty remote cannot move a default branch,
     // because there is none yet. That is the one case the resolution below can
     // never satisfy, and refusing it left a new repository with no governed way
@@ -182,47 +167,16 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
         return bootstrap_branch(args, branch);
     }
 
-    let default_branch = match (cached_default_branch(&args.remote), &args.expect_default) {
-        (Some(cached), Some(expected)) if cached != *expected => {
-            return Err(CliError::data(
-                "expect-default-mismatch",
-                format!(
-                    "--expect-default '{expected}' disagrees with the cached default \
-                     branch '{cached}' of remote '{}'",
-                    args.remote
-                ),
-            )
-            .with_hint(
-                "drop `--expect-default`; it names the default branch only when the \
-                 remote head is not cached locally",
-            ));
-        }
-        (Some(cached), _) => cached,
-        (None, Some(expected)) => {
-            // The assertion is unverifiable here, so it cannot be trusted to
-            // clear a branch that plausibly *is* a default branch.
-            if let Some(err) = empty_remote_refusal(&args.remote) {
-                return Err(err);
-            }
-            if WELL_KNOWN_DEFAULT_BRANCHES.contains(&branch.as_str()) {
-                return Err(CliError::data(
-                    "default-branch-unverifiable",
-                    format!(
-                        "'{branch}' is a conventional default-branch name and the \
-                         default branch of remote '{}' is not cached, so this push \
-                         cannot be proven safe",
-                        args.remote
-                    ),
-                )
-                .with_hint(format!(
-                    "run `git remote set-head {} --auto` to establish the real \
-                     default branch; `--expect-default` cannot admit this push",
-                    args.remote
-                )));
-            }
-            expected.clone()
-        }
-        (None, None) => {
+    // The cached remote head is the only admissible source. A caller-supplied
+    // name was accepted here once, guarded by a list of conventional default
+    // names, but that guard only ever stopped the caller who answered
+    // truthfully: naming any branch outside the list cleared the push. Now that
+    // an empty remote has `--bootstrap` and a populated one can always answer
+    // `git remote set-head <remote> --auto`, the assertion bought nothing that
+    // was not either verifiable or already covered.
+    let default_branch = match cached_default_branch(&args.remote) {
+        Some(cached) => cached,
+        None => {
             if let Some(err) = empty_remote_refusal(&args.remote) {
                 return Err(err);
             }
@@ -234,8 +188,7 @@ fn push_branch(args: &PushArgs) -> Result<PushOutput, CliError> {
                 ),
             )
             .with_hint(format!(
-                "run `git remote set-head {} --auto` to cache it, or pass \
-                 `--expect-default <branch>` to name it offline",
+                "run `git remote set-head {} --auto` to cache it",
                 args.remote
             )));
         }
@@ -879,7 +832,6 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
     let mut rest: Vec<String> = args.to_vec();
     let format = take_format(&mut rest)?;
     let mut remote = DEFAULT_REMOTE.to_string();
-    let mut expect_default = None;
     let mut force_with_lease = false;
     let mut bootstrap = false;
     let mut dry_run = false;
@@ -893,14 +845,6 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
             }
             value if value.starts_with("--remote=") => {
                 remote = value.trim_start_matches("--remote=").to_string();
-                index += 1;
-            }
-            "--expect-default" => {
-                expect_default = Some(take_value(&rest, index, "--expect-default")?);
-                index += 2;
-            }
-            value if value.starts_with("--expect-default=") => {
-                expect_default = Some(value.trim_start_matches("--expect-default=").to_string());
                 index += 1;
             }
             "--force-with-lease" => {
@@ -931,41 +875,22 @@ fn parse_push_args(args: &[String]) -> Result<PushArgs, CliError> {
             "--remote requires a value",
         ));
     }
-    if expect_default.as_deref() == Some("") {
+    // A bootstrap publish creates the remote's first ref and has no prior value
+    // to lease against, so a caller-supplied force is a contradiction rather
+    // than a no-op.
+    if bootstrap && force_with_lease {
         return Err(CliError::usage(
-            "missing-expect-default",
-            "--expect-default requires a branch name",
+            "bootstrap-conflicting-flag",
+            "--bootstrap cannot be combined with --force-with-lease",
+        )
+        .with_hint(
+            "a bootstrap publish only ever creates a ref, so there is \
+             nothing to force; drop `--force-with-lease`",
         ));
-    }
-    // A bootstrap publish creates the remote's first ref. There is no default
-    // branch to name and no prior value to lease against, so a flag that speaks
-    // to either one is a contradiction rather than a no-op.
-    if bootstrap {
-        if expect_default.is_some() {
-            return Err(CliError::usage(
-                "bootstrap-conflicting-flag",
-                "--bootstrap cannot be combined with --expect-default",
-            )
-            .with_hint(
-                "an empty remote has no default branch to name; drop \
-                 `--expect-default`",
-            ));
-        }
-        if force_with_lease {
-            return Err(CliError::usage(
-                "bootstrap-conflicting-flag",
-                "--bootstrap cannot be combined with --force-with-lease",
-            )
-            .with_hint(
-                "a bootstrap publish only ever creates a ref, so there is \
-                 nothing to force; drop `--force-with-lease`",
-            ));
-        }
     }
 
     Ok(PushArgs {
         remote,
-        expect_default,
         bootstrap,
         force_with_lease,
         dry_run,
@@ -1038,14 +963,11 @@ fn take_value(args: &[String], index: usize, flag: &str) -> Result<String, CliEr
 
 fn print_push_help() {
     println!(
-        "Usage: git-cli push [--remote <name>] [--expect-default <branch>] [--bootstrap] [--force-with-lease] [--dry-run] [--format text|json]"
+        "Usage: git-cli push [--remote <name>] [--bootstrap] [--force-with-lease] [--dry-run] [--format text|json]"
     );
     println!("  Publish the checked-out branch to its own branch on <remote> (default: origin).");
     println!("  Refuses the remote's default branch; that is `forge-cli repo push-default`'s job.");
     println!("  Sets the upstream on first publish, so the branch tracks its own ref.");
-    println!(
-        "  --expect-default names the default branch when `refs/remotes/<remote>/HEAD` is not cached."
-    );
     println!("  --bootstrap publishes the first branch of a remote proven to have no refs at all.");
 }
 
@@ -1100,26 +1022,30 @@ mod tests {
         assert_eq!(parsed.remote, "origin");
         assert!(!parsed.force_with_lease);
         assert!(!parsed.dry_run);
-        assert!(parsed.expect_default.is_none());
+        assert!(!parsed.bootstrap);
     }
 
     #[test]
     fn push_args_accept_inline_and_separated_values() {
-        let inline =
-            parse_push_args(&["--remote=upstream".into(), "--expect-default=trunk".into()])
-                .expect("parse inline");
+        let inline = parse_push_args(&["--remote=upstream".into()]).expect("parse inline");
         assert_eq!(inline.remote, "upstream");
-        assert_eq!(inline.expect_default.as_deref(), Some("trunk"));
 
-        let separated = parse_push_args(&[
-            "--remote".into(),
-            "upstream".into(),
-            "--expect-default".into(),
-            "trunk".into(),
-        ])
-        .expect("parse separated");
+        let separated =
+            parse_push_args(&["--remote".into(), "upstream".into()]).expect("parse separated");
         assert_eq!(separated.remote, "upstream");
-        assert_eq!(separated.expect_default.as_deref(), Some("trunk"));
+    }
+
+    /// The flag is gone, so it must be rejected like any other unknown word
+    /// rather than silently ignored.
+    #[test]
+    fn push_args_reject_the_removed_expect_default_flag() {
+        for argv in [
+            vec!["--expect-default".to_string(), "trunk".to_string()],
+            vec!["--expect-default=trunk".to_string()],
+        ] {
+            let err = parse_push_args(&argv).expect_err("reject");
+            assert_eq!(err.code, "unknown-argument", "argv: {argv:?}");
+        }
     }
 
     #[test]

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -237,6 +237,13 @@ fn push_refuses_when_the_remote_default_branch_is_unknown() {
         "the refusal names the one way to resolve this, got: {hint}"
     );
 
+    // A bare fixture remote is created with whatever `init.defaultBranch` the
+    // host happens to use, so its HEAD can point at a branch that was never
+    // pushed and `--auto` has nothing to read. A real provider remote always
+    // advertises a valid HEAD; point it at the published branch so the fixture
+    // models that rather than the host's git config.
+    git(remote.path(), &["symbolic-ref", "HEAD", "refs/heads/main"]);
+
     // Caching the real remote head is now the only route, and it works: the
     // remote is populated, so it has a HEAD to read.
     git(repo.path(), &["remote", "set-head", "origin", "--auto"]);

--- a/crates/git-cli/tests/integration/publish.rs
+++ b/crates/git-cli/tests/integration/publish.rs
@@ -233,27 +233,25 @@ fn push_refuses_when_the_remote_default_branch_is_unknown() {
     assert_eq!(json["error"]["code"], "default-branch-unresolved");
     let hint = json["error"]["hint"].as_str().unwrap_or_default();
     assert!(
-        hint.contains("--expect-default"),
-        "the refusal names the offline escape hatch, got: {hint}"
+        hint.contains("git remote set-head origin --auto"),
+        "the refusal names the one way to resolve this, got: {hint}"
     );
 
-    // The escape hatch names what the default *is*, so it can admit this push
-    // without ever admitting a push of the default branch itself.
-    let admitted = harness.run(
-        repo.path(),
-        &["push", "--expect-default", "main", "--format", "json"],
-    );
+    // Caching the real remote head is now the only route, and it works: the
+    // remote is populated, so it has a HEAD to read.
+    git(repo.path(), &["remote", "set-head", "origin", "--auto"]);
+    let admitted = harness.run(repo.path(), &["push", "--format", "json"]);
     assert_eq!(admitted.code, 0, "stderr: {}", admitted.stderr_text());
     assert_eq!(parse_json(&admitted)["data"]["pushed"], true);
 }
 
 #[test]
-fn push_expect_default_cannot_widen_admission() {
-    // `--expect-default` exists so an offline caller can name the default branch
-    // when the remote head is not cached. It must never be able to *admit* a
-    // push that would otherwise be refused, or it is a bypass rather than an
-    // escape hatch: asserting some other branch while standing on the real
-    // default would publish the default branch.
+fn push_no_longer_accepts_a_caller_asserted_default_branch() {
+    // A caller-supplied `--expect-default` used to name the default branch for
+    // an uncached remote head, guarded by a list of conventional default names.
+    // That guard only ever stopped the honest caller: `--expect-default main`
+    // was refused while `--expect-default trunk` cleared the very same push.
+    // The flag is gone, so the assertion cannot be made at all.
     let harness = GitCliHarness::new();
     let repo = init_repo();
     let remote = init_bare_remote();
@@ -263,37 +261,28 @@ fn push_expect_default_cannot_widen_admission() {
     let published = rev_parse(repo.path(), "HEAD");
     commit_file(repo.path(), "local.txt", "local\n", "local only");
 
-    // No cached `origin/HEAD`, standing on `main`, asserting a different branch.
-    let output = harness.run(
-        repo.path(),
-        &["push", "--expect-default", "develop", "--format", "json"],
-    );
-    assert_ne!(
-        output.code, 0,
-        "a wrong --expect-default must not admit a push of a default-looking branch"
-    );
+    for argv in [
+        vec!["push", "--expect-default", "trunk", "--format", "json"],
+        vec!["push", "--expect-default=trunk", "--format", "json"],
+    ] {
+        let output = harness.run(repo.path(), &argv);
+        assert_ne!(output.code, 0, "argv: {argv:?}");
+        assert_eq!(
+            parse_json(&output)["error"]["code"],
+            "unknown-argument",
+            "argv: {argv:?}"
+        );
+    }
+
     assert_eq!(
         rev_parse(remote.path(), "refs/heads/main"),
         published,
         "the remote default branch is untouched"
     );
-
-    // With the real default cached, a disagreeing assertion is a mismatch, not a
-    // second opinion that wins.
-    git(repo.path(), &["remote", "set-head", "origin", "main"]);
-    let mismatch = harness.run(
-        repo.path(),
-        &["push", "--expect-default", "develop", "--format", "json"],
-    );
-    assert_ne!(mismatch.code, 0);
-    assert_eq!(
-        parse_json(&mismatch)["error"]["code"],
-        "expect-default-mismatch"
-    );
 }
 
 #[test]
-fn push_expect_default_still_refuses_the_default_branch() {
+fn push_still_refuses_the_default_branch_once_the_head_is_cached() {
     let harness = GitCliHarness::new();
     let repo = init_repo();
     let remote = init_bare_remote();
@@ -302,26 +291,8 @@ fn push_expect_default_still_refuses_the_default_branch() {
     git(repo.path(), &["push", "origin", "main"]);
     commit_file(repo.path(), "local.txt", "local\n", "local only");
 
-    // Uncached remote head: refused before the assertion is even consulted,
-    // because a conventional default-branch name cannot be cleared by an
-    // unverifiable claim.
-    let unverifiable = harness.run(
-        repo.path(),
-        &["push", "--expect-default", "main", "--format", "json"],
-    );
-    assert_ne!(unverifiable.code, 0);
-    assert_eq!(
-        parse_json(&unverifiable)["error"]["code"],
-        "default-branch-unverifiable"
-    );
-
-    // Cached remote head: the assertion agrees, and the push is refused for the
-    // plain reason that this *is* the default branch.
     git(repo.path(), &["remote", "set-head", "origin", "main"]);
-    let refused = harness.run(
-        repo.path(),
-        &["push", "--expect-default", "main", "--format", "json"],
-    );
+    let refused = harness.run(repo.path(), &["push", "--format", "json"]);
     assert_ne!(refused.code, 0);
     assert_eq!(
         parse_json(&refused)["error"]["code"],
@@ -410,24 +381,27 @@ fn push_bootstrap_refuses_a_remote_that_already_has_refs() {
 }
 
 #[test]
-fn push_bootstrap_rejects_flags_that_contradict_a_create_only_publish() {
+fn push_bootstrap_rejects_a_force_that_contradicts_a_create_only_publish() {
+    // A bootstrap publish only ever creates a ref, so a caller-supplied force is
+    // a contradiction rather than a no-op and is refused instead of ignored.
     let harness = GitCliHarness::new();
     let (repo, _remote) = repo_with_empty_remote();
 
-    for flags in [
-        vec!["push", "--bootstrap", "--expect-default", "main"],
-        vec!["push", "--bootstrap", "--force-with-lease"],
-    ] {
-        let mut argv = flags.clone();
-        argv.extend_from_slice(&["--format", "json"]);
-        let output = harness.run(repo.path(), &argv);
-        assert_ne!(output.code, 0, "flags: {flags:?}");
-        assert_eq!(
-            parse_json(&output)["error"]["code"],
-            "bootstrap-conflicting-flag",
-            "flags: {flags:?}"
-        );
-    }
+    let output = harness.run(
+        repo.path(),
+        &[
+            "push",
+            "--bootstrap",
+            "--force-with-lease",
+            "--format",
+            "json",
+        ],
+    );
+    assert_ne!(output.code, 0);
+    assert_eq!(
+        parse_json(&output)["error"]["code"],
+        "bootstrap-conflicting-flag"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`git-cli push --expect-default <branch>` let the caller name the remote's default
branch when `refs/remotes/<remote>/HEAD` was not cached — the offline path. It was
guarded by a list of conventional default names so the assertion could only ever
*add* a refusal, never widen admission.

The guard only stopped the caller who answered truthfully. Against the same
uncached remote, standing on the same branch:

```
git-cli push --dry-run --expect-default main   -> default-branch-unverifiable (refused)
git-cli push --dry-run --expect-default trunk  -> ok, created_remote_branch: true
```

The caller supplies the name, so anyone who wanted through simply named a branch
outside the list. A longer list cannot fix an assertion the caller controls, so
the flag is removed rather than hardened. The cached remote head is now the only
admissible source for the default branch.

Nothing is lost. An empty remote is `--bootstrap` (sympoies/nils-cli#1540), and a
populated remote always has a HEAD for `git remote set-head <remote> --auto` to
read — so every case the escape hatch covered is now either verifiable or
explicitly governed. The flag has no caller anywhere in the sympoies
repositories: not in `agent-runtime-kit` skills or policies, not in any other
repo, only in `git-cli`'s own implementation, tests, and docs.

This is a breaking change to a published CLI surface, and it ships in the same
release as `--bootstrap` so consumers meet both at once rather than losing the
flag before its replacement exists.

## Issues

- Item 5 of sympoies/agent-runtime-kit#61, recorded as context on
  sympoies/nils-cli#1539. It was filed as an observation rather than a request;
  this is the decision on it.
- Follows sympoies/nils-cli#1540, which added `--bootstrap` and is what makes
  this removal lossless.

## Changes

- `crates/git-cli/src/publish.rs` — drop the `--expect-default` flag, its
  `expect_default` field and parsing, the `expect-default-mismatch` and
  `default-branch-unverifiable` refusals, the `missing-expect-default` usage
  error, and the `WELL_KNOWN_DEFAULT_BRANCHES` list that existed only to guard
  it. The four-arm resolution `match` collapses to "cached head, or refuse".
- `crates/git-cli/tests/integration/publish.rs` — two tests that protected the
  flag's behaviour are superseded by one that asserts both spellings are now
  rejected as `unknown-argument` and the remote default is untouched; a third
  was rewritten to resolve through `git remote set-head --auto`.
- Unit tests: the parse-args cases drop the flag and gain a direct assertion that
  it is rejected rather than silently ignored.
- `docs/specs/git-cli-remote-surfaces.md` and `README.md` — refusal table, usage
  line, and the rationale section, which now records *why* the flag was removed
  rather than leaving a gap where it was documented.

`bootstrap-conflicting-flag` survives, now covering only `--force-with-lease`.

## Test-First Evidence

`push_no_longer_accepts_a_caller_asserted_default_branch` was run against the
pre-removal source with the new test already in place, and failed:

```
assertion failed: (left == right): argv: ["push", "--expect-default", "trunk", "--format", "json"]
test result: FAILED. 0 passed; 1 failed
```

The CLI accepted the flag where the test expects `unknown-argument`. Restoring
the removal turns it green.

Three existing tests were materially affected and are declared in the evidence
record: two are `remove-superseded` with the new test named as their owner, and
`push_refuses_when_the_remote_default_branch_is_unknown` is `update-spec` — it
still asserts the closed failure first, then resolves through `set-head --auto`
instead of the removed flag.

## Test plan

- `cargo test -p nils-git-cli --test integration publish::` — 27 pass.
- `cargo test -p nils-git-cli` — 158 lib + 226 integration tests pass.
- `cargo fmt --all -- --check`, `cargo clippy -p nils-git-cli --all-targets
  --all-features -- -D warnings`, `docs-placement-audit.sh --strict`, and
  `docs-hygiene-audit.sh --strict` all pass. Clippy caught a `collapsible_if`
  left behind once the inner `--expect-default` arm was removed; collapsed.
- Confirmed by grep that the flag has no caller in `agent-runtime-kit`'s skills,
  policies, or docs, nor in any other sympoies repository.

## Risk / Notes

- Breaking change to a published CLI surface. Mitigated by there being no caller
  in any sympoies repository, and by shipping alongside `--bootstrap` in the same
  release.
- A caller who was relying on the flag offline against a populated remote loses
  the offline path: they now need one `git remote set-head <remote> --auto`,
  which contacts the remote. That is the point — the resolution becomes
  verifiable instead of asserted.
