### PR TITLE
fix(forge-cli): recover truncated review hunk sides

### DIFF
--- a/crates/forge-cli/src/ops/pr_review_threads.rs
+++ b/crates/forge-cli/src/ops/pr_review_threads.rs
@@ -19,7 +19,7 @@
 //! The local provider has no review-thread model: the atom returns an empty
 //! thread list and the merge gate passes trivially.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 
 use nils_common::cli_contract::{OutputFormat, schema_version_for};
@@ -48,6 +48,7 @@ const MAX_GITHUB_THREAD_COMMENT_PAGES: usize = 100;
 /// must not silently ignore a later reviewer reply.
 const GITHUB_THREADS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { id isResolved isOutdated path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 100) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_THREAD_FINGERPRINTS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { id isResolved isOutdated path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 1) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
+const GITHUB_COMMENT_ANCHORS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 1) { nodes { id author { login } body createdAt url } } } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_THREAD_COMMENTS_QUERY: &str = "query($thread: ID!, $after: String) { node(id: $thread) { ... on PullRequestReviewThread { id comments(first: 100, after: $after) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } } }";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -120,6 +121,32 @@ struct GitHubThreadNode {
 struct GitHubThreadCommentsPage {
     thread_id: String,
     comments: Vec<PrReviewThreadComment>,
+    has_next_page: bool,
+    end_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubReviewCommentAnchor {
+    pub comment: PrReviewThreadComment,
+    pub path: String,
+    pub diff_side: Option<String>,
+    pub line: Option<u32>,
+    pub original_line: Option<u32>,
+    pub original_start_line: Option<u32>,
+    pub start_diff_side: Option<String>,
+    pub start_line: Option<u32>,
+    pub subject_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubReviewCommentAnchorsSnapshot {
+    pub head_sha: String,
+    pub anchors: BTreeMap<String, GitHubReviewCommentAnchor>,
+}
+
+struct GitHubReviewCommentAnchorsPage {
+    head_sha: String,
+    anchors: Vec<GitHubReviewCommentAnchor>,
     has_next_page: bool,
     end_cursor: Option<String>,
 }
@@ -443,6 +470,106 @@ pub(crate) fn compute_fingerprints_for_pr<R: BackendRunner>(
     ))
 }
 
+/// Fetch only the root-comment identity and anchor fields for the requested
+/// GitHub comment IDs. Pending-review recovery uses this bounded read instead
+/// of hydrating every thread reply, and stops as soon as every globally unique
+/// comment node ID has been found.
+pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    pr_url: &str,
+    number: u64,
+    requested_ids: &BTreeSet<String>,
+) -> Result<GitHubReviewCommentAnchorsSnapshot, ForgeError> {
+    if requested_ids.is_empty() {
+        return Err(snapshot_incomplete(
+            "review-comment anchor lookup requires at least one comment id",
+            None,
+        ));
+    }
+    let slug = github_repo_slug_from_url(pr_url).ok_or_else(|| {
+        snapshot_incomplete(
+            "unable to derive GitHub owner/repo from PR url",
+            Some(format!("url={pr_url}")),
+        )
+    })?;
+    let (owner, name) = slug.split_once('/').ok_or_else(|| {
+        snapshot_incomplete(
+            "unable to split GitHub owner/repo slug",
+            Some(format!("slug={slug}")),
+        )
+    })?;
+    let mut cursor = None;
+    let mut seen_cursors = BTreeSet::new();
+    let mut expected_head = None;
+    let mut remaining = requested_ids.clone();
+    let mut anchors = BTreeMap::new();
+
+    for page_index in 0..MAX_GITHUB_THREAD_PAGES {
+        let output = runner.run(&build_github_comment_anchors_page_call(
+            ctx,
+            owner,
+            name,
+            number,
+            cursor.as_deref(),
+        ))?;
+        let page = parse_github_comment_anchors_page(&output, requested_ids)?;
+        if expected_head
+            .as_deref()
+            .is_some_and(|head| head != page.head_sha)
+        {
+            return Err(snapshot_incomplete(
+                "the PR head changed while paginating review-comment anchors",
+                Some(format!(
+                    "expected_head={}; provider_head={}",
+                    expected_head.as_deref().unwrap_or("<missing>"),
+                    page.head_sha
+                )),
+            ));
+        }
+        expected_head.get_or_insert(page.head_sha);
+        for anchor in page.anchors {
+            let comment_id = anchor.comment.id.clone();
+            if anchors.insert(comment_id.clone(), anchor).is_some() {
+                return Err(snapshot_incomplete(
+                    "a requested review comment appears in more than one review thread",
+                    Some(format!("comment_id={comment_id}")),
+                ));
+            }
+            remaining.remove(&comment_id);
+        }
+        if remaining.is_empty() {
+            return Ok(GitHubReviewCommentAnchorsSnapshot {
+                head_sha: expected_head.expect("the current page supplied a head"),
+                anchors,
+            });
+        }
+        if !page.has_next_page {
+            return Err(snapshot_incomplete(
+                "review-comment anchor lookup did not find every requested comment",
+                Some(format!("missing_count={}", remaining.len())),
+            ));
+        }
+        let next = page.end_cursor.ok_or_else(|| {
+            snapshot_incomplete(
+                "review-comment anchor pagination is missing endCursor",
+                Some(format!("page={}", page_index + 1)),
+            )
+        })?;
+        if !seen_cursors.insert(next.clone()) {
+            return Err(snapshot_incomplete(
+                "review-comment anchor pagination repeated a cursor",
+                Some(format!("page={}; cursor={next}", page_index + 1)),
+            ));
+        }
+        cursor = Some(next);
+    }
+    Err(snapshot_incomplete(
+        "review-comment anchor pagination exceeded the safety page limit",
+        Some(format!("max_pages={MAX_GITHUB_THREAD_PAGES}")),
+    ))
+}
+
 fn complete_github_thread_comments<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
@@ -716,6 +843,34 @@ fn build_github_thread_fingerprints_page_call(
     BackendCall::new(BackendProgram::Gh, argv)
 }
 
+fn build_github_comment_anchors_page_call(
+    ctx: &ProviderContext,
+    owner: &str,
+    name: &str,
+    number: u64,
+    after: Option<&str>,
+) -> BackendCall {
+    let mut argv = vec![OsString::from("api"), OsString::from("graphql")];
+    ctx.push_github_api_hostname(&mut argv);
+    argv.extend([
+        OsString::from("-f"),
+        OsString::from(format!("query={GITHUB_COMMENT_ANCHORS_QUERY}")),
+        OsString::from("-f"),
+        OsString::from(format!("owner={owner}")),
+        OsString::from("-f"),
+        OsString::from(format!("name={name}")),
+        OsString::from("-F"),
+        OsString::from(format!("pr={number}")),
+    ]);
+    if let Some(after) = after {
+        argv.extend([
+            OsString::from("-f"),
+            OsString::from(format!("after={after}")),
+        ]);
+    }
+    BackendCall::new(BackendProgram::Gh, argv)
+}
+
 fn build_github_thread_comments_call(
     ctx: &ProviderContext,
     thread_id: &str,
@@ -890,6 +1045,104 @@ fn parse_github_thread_page(output: &BackendSuccess) -> Result<GitHubThreadPage,
     Ok(GitHubThreadPage {
         head_sha,
         threads,
+        has_next_page,
+        end_cursor,
+    })
+}
+
+fn parse_github_comment_anchors_page(
+    output: &BackendSuccess,
+    requested_ids: &BTreeSet<String>,
+) -> Result<GitHubReviewCommentAnchorsPage, ForgeError> {
+    let value: serde_json::Value = serde_json::from_str(output.stdout.trim()).map_err(|e| {
+        ForgeError::software(
+            schema_err(),
+            "review-comment anchors response is invalid JSON",
+            Some(e.to_string()),
+        )
+    })?;
+    reject_graphql_errors(&value, "review-comment anchors")?;
+    let pull = value
+        .pointer("/data/repository/pullRequest")
+        .ok_or_else(|| {
+            snapshot_incomplete(
+                "review-comment anchors response is missing pullRequest",
+                None,
+            )
+        })?;
+    let head_sha = required_json_string(pull, "/headRefOid", "headRefOid")?;
+    let connection = pull.pointer("/reviewThreads").ok_or_else(|| {
+        snapshot_incomplete(
+            "review-comment anchors response is missing reviewThreads",
+            None,
+        )
+    })?;
+    let nodes = connection
+        .pointer("/nodes")
+        .and_then(|nodes| nodes.as_array())
+        .ok_or_else(|| {
+            snapshot_incomplete(
+                "review-comment anchors response is missing reviewThreads nodes",
+                None,
+            )
+        })?;
+    let (has_next_page, end_cursor) = parse_page_info(connection, "reviewThreads")?;
+    let mut anchors = Vec::new();
+    for node in nodes {
+        let Some(comment) = node
+            .pointer("/comments/nodes")
+            .and_then(|comments| comments.as_array())
+            .and_then(|comments| comments.first())
+        else {
+            continue;
+        };
+        let Some(comment_id) = comment.get("id").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        if !requested_ids.contains(comment_id) {
+            continue;
+        }
+        let comment = PrReviewThreadComment {
+            id: comment_id.to_string(),
+            author: comment
+                .pointer("/author/login")
+                .and_then(|value| value.as_str())
+                .unwrap_or("<unknown>")
+                .to_string(),
+            body: required_json_string_allow_empty(comment, "/body", "reviewThread.comment.body")?,
+            created_at: required_json_string(
+                comment,
+                "/createdAt",
+                "reviewThread.comment.createdAt",
+            )?,
+            url: required_json_string(comment, "/url", "reviewThread.comment.url")?,
+        };
+        anchors.push(GitHubReviewCommentAnchor {
+            comment,
+            path: required_json_string(node, "/path", "reviewThread.path")?,
+            diff_side: Some(required_json_string(
+                node,
+                "/diffSide",
+                "reviewThread.diffSide",
+            )?),
+            line: optional_json_u32(node, "/line"),
+            original_line: optional_json_u32(node, "/originalLine"),
+            original_start_line: optional_json_u32(node, "/originalStartLine"),
+            start_diff_side: node
+                .pointer("/startDiffSide")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
+            start_line: optional_json_u32(node, "/startLine"),
+            subject_type: Some(required_json_string(
+                node,
+                "/subjectType",
+                "reviewThread.subjectType",
+            )?),
+        });
+    }
+    Ok(GitHubReviewCommentAnchorsPage {
+        head_sha,
+        anchors,
         has_next_page,
         end_cursor,
     })

--- a/crates/forge-cli/src/ops/pr_review_threads.rs
+++ b/crates/forge-cli/src/ops/pr_review_threads.rs
@@ -48,7 +48,7 @@ const MAX_GITHUB_THREAD_COMMENT_PAGES: usize = 100;
 /// must not silently ignore a later reviewer reply.
 const GITHUB_THREADS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { id isResolved isOutdated path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 100) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_THREAD_FINGERPRINTS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { id isResolved isOutdated path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 1) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } pageInfo { hasNextPage endCursor } } } } }";
-const GITHUB_COMMENT_ANCHORS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $after: String) { repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 1) { nodes { id author { login } body createdAt url } } } pageInfo { hasNextPage endCursor } } } } }";
+const GITHUB_COMMENT_ANCHORS_QUERY: &str = "query($owner: String!, $name: String!, $pr: Int!, $review: ID!, $after: String) { review: node(id: $review) { ... on PullRequestReview { id url author { login } state commit { oid } body viewerDidAuthor viewerCanDelete pullRequest { number url headRefOid } } } repository(owner: $owner, name: $name) { pullRequest(number: $pr) { headRefOid reviewThreads(first: 100, after: $after) { nodes { path diffSide line originalLine originalStartLine startDiffSide startLine subjectType comments(first: 1) { nodes { id author { login } body createdAt url } } } pageInfo { hasNextPage endCursor } } } } }";
 const GITHUB_THREAD_COMMENTS_QUERY: &str = "query($thread: ID!, $after: String) { node(id: $thread) { ... on PullRequestReviewThread { id comments(first: 100, after: $after) { nodes { id author { login } body createdAt url } pageInfo { hasNextPage endCursor } } } } }";
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -141,11 +141,28 @@ pub(crate) struct GitHubReviewCommentAnchor {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct GitHubReviewCommentAnchorsSnapshot {
     pub head_sha: String,
+    pub review: GitHubPendingReviewIdentity,
     pub anchors: BTreeMap<String, GitHubReviewCommentAnchor>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitHubPendingReviewIdentity {
+    pub number: u64,
+    pub pr_url: String,
+    pub head_sha: String,
+    pub review_id: String,
+    pub review_url: String,
+    pub author: String,
+    pub state: String,
+    pub commit_sha: Option<String>,
+    pub body: String,
+    pub viewer_did_author: bool,
+    pub viewer_can_delete: bool,
 }
 
 struct GitHubReviewCommentAnchorsPage {
     head_sha: String,
+    review: GitHubPendingReviewIdentity,
     anchors: Vec<GitHubReviewCommentAnchor>,
     has_next_page: bool,
     end_cursor: Option<String>,
@@ -479,6 +496,7 @@ pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
     ctx: &ProviderContext,
     pr_url: &str,
     number: u64,
+    review_id: &str,
     requested_ids: &BTreeSet<String>,
 ) -> Result<GitHubReviewCommentAnchorsSnapshot, ForgeError> {
     if requested_ids.is_empty() {
@@ -502,6 +520,7 @@ pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
     let mut cursor = None;
     let mut seen_cursors = BTreeSet::new();
     let mut expected_head = None;
+    let mut expected_review = None;
     let mut remaining = requested_ids.clone();
     let mut anchors = BTreeMap::new();
 
@@ -511,9 +530,19 @@ pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
             owner,
             name,
             number,
+            review_id,
             cursor.as_deref(),
         ))?;
         let page = parse_github_comment_anchors_page(&output, requested_ids)?;
+        if page.review.head_sha != page.head_sha {
+            return Err(snapshot_incomplete(
+                "the pending review and PR head differ during comment-anchor recovery",
+                Some(format!(
+                    "review_head={}; provider_head={}",
+                    page.review.head_sha, page.head_sha
+                )),
+            ));
+        }
         if expected_head
             .as_deref()
             .is_some_and(|head| head != page.head_sha)
@@ -528,6 +557,16 @@ pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
             ));
         }
         expected_head.get_or_insert(page.head_sha);
+        if expected_review
+            .as_ref()
+            .is_some_and(|review| review != &page.review)
+        {
+            return Err(snapshot_incomplete(
+                "the pending review changed while paginating comment anchors",
+                Some(format!("review_id={review_id}")),
+            ));
+        }
+        expected_review.get_or_insert(page.review);
         for anchor in page.anchors {
             let comment_id = anchor.comment.id.clone();
             if anchors.insert(comment_id.clone(), anchor).is_some() {
@@ -541,6 +580,7 @@ pub(crate) fn compute_comment_anchors_for_pr<R: BackendRunner>(
         if remaining.is_empty() {
             return Ok(GitHubReviewCommentAnchorsSnapshot {
                 head_sha: expected_head.expect("the current page supplied a head"),
+                review: expected_review.expect("the current page supplied a review"),
                 anchors,
             });
         }
@@ -848,6 +888,7 @@ fn build_github_comment_anchors_page_call(
     owner: &str,
     name: &str,
     number: u64,
+    review_id: &str,
     after: Option<&str>,
 ) -> BackendCall {
     let mut argv = vec![OsString::from("api"), OsString::from("graphql")];
@@ -861,6 +902,8 @@ fn build_github_comment_anchors_page_call(
         OsString::from(format!("name={name}")),
         OsString::from("-F"),
         OsString::from(format!("pr={number}")),
+        OsString::from("-f"),
+        OsString::from(format!("review={review_id}")),
     ]);
     if let Some(after) = after {
         argv.extend([
@@ -1062,6 +1105,50 @@ fn parse_github_comment_anchors_page(
         )
     })?;
     reject_graphql_errors(&value, "review-comment anchors")?;
+    let review = value.pointer("/data/review").ok_or_else(|| {
+        snapshot_incomplete(
+            "review-comment anchors response is missing the pending review",
+            None,
+        )
+    })?;
+    if review.is_null() {
+        return Err(snapshot_incomplete(
+            "review-comment anchors response returned no pending review",
+            None,
+        ));
+    }
+    let review = GitHubPendingReviewIdentity {
+        number: required_json_u64(review, "/pullRequest/number", "review.pullRequest.number")?,
+        pr_url: required_json_string(review, "/pullRequest/url", "review.pullRequest.url")?,
+        head_sha: required_json_string(
+            review,
+            "/pullRequest/headRefOid",
+            "review.pullRequest.headRefOid",
+        )?,
+        review_id: required_json_string(review, "/id", "review.id")?,
+        review_url: required_json_string(review, "/url", "review.url")?,
+        author: review
+            .pointer("/author/login")
+            .and_then(|value| value.as_str())
+            .unwrap_or("<unknown>")
+            .to_string(),
+        state: required_json_string(review, "/state", "review.state")?,
+        commit_sha: review
+            .pointer("/commit/oid")
+            .and_then(|value| value.as_str())
+            .map(str::to_string),
+        body: required_json_string_allow_empty(review, "/body", "review.body")?,
+        viewer_did_author: required_json_bool(
+            review,
+            "/viewerDidAuthor",
+            "review.viewerDidAuthor",
+        )?,
+        viewer_can_delete: required_json_bool(
+            review,
+            "/viewerCanDelete",
+            "review.viewerCanDelete",
+        )?,
+    };
     let pull = value
         .pointer("/data/repository/pullRequest")
         .ok_or_else(|| {
@@ -1117,14 +1204,14 @@ fn parse_github_comment_anchors_page(
             )?,
             url: required_json_string(comment, "/url", "reviewThread.comment.url")?,
         };
+        let subject_type = required_json_string(node, "/subjectType", "reviewThread.subjectType")?;
         anchors.push(GitHubReviewCommentAnchor {
             comment,
             path: required_json_string(node, "/path", "reviewThread.path")?,
-            diff_side: Some(required_json_string(
-                node,
-                "/diffSide",
-                "reviewThread.diffSide",
-            )?),
+            diff_side: node
+                .pointer("/diffSide")
+                .and_then(|value| value.as_str())
+                .map(str::to_string),
             line: optional_json_u32(node, "/line"),
             original_line: optional_json_u32(node, "/originalLine"),
             original_start_line: optional_json_u32(node, "/originalStartLine"),
@@ -1133,15 +1220,12 @@ fn parse_github_comment_anchors_page(
                 .and_then(|value| value.as_str())
                 .map(str::to_string),
             start_line: optional_json_u32(node, "/startLine"),
-            subject_type: Some(required_json_string(
-                node,
-                "/subjectType",
-                "reviewThread.subjectType",
-            )?),
+            subject_type: Some(subject_type),
         });
     }
     Ok(GitHubReviewCommentAnchorsPage {
         head_sha,
+        review,
         anchors,
         has_next_page,
         end_cursor,
@@ -1302,6 +1386,22 @@ fn optional_json_u32(value: &serde_json::Value, pointer: &str) -> Option<u32> {
         .pointer(pointer)
         .and_then(serde_json::Value::as_u64)
         .and_then(|value| u32::try_from(value).ok())
+}
+
+fn required_json_u64(
+    value: &serde_json::Value,
+    pointer: &str,
+    field: &str,
+) -> Result<u64, ForgeError> {
+    value
+        .pointer(pointer)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            snapshot_incomplete(
+                "review-thread response is missing a required field",
+                Some(format!("field={field}")),
+            )
+        })
 }
 
 fn required_json_bool(
@@ -1571,6 +1671,71 @@ mod tests {
         )
     }
 
+    fn github_anchor_node(comment_id: &str, path: &str) -> serde_json::Value {
+        serde_json::json!({
+            "path": path,
+            "diffSide": "RIGHT",
+            "line": 10,
+            "originalLine": 10,
+            "originalStartLine": null,
+            "startDiffSide": null,
+            "startLine": null,
+            "subjectType": "LINE",
+            "comments": {"nodes": [{
+                "id": comment_id,
+                "author": {"login": "review-bot"},
+                "body": format!("finding {comment_id}"),
+                "createdAt": "2026-07-20T12:00:00Z",
+                "url": format!("https://github.com/acme/widgets/pull/7#discussion_{comment_id}")
+            }]}
+        })
+    }
+
+    fn github_anchor_page(
+        head: &str,
+        nodes: Vec<serde_json::Value>,
+        has_next_page: bool,
+        end_cursor: Option<&str>,
+    ) -> BackendSuccess {
+        BackendSuccess {
+            stdout: serde_json::json!({
+                "data": {
+                    "review": {
+                        "id": "PRR_pending",
+                        "url": "https://github.com/acme/widgets/pull/7#pullrequestreview-9",
+                        "author": {"login": "review-bot"},
+                        "state": "PENDING",
+                        "commit": {"oid": "head-7"},
+                        "body": "Summary",
+                        "viewerDidAuthor": true,
+                        "viewerCanDelete": true,
+                        "pullRequest": {
+                            "number": 7,
+                            "url": "https://github.com/acme/widgets/pull/7",
+                            "headRefOid": head
+                        }
+                    },
+                    "repository": {"pullRequest": {
+                        "headRefOid": head,
+                        "reviewThreads": {
+                            "nodes": nodes,
+                            "pageInfo": {
+                                "hasNextPage": has_next_page,
+                                "endCursor": end_cursor
+                            }
+                        }
+                    }}
+                }
+            })
+            .to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn requested_comment_ids(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|id| (*id).to_string()).collect()
+    }
+
     #[test]
     fn github_threads_call_uses_graphql_with_owner_name_pr() {
         let call = build_threads_call(
@@ -1647,6 +1812,127 @@ mod tests {
         let query = calls[0].1.join(" ");
         assert!(query.contains("comments(first: 1)"), "{query}");
         assert!(!query.contains("thread=PRRT_1"), "{query}");
+    }
+
+    #[test]
+    fn comment_anchor_lookup_finds_a_requested_comment_on_page_two() {
+        let runner = ScriptedRunner::new(vec![
+            github_anchor_page("head-7", vec![], true, Some("page-2")),
+            github_anchor_page(
+                "head-7",
+                vec![github_anchor_node("PRRC_target", "src/lib.rs")],
+                false,
+                None,
+            ),
+        ]);
+
+        let snapshot = compute_comment_anchors_for_pr(
+            &runner,
+            &ctx(Provider::GitHub),
+            "https://github.com/acme/widgets/pull/7",
+            7,
+            "PRR_pending",
+            &requested_comment_ids(&["PRRC_target"]),
+        )
+        .expect("later-page requested comment should be recovered");
+
+        assert_eq!(snapshot.anchors.len(), 1);
+        assert_eq!(snapshot.review.review_id, "PRR_pending");
+        let calls = runner.calls();
+        assert_eq!(calls.len(), 2);
+        assert!(calls[1].1.iter().any(|arg| arg == "after=page-2"));
+        assert!(calls[1].1.iter().any(|arg| arg == "review=PRR_pending"));
+    }
+
+    #[test]
+    fn comment_anchor_lookup_rejects_cross_page_head_drift() {
+        let runner = ScriptedRunner::new(vec![
+            github_anchor_page("head-7", vec![], true, Some("page-2")),
+            github_anchor_page(
+                "head-8",
+                vec![github_anchor_node("PRRC_target", "src/lib.rs")],
+                false,
+                None,
+            ),
+        ]);
+
+        let error = compute_comment_anchors_for_pr(
+            &runner,
+            &ctx(Provider::GitHub),
+            "https://github.com/acme/widgets/pull/7",
+            7,
+            "PRR_pending",
+            &requested_comment_ids(&["PRRC_target"]),
+        )
+        .expect_err("head drift must fail closed");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(error.to_string().contains("head changed"), "{error}");
+    }
+
+    #[test]
+    fn comment_anchor_lookup_rejects_a_repeated_cursor() {
+        let runner = ScriptedRunner::new(vec![
+            github_anchor_page("head-7", vec![], true, Some("same-cursor")),
+            github_anchor_page("head-7", vec![], true, Some("same-cursor")),
+        ]);
+
+        let error = compute_comment_anchors_for_pr(
+            &runner,
+            &ctx(Provider::GitHub),
+            "https://github.com/acme/widgets/pull/7",
+            7,
+            "PRR_pending",
+            &requested_comment_ids(&["PRRC_missing"]),
+        )
+        .expect_err("repeated cursor must fail closed");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(error.to_string().contains("repeated a cursor"), "{error}");
+    }
+
+    #[test]
+    fn comment_anchor_lookup_rejects_a_missing_requested_comment() {
+        let runner = ScriptedRunner::new(vec![github_anchor_page("head-7", vec![], false, None)]);
+
+        let error = compute_comment_anchors_for_pr(
+            &runner,
+            &ctx(Provider::GitHub),
+            "https://github.com/acme/widgets/pull/7",
+            7,
+            "PRR_pending",
+            &requested_comment_ids(&["PRRC_missing"]),
+        )
+        .expect_err("missing requested comment must fail closed");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(error.to_string().contains("did not find every"), "{error}");
+    }
+
+    #[test]
+    fn comment_anchor_lookup_rejects_a_duplicate_requested_comment() {
+        let runner = ScriptedRunner::new(vec![github_anchor_page(
+            "head-7",
+            vec![
+                github_anchor_node("PRRC_duplicate", "src/one.rs"),
+                github_anchor_node("PRRC_duplicate", "src/two.rs"),
+            ],
+            false,
+            None,
+        )]);
+
+        let error = compute_comment_anchors_for_pr(
+            &runner,
+            &ctx(Provider::GitHub),
+            "https://github.com/acme/widgets/pull/7",
+            7,
+            "PRR_pending",
+            &requested_comment_ids(&["PRRC_duplicate"]),
+        )
+        .expect_err("duplicate requested comment must fail closed");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(error.to_string().contains("more than one"), "{error}");
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -1125,18 +1125,28 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
     ctx: &ProviderContext,
     snapshot: &mut PendingReviewSnapshot,
 ) -> Result<(), ForgeError> {
-    let needs_thread_snapshot = snapshot.inline_comments.iter().any(|comment| {
-        comment.subject_type == "LINE"
-            && (comment.diff_side.is_none()
-                || (comment.start_line.is_some() && comment.start_diff_side.is_none()))
-    });
-    if !needs_thread_snapshot {
+    let requested_ids = snapshot
+        .inline_comments
+        .iter()
+        .filter(|comment| {
+            comment.subject_type == "LINE"
+                && (comment.diff_side.is_none()
+                    || (comment.start_line.is_some() && comment.start_diff_side.is_none()))
+        })
+        .map(|comment| comment.id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    if requested_ids.is_empty() {
         return Ok(());
     }
 
-    let threads =
-        pr_review_threads::compute_for_pr(runner, ctx, &snapshot.pr_url, snapshot.number)?;
-    if threads.head_sha.as_deref() != Some(snapshot.head_sha.as_str()) {
+    let recovered = pr_review_threads::compute_comment_anchors_for_pr(
+        runner,
+        ctx,
+        &snapshot.pr_url,
+        snapshot.number,
+        &requested_ids,
+    )?;
+    if recovered.head_sha != snapshot.head_sha {
         return Err(snapshot_incomplete(
             "the PR head changed while recovering pending review comment anchors",
             Some(format!("review_id={}", snapshot.review_id)),
@@ -1150,37 +1160,35 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
         {
             continue;
         }
-        let mut matches = threads.threads.iter().filter(|thread| {
-            thread
-                .comments
-                .iter()
-                .any(|thread_comment| thread_comment.id == comment.id)
-        });
-        let thread = matches.next().ok_or_else(|| {
+        let anchor = recovered.anchors.get(&comment.id).ok_or_else(|| {
             snapshot_incomplete(
                 "pending review comment is missing from the exact review-thread snapshot",
                 Some(format!("comment_id={}", comment.id)),
             )
         })?;
-        if matches.next().is_some() {
+        if anchor.comment.body != comment.body
+            || anchor.comment.author != comment.author
+            || anchor.comment.created_at != comment.created_at
+            || anchor.comment.url != comment.url
+        {
             return Err(snapshot_incomplete(
-                "pending review comment appears in more than one review thread",
+                "pending review comment identity differs from its review thread",
                 Some(format!("comment_id={}", comment.id)),
             ));
         }
-        if thread.path != comment.path
-            || thread.line != comment.line
-            || thread.original_line != comment.original_line
-            || thread.start_line != comment.start_line
-            || thread.original_start_line != comment.original_start_line
-            || thread.subject_type.as_deref() != Some(comment.subject_type.as_str())
+        if anchor.path != comment.path
+            || anchor.line != comment.line
+            || anchor.original_line != comment.original_line
+            || anchor.start_line != comment.start_line
+            || anchor.original_start_line != comment.original_start_line
+            || anchor.subject_type.as_deref() != Some(comment.subject_type.as_str())
         {
             return Err(snapshot_incomplete(
                 "pending review comment anchor differs from its review thread",
                 Some(format!("comment_id={}", comment.id)),
             ));
         }
-        let diff_side = thread.diff_side.as_deref().ok_or_else(|| {
+        let diff_side = anchor.diff_side.as_deref().ok_or_else(|| {
             snapshot_incomplete(
                 "pending review thread is missing its line side",
                 Some(format!("comment_id={}", comment.id)),
@@ -1199,7 +1207,7 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
         comment.diff_side = Some(diff_side.to_string());
 
         if comment.start_line.is_some() {
-            let start_side = thread.start_diff_side.as_deref().ok_or_else(|| {
+            let start_side = anchor.start_diff_side.as_deref().ok_or_else(|| {
                 snapshot_incomplete(
                     "pending review thread is missing its range start side",
                     Some(format!("comment_id={}", comment.id)),
@@ -1932,6 +1940,55 @@ mod tests {
             error.to_string().contains("anchor differs"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_rejects_cross_read_comment_drift() {
+        let mut thread = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&thread.stdout).expect("thread fixture");
+        value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][0]["comments"]["nodes"]
+            [0]["body"] = "changed between provider reads".into();
+        thread.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![truncated_pending_snapshot_page(), thread]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("cross-read comment drift must fail before snapshot authority exists");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(
+            error.to_string().contains("identity differs"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_stops_after_the_requested_root_comment() {
+        let mut thread = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&thread.stdout).expect("thread fixture");
+        value["data"]["repository"]["pullRequest"]["reviewThreads"]["pageInfo"] =
+            serde_json::json!({"hasNextPage": true, "endCursor": "cursor-1"});
+        thread.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![truncated_pending_snapshot_page(), thread]);
+
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("the exact requested root comment completes recovery")
+            .expect("pending snapshot");
+
+        assert_eq!(
+            snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        let calls = runner.calls.borrow();
+        assert_eq!(
+            calls.len(),
+            2,
+            "later review-thread pages must not be fetched"
+        );
+        assert!(calls[1].contains("comments(first: 1)"), "{}", calls[1]);
+        assert!(!calls[1].contains("comments(first: 100)"), "{}", calls[1]);
+        assert!(!calls[1].contains("after=cursor-1"), "{}", calls[1]);
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -12,6 +12,7 @@ use crate::cli::{BINARY, GlobalFlags, PrReviewsArgs};
 use crate::envelope::emit_success;
 use crate::error::ForgeError;
 use crate::ops::pr_comments::github_repo_slug_from_url;
+use crate::ops::pr_review_threads;
 use crate::ops::pr_view;
 use crate::ops::review_state;
 use crate::provider::{Provider, ProviderContext, detect, git_remote_url};
@@ -426,33 +427,10 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
             expected_total = Some(page.total_count);
             snapshot = Some(page.snapshot);
         }
-        let retained = snapshot.as_ref().expect("page created a snapshot");
-        if retained.inline_comments.len() as u64 > MAX_PENDING_REVIEW_COMMENTS {
-            return Err(snapshot_incomplete(
-                "pending review retained inline-comment count exceeds the recovery safety limit",
-                Some(format!(
-                    "review_id={review_id}; observed_comments={}; max_comments={MAX_PENDING_REVIEW_COMMENTS}",
-                    retained.inline_comments.len()
-                )),
-            ));
-        }
-        let retained_bytes = serde_json::to_vec(retained)
-            .map_err(|error| {
-                ForgeError::software(
-                    schema_err(),
-                    "failed to size pending-review snapshot",
-                    Some(error.to_string()),
-                )
-            })?
-            .len();
-        if retained_bytes > MAX_PENDING_REVIEW_SNAPSHOT_BYTES {
-            return Err(snapshot_incomplete(
-                "pending review decoded snapshot exceeds the recovery safety limit",
-                Some(format!(
-                    "review_id={review_id}; retained_bytes={retained_bytes}; max_bytes={MAX_PENDING_REVIEW_SNAPSHOT_BYTES}"
-                )),
-            ));
-        }
+        ensure_pending_snapshot_within_limits(
+            snapshot.as_ref().expect("page created a snapshot"),
+            review_id,
+        )?;
         if !page.has_next_page {
             let mut snapshot = snapshot.expect("page created a snapshot");
             if snapshot.inline_comments.len() as u64 != expected_total.unwrap_or(0) {
@@ -465,6 +443,8 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
                     )),
                 ));
             }
+            hydrate_deferred_comment_sides(runner, ctx, &mut snapshot)?;
+            ensure_pending_snapshot_within_limits(&snapshot, review_id)?;
             classify_pending_snapshot(&mut snapshot)?;
             snapshot.snapshot_digest = pending_snapshot_digest(&snapshot)?;
             return Ok(Some(snapshot));
@@ -489,6 +469,39 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
             "review_id={review_id}; max_pages={MAX_REVIEW_PAGES}"
         )),
     ))
+}
+
+fn ensure_pending_snapshot_within_limits(
+    snapshot: &PendingReviewSnapshot,
+    review_id: &str,
+) -> Result<(), ForgeError> {
+    if snapshot.inline_comments.len() as u64 > MAX_PENDING_REVIEW_COMMENTS {
+        return Err(snapshot_incomplete(
+            "pending review retained inline-comment count exceeds the recovery safety limit",
+            Some(format!(
+                "review_id={review_id}; observed_comments={}; max_comments={MAX_PENDING_REVIEW_COMMENTS}",
+                snapshot.inline_comments.len()
+            )),
+        ));
+    }
+    let retained_bytes = serde_json::to_vec(snapshot)
+        .map_err(|error| {
+            ForgeError::software(
+                schema_err(),
+                "failed to size pending-review snapshot",
+                Some(error.to_string()),
+            )
+        })?
+        .len();
+    if retained_bytes > MAX_PENDING_REVIEW_SNAPSHOT_BYTES {
+        return Err(snapshot_incomplete(
+            "pending review decoded snapshot exceeds the recovery safety limit",
+            Some(format!(
+                "review_id={review_id}; retained_bytes={retained_bytes}; max_bytes={MAX_PENDING_REVIEW_SNAPSHOT_BYTES}"
+            )),
+        ));
+    }
+    Ok(())
 }
 
 /// Deadline-aware variant used by merge convergence. The timeout covers the
@@ -1101,19 +1114,111 @@ fn normalized_comment_side(
         return Ok(None);
     }
     let diff_hunk = required_string(comment, "/diffHunk", "review.comment.diffHunk")?;
-    let side = infer_side_from_diff_hunk(&diff_hunk, anchor_line.expect("checked above"))
-        .ok_or_else(|| {
+    Ok(
+        infer_side_from_diff_hunk(&diff_hunk, anchor_line.expect("checked above"))
+            .map(str::to_string),
+    )
+}
+
+fn hydrate_deferred_comment_sides<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    snapshot: &mut PendingReviewSnapshot,
+) -> Result<(), ForgeError> {
+    let needs_thread_snapshot = snapshot.inline_comments.iter().any(|comment| {
+        comment.subject_type == "LINE"
+            && (comment.diff_side.is_none()
+                || (comment.start_line.is_some() && comment.start_diff_side.is_none()))
+    });
+    if !needs_thread_snapshot {
+        return Ok(());
+    }
+
+    let threads =
+        pr_review_threads::compute_for_pr(runner, ctx, &snapshot.pr_url, snapshot.number)?;
+    if threads.head_sha.as_deref() != Some(snapshot.head_sha.as_str()) {
+        return Err(snapshot_incomplete(
+            "the PR head changed while recovering pending review comment anchors",
+            Some(format!("review_id={}", snapshot.review_id)),
+        ));
+    }
+
+    for comment in &mut snapshot.inline_comments {
+        if comment.subject_type != "LINE"
+            || (comment.diff_side.is_some()
+                && (comment.start_line.is_none() || comment.start_diff_side.is_some()))
+        {
+            continue;
+        }
+        let mut matches = threads.threads.iter().filter(|thread| {
+            thread
+                .comments
+                .iter()
+                .any(|thread_comment| thread_comment.id == comment.id)
+        });
+        let thread = matches.next().ok_or_else(|| {
             snapshot_incomplete(
-                "pending review comment diff side cannot be derived from its diff hunk",
-                optional_string(comment, "/id").map(|id| {
-                    format!(
-                        "comment_id={id}; anchor_line={}",
-                        anchor_line.expect("checked above")
-                    )
-                }),
+                "pending review comment is missing from the exact review-thread snapshot",
+                Some(format!("comment_id={}", comment.id)),
             )
         })?;
-    Ok(Some(side.to_string()))
+        if matches.next().is_some() {
+            return Err(snapshot_incomplete(
+                "pending review comment appears in more than one review thread",
+                Some(format!("comment_id={}", comment.id)),
+            ));
+        }
+        if thread.path != comment.path
+            || thread.line != comment.line
+            || thread.original_line != comment.original_line
+            || thread.start_line != comment.start_line
+            || thread.original_start_line != comment.original_start_line
+            || thread.subject_type.as_deref() != Some(comment.subject_type.as_str())
+        {
+            return Err(snapshot_incomplete(
+                "pending review comment anchor differs from its review thread",
+                Some(format!("comment_id={}", comment.id)),
+            ));
+        }
+        let diff_side = thread.diff_side.as_deref().ok_or_else(|| {
+            snapshot_incomplete(
+                "pending review thread is missing its line side",
+                Some(format!("comment_id={}", comment.id)),
+            )
+        })?;
+        if comment
+            .diff_side
+            .as_deref()
+            .is_some_and(|side| side != diff_side)
+        {
+            return Err(snapshot_incomplete(
+                "pending review comment side differs from its review thread",
+                Some(format!("comment_id={}", comment.id)),
+            ));
+        }
+        comment.diff_side = Some(diff_side.to_string());
+
+        if comment.start_line.is_some() {
+            let start_side = thread.start_diff_side.as_deref().ok_or_else(|| {
+                snapshot_incomplete(
+                    "pending review thread is missing its range start side",
+                    Some(format!("comment_id={}", comment.id)),
+                )
+            })?;
+            if comment
+                .start_diff_side
+                .as_deref()
+                .is_some_and(|side| side != start_side)
+            {
+                return Err(snapshot_incomplete(
+                    "pending review comment range side differs from its review thread",
+                    Some(format!("comment_id={}", comment.id)),
+                ));
+            }
+            comment.start_diff_side = Some(start_side.to_string());
+        }
+    }
+    Ok(())
 }
 
 fn infer_side_from_diff_hunk(diff_hunk: &str, anchor_line: u32) -> Option<&'static str> {
@@ -1714,11 +1819,119 @@ mod tests {
             },
             "@@ -8,1 +8,1 @@\n-old value\n+new value",
         );
-        let error = match parse_github_pending_review_snapshot_page(&ambiguous, "PENDING") {
-            Err(error) => error,
-            Ok(_) => panic!("same-number replacement without a side discriminator is ambiguous"),
-        };
+        let page = parse_github_pending_review_snapshot_page(&ambiguous, "PENDING")
+            .expect("ambiguous hunk is deferred to the exact thread snapshot")
+            .expect("pending snapshot");
+        assert_eq!(page.snapshot.inline_comments[0].diff_side, None);
+    }
+
+    fn truncated_pending_snapshot_page() -> BackendSuccess {
+        let mut truncated = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_truncated",
+            path: "src/new.rs",
+            line: 982,
+            diff_side: "RIGHT",
+            start_line: None,
+            start_diff_side: None,
+            has_next_page: false,
+            end_cursor: None,
+        });
+        let mut value: serde_json::Value =
+            serde_json::from_str(&truncated.stdout).expect("snapshot fixture");
+        value["data"]["node"]["comments"]["totalCount"] = 1.into();
+        let comment = value
+            .pointer_mut("/data/node/comments/nodes/0")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("comment object");
+        comment.remove("diffSide");
+        comment.remove("startDiffSide");
+        comment.insert(
+            "diffHunk".into(),
+            "@@ -970,1 +970,1 @@\n-old context\n+new context".into(),
+        );
+        truncated.stdout = value.to_string();
+        truncated
+    }
+
+    fn truncated_comment_thread(path: &str, comment_id: &str) -> BackendSuccess {
+        BackendSuccess {
+            stdout: serde_json::json!({
+                "data": {"repository": {"pullRequest": {
+                    "headRefOid": "head-7",
+                    "reviewThreads": {
+                        "nodes": [{
+                            "id": "PRRT_truncated",
+                            "isResolved": false,
+                            "isOutdated": false,
+                            "path": path,
+                            "diffSide": "RIGHT",
+                            "line": 982,
+                            "originalLine": 982,
+                            "originalStartLine": null,
+                            "startDiffSide": null,
+                            "startLine": null,
+                            "subjectType": "LINE",
+                            "comments": {
+                                "nodes": [{
+                                    "id": comment_id,
+                                    "author": {"login": "review-bot"},
+                                    "body": "finding PRRC_truncated",
+                                    "createdAt": "2026-07-20T12:00:00Z",
+                                    "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_truncated"
+                                }],
+                                "pageInfo": {"hasNextPage": false, "endCursor": null}
+                            }
+                        }],
+                        "pageInfo": {"hasNextPage": false, "endCursor": null}
+                    }
+                }}}
+            })
+            .to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    #[test]
+    fn pending_snapshot_recovers_a_truncated_hunk_side_from_the_exact_review_thread() {
+        let runner = ScriptedRunner::new(vec![
+            truncated_pending_snapshot_page(),
+            truncated_comment_thread("src/new.rs", "PRRC_truncated"),
+        ]);
+
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("provider-valid truncated hunks recover from review threads")
+            .expect("pending snapshot");
+
+        assert_eq!(
+            snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        assert!(
+            runner
+                .calls
+                .borrow()
+                .iter()
+                .any(|call| call.contains("reviewThreads(first: 100")),
+            "the exact provider thread snapshot must own the fallback side"
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_rejects_a_mismatched_thread_anchor() {
+        let runner = ScriptedRunner::new(vec![
+            truncated_pending_snapshot_page(),
+            truncated_comment_thread("src/other.rs", "PRRC_truncated"),
+        ]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("thread anchors must match before their side becomes authoritative");
+
         assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(
+            error.to_string().contains("anchor differs"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -443,7 +443,7 @@ fn compute_review_snapshot_for_state<R: BackendRunner>(
                     )),
                 ));
             }
-            hydrate_deferred_comment_sides(runner, ctx, &mut snapshot)?;
+            hydrate_deferred_comment_sides(runner, ctx, &mut snapshot, expected_state)?;
             ensure_pending_snapshot_within_limits(&snapshot, review_id)?;
             classify_pending_snapshot(&mut snapshot)?;
             snapshot.snapshot_digest = pending_snapshot_digest(&snapshot)?;
@@ -1124,6 +1124,7 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
     snapshot: &mut PendingReviewSnapshot,
+    expected_state: &str,
 ) -> Result<(), ForgeError> {
     let needs_recovery = snapshot.inline_comments.iter().any(|comment| {
         comment.subject_type == "LINE"
@@ -1149,11 +1150,30 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
         ctx,
         &snapshot.pr_url,
         snapshot.number,
+        &snapshot.review_id,
         &requested_ids,
     )?;
     if recovered.head_sha != snapshot.head_sha {
         return Err(snapshot_incomplete(
             "the PR head changed while recovering pending review comment anchors",
+            Some(format!("review_id={}", snapshot.review_id)),
+        ));
+    }
+    let review = &recovered.review;
+    if review.number != snapshot.number
+        || review.pr_url != snapshot.pr_url
+        || review.head_sha != snapshot.head_sha
+        || review.review_id != snapshot.review_id
+        || review.review_url != snapshot.review_url
+        || review.author != snapshot.author
+        || review.state != expected_state
+        || review.commit_sha != snapshot.commit_sha
+        || review.body != snapshot.body
+        || review.viewer_did_author != snapshot.viewer_did_author
+        || review.viewer_can_delete != snapshot.viewer_can_delete
+    {
+        return Err(snapshot_incomplete(
+            "pending review metadata changed while recovering comment anchors",
             Some(format!("review_id={}", snapshot.review_id)),
         ));
     }
@@ -1867,7 +1887,23 @@ mod tests {
     fn truncated_comment_thread(path: &str, comment_id: &str) -> BackendSuccess {
         BackendSuccess {
             stdout: serde_json::json!({
-                "data": {"repository": {"pullRequest": {
+                "data": {
+                    "review": {
+                        "id": "PRR_pending",
+                        "url": "https://github.com/acme/widgets/pull/7#pullrequestreview-9",
+                        "author": {"login": "review-bot"},
+                        "state": "PENDING",
+                        "commit": {"oid": "head-7"},
+                        "body": "Summary",
+                        "viewerDidAuthor": true,
+                        "viewerCanDelete": true,
+                        "pullRequest": {
+                            "number": 7,
+                            "url": "https://github.com/acme/widgets/pull/7",
+                            "headRefOid": "head-7"
+                        }
+                    },
+                    "repository": {"pullRequest": {
                     "headRefOid": "head-7",
                     "reviewThreads": {
                         "nodes": [{
@@ -1895,11 +1931,72 @@ mod tests {
                         }],
                         "pageInfo": {"hasNextPage": false, "endCursor": null}
                     }
-                }}}
+                }}
+                }
             })
             .to_string(),
             stderr: String::new(),
         }
+    }
+
+    fn mixed_pending_snapshot_and_threads(
+        direct_thread_body: &str,
+    ) -> (BackendSuccess, BackendSuccess) {
+        let mut pending = truncated_pending_snapshot_page();
+        let mut pending_value: serde_json::Value =
+            serde_json::from_str(&pending.stdout).expect("pending fixture");
+        pending_value["data"]["node"]["comments"]["totalCount"] = 2.into();
+        pending_value["data"]["node"]["comments"]["nodes"]
+            .as_array_mut()
+            .expect("pending comments")
+            .push(serde_json::json!({
+                "id": "PRRC_direct",
+                "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct",
+                "author": {"login": "review-bot"},
+                "body": "direct-side finding",
+                "createdAt": "2026-07-20T12:00:00Z",
+                "path": "src/direct.rs",
+                "line": 12,
+                "originalLine": 12,
+                "diffSide": "RIGHT",
+                "startLine": null,
+                "originalStartLine": null,
+                "startDiffSide": null,
+                "subjectType": "LINE"
+            }));
+        pending.stdout = pending_value.to_string();
+
+        let mut threads = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut thread_value: serde_json::Value =
+            serde_json::from_str(&threads.stdout).expect("thread fixture");
+        thread_value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+            .as_array_mut()
+            .expect("review threads")
+            .push(serde_json::json!({
+                "id": "PRRT_direct",
+                "isResolved": false,
+                "isOutdated": false,
+                "path": "src/direct.rs",
+                "diffSide": "RIGHT",
+                "line": 12,
+                "originalLine": 12,
+                "originalStartLine": null,
+                "startDiffSide": null,
+                "startLine": null,
+                "subjectType": "LINE",
+                "comments": {
+                    "nodes": [{
+                        "id": "PRRC_direct",
+                        "author": {"login": "review-bot"},
+                        "body": direct_thread_body,
+                        "createdAt": "2026-07-20T12:00:00Z",
+                        "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct"
+                    }],
+                    "pageInfo": {"hasNextPage": false, "endCursor": null}
+                }
+            }));
+        threads.stdout = thread_value.to_string();
+        (pending, threads)
     }
 
     #[test]
@@ -1965,62 +2062,28 @@ mod tests {
     }
 
     #[test]
+    fn pending_snapshot_recovery_rejects_cross_read_review_metadata_drift() {
+        let mut thread = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&thread.stdout).expect("thread fixture");
+        value["data"]["review"]["body"] = "changed between provider reads".into();
+        thread.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![truncated_pending_snapshot_page(), thread]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("cross-read review metadata drift must fail before snapshot authority");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(
+            error.to_string().contains("metadata changed"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn pending_snapshot_recovery_rejects_drift_in_a_non_deferred_comment() {
-        let mut pending = truncated_pending_snapshot_page();
-        let mut pending_value: serde_json::Value =
-            serde_json::from_str(&pending.stdout).expect("pending fixture");
-        pending_value["data"]["node"]["comments"]["totalCount"] = 2.into();
-        pending_value["data"]["node"]["comments"]["nodes"]
-            .as_array_mut()
-            .expect("pending comments")
-            .push(serde_json::json!({
-                "id": "PRRC_direct",
-                "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct",
-                "author": {"login": "review-bot"},
-                "body": "direct-side finding",
-                "createdAt": "2026-07-20T12:00:00Z",
-                "path": "src/direct.rs",
-                "line": 12,
-                "originalLine": 12,
-                "diffSide": "RIGHT",
-                "startLine": null,
-                "originalStartLine": null,
-                "startDiffSide": null,
-                "subjectType": "LINE"
-            }));
-        pending.stdout = pending_value.to_string();
-
-        let mut threads = truncated_comment_thread("src/new.rs", "PRRC_truncated");
-        let mut thread_value: serde_json::Value =
-            serde_json::from_str(&threads.stdout).expect("thread fixture");
-        thread_value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-            .as_array_mut()
-            .expect("review threads")
-            .push(serde_json::json!({
-                "id": "PRRT_direct",
-                "isResolved": false,
-                "isOutdated": false,
-                "path": "src/direct.rs",
-                "diffSide": "RIGHT",
-                "line": 12,
-                "originalLine": 12,
-                "originalStartLine": null,
-                "startDiffSide": null,
-                "startLine": null,
-                "subjectType": "LINE",
-                "comments": {
-                    "nodes": [{
-                        "id": "PRRC_direct",
-                        "author": {"login": "review-bot"},
-                        "body": "changed between provider reads",
-                        "createdAt": "2026-07-20T12:00:00Z",
-                        "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct"
-                    }],
-                    "pageInfo": {"hasNextPage": false, "endCursor": null}
-                }
-            }));
-        threads.stdout = thread_value.to_string();
-
+        let (pending, threads) =
+            mixed_pending_snapshot_and_threads("changed between provider reads");
         let runner = ScriptedRunner::new(vec![pending, threads]);
         let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
             .expect_err("every inline comment must be stable across provider reads");
@@ -2030,6 +2093,63 @@ mod tests {
             error.to_string().contains("identity differs"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn pending_snapshot_recovers_a_stable_mixed_comment_set() {
+        let (pending, threads) = mixed_pending_snapshot_and_threads("direct-side finding");
+        let runner = ScriptedRunner::new(vec![pending, threads]);
+
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("stable mixed comments should authenticate together")
+            .expect("pending snapshot");
+
+        assert_eq!(snapshot.inline_comments.len(), 2);
+        assert_eq!(
+            snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        assert_eq!(
+            snapshot.inline_comments[1].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        assert_eq!(snapshot.inline_comments[1].body, "direct-side finding");
+    }
+
+    #[test]
+    fn pending_snapshot_authenticates_a_file_comment_during_line_recovery() {
+        let (mut pending, mut threads) = mixed_pending_snapshot_and_threads("direct-side finding");
+        let mut pending_value: serde_json::Value =
+            serde_json::from_str(&pending.stdout).expect("pending fixture");
+        let file_comment = &mut pending_value["data"]["node"]["comments"]["nodes"][1];
+        file_comment["diffSide"] = serde_json::Value::Null;
+        file_comment["line"] = serde_json::Value::Null;
+        file_comment["originalLine"] = serde_json::Value::Null;
+        file_comment["subjectType"] = "FILE".into();
+        pending.stdout = pending_value.to_string();
+
+        let mut thread_value: serde_json::Value =
+            serde_json::from_str(&threads.stdout).expect("thread fixture");
+        let file_thread =
+            &mut thread_value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][1];
+        file_thread["diffSide"] = serde_json::Value::Null;
+        file_thread["line"] = serde_json::Value::Null;
+        file_thread["originalLine"] = serde_json::Value::Null;
+        file_thread["subjectType"] = "FILE".into();
+        threads.stdout = thread_value.to_string();
+
+        let runner = ScriptedRunner::new(vec![pending, threads]);
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("file comments should authenticate during line recovery")
+            .expect("pending snapshot");
+
+        assert_eq!(snapshot.inline_comments.len(), 2);
+        assert_eq!(
+            snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+        assert_eq!(snapshot.inline_comments[1].subject_type, "FILE");
+        assert_eq!(snapshot.inline_comments[1].diff_side, None);
     }
 
     #[test]

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -1125,19 +1125,24 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
     ctx: &ProviderContext,
     snapshot: &mut PendingReviewSnapshot,
 ) -> Result<(), ForgeError> {
+    let needs_recovery = snapshot.inline_comments.iter().any(|comment| {
+        comment.subject_type == "LINE"
+            && (comment.diff_side.is_none()
+                || (comment.start_line.is_some() && comment.start_diff_side.is_none()))
+    });
+    if !needs_recovery {
+        return Ok(());
+    }
+
+    // Once recovery requires a second provider read, authenticate every inline
+    // comment against that same read. Otherwise a direct-side comment could
+    // change between reads and leave the snapshot with a stale body beside a
+    // freshly recovered anchor.
     let requested_ids = snapshot
         .inline_comments
         .iter()
-        .filter(|comment| {
-            comment.subject_type == "LINE"
-                && (comment.diff_side.is_none()
-                    || (comment.start_line.is_some() && comment.start_diff_side.is_none()))
-        })
         .map(|comment| comment.id.clone())
         .collect::<std::collections::BTreeSet<_>>();
-    if requested_ids.is_empty() {
-        return Ok(());
-    }
 
     let recovered = pr_review_threads::compute_comment_anchors_for_pr(
         runner,
@@ -1154,12 +1159,6 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
     }
 
     for comment in &mut snapshot.inline_comments {
-        if comment.subject_type != "LINE"
-            || (comment.diff_side.is_some()
-                && (comment.start_line.is_none() || comment.start_diff_side.is_some()))
-        {
-            continue;
-        }
         let anchor = recovered.anchors.get(&comment.id).ok_or_else(|| {
             snapshot_incomplete(
                 "pending review comment is missing from the exact review-thread snapshot",
@@ -1187,6 +1186,9 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
                 "pending review comment anchor differs from its review thread",
                 Some(format!("comment_id={}", comment.id)),
             ));
+        }
+        if comment.subject_type != "LINE" {
+            continue;
         }
         let diff_side = anchor.diff_side.as_deref().ok_or_else(|| {
             snapshot_incomplete(
@@ -1954,6 +1956,74 @@ mod tests {
 
         let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
             .expect_err("cross-read comment drift must fail before snapshot authority exists");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(
+            error.to_string().contains("identity differs"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_rejects_drift_in_a_non_deferred_comment() {
+        let mut pending = truncated_pending_snapshot_page();
+        let mut pending_value: serde_json::Value =
+            serde_json::from_str(&pending.stdout).expect("pending fixture");
+        pending_value["data"]["node"]["comments"]["totalCount"] = 2.into();
+        pending_value["data"]["node"]["comments"]["nodes"]
+            .as_array_mut()
+            .expect("pending comments")
+            .push(serde_json::json!({
+                "id": "PRRC_direct",
+                "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct",
+                "author": {"login": "review-bot"},
+                "body": "direct-side finding",
+                "createdAt": "2026-07-20T12:00:00Z",
+                "path": "src/direct.rs",
+                "line": 12,
+                "originalLine": 12,
+                "diffSide": "RIGHT",
+                "startLine": null,
+                "originalStartLine": null,
+                "startDiffSide": null,
+                "subjectType": "LINE"
+            }));
+        pending.stdout = pending_value.to_string();
+
+        let mut threads = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut thread_value: serde_json::Value =
+            serde_json::from_str(&threads.stdout).expect("thread fixture");
+        thread_value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+            .as_array_mut()
+            .expect("review threads")
+            .push(serde_json::json!({
+                "id": "PRRT_direct",
+                "isResolved": false,
+                "isOutdated": false,
+                "path": "src/direct.rs",
+                "diffSide": "RIGHT",
+                "line": 12,
+                "originalLine": 12,
+                "originalStartLine": null,
+                "startDiffSide": null,
+                "startLine": null,
+                "subjectType": "LINE",
+                "comments": {
+                    "nodes": [{
+                        "id": "PRRC_direct",
+                        "author": {"login": "review-bot"},
+                        "body": "changed between provider reads",
+                        "createdAt": "2026-07-20T12:00:00Z",
+                        "url": "https://github.com/acme/widgets/pull/7#discussion_PRRC_direct"
+                    }],
+                    "pageInfo": {"hasNextPage": false, "endCursor": null}
+                }
+            }));
+        threads.stdout = thread_value.to_string();
+
+        let runner = ScriptedRunner::new(vec![pending, threads]);
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("every inline comment must be stable across provider reads");
 
         assert_eq!(error.kind(), "review_snapshot_incomplete");
         assert!(

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -413,6 +413,141 @@ esac
     .replace("@SECOND_PAGE@", &second_page)
 }
 
+fn truncated_pending_snapshot_script(capture: &str) -> String {
+    let pending = serde_json::json!({
+        "data": {"node": {
+            "id": "PRR_pending",
+            "url": "https://github.com/acme/widgets/pull/42#pullrequestreview-102",
+            "author": {"login": "review-bot"},
+            "state": "PENDING",
+            "commit": {"oid": "head-new"},
+            "body": "Summary",
+            "viewerDidAuthor": true,
+            "viewerCanDelete": true,
+            "comments": {
+                "totalCount": 1,
+                "nodes": [{
+                    "id": "PRRC_truncated",
+                    "url": "https://github.com/acme/widgets/pull/42#discussion_r123",
+                    "author": {"login": "review-bot"},
+                    "body": "finding",
+                    "createdAt": "2026-07-20T12:00:00Z",
+                    "path": "src/lib.rs",
+                    "diffHunk": "@@ -970,1 +970,1 @@\n-old context\n+new context",
+                    "line": 982,
+                    "originalLine": 982,
+                    "startLine": null,
+                    "originalStartLine": null,
+                    "subjectType": "LINE"
+                }],
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            },
+            "pullRequest": {
+                "number": 42,
+                "url": "https://github.com/acme/widgets/pull/42",
+                "headRefOid": "head-new"
+            }
+        }}
+    })
+    .to_string();
+    let threads = serde_json::json!({
+        "data": {"repository": {"pullRequest": {
+            "headRefOid": "head-new",
+            "reviewThreads": {
+                "nodes": [{
+                    "id": "PRRT_truncated",
+                    "isResolved": false,
+                    "isOutdated": false,
+                    "path": "src/lib.rs",
+                    "diffSide": "RIGHT",
+                    "line": 982,
+                    "originalLine": 982,
+                    "originalStartLine": null,
+                    "startDiffSide": null,
+                    "startLine": null,
+                    "subjectType": "LINE",
+                    "comments": {
+                        "nodes": [{
+                            "id": "PRRC_truncated",
+                            "author": {"login": "review-bot"},
+                            "body": "finding",
+                            "createdAt": "2026-07-20T12:00:00Z",
+                            "url": "https://github.com/acme/widgets/pull/42#discussion_r123"
+                        }],
+                        "pageInfo": {"hasNextPage": false, "endCursor": null}
+                    }
+                }],
+                "pageInfo": {"hasNextPage": false, "endCursor": null}
+            }
+        }}}
+    })
+    .to_string();
+    r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "@CAPTURE@"
+case "$1 $2" in
+  "pr view")
+    printf '%s\n' '{"number":42,"url":"https://github.com/acme/widgets/pull/42","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"fix/reviews","headRefOid":"head-new","title":"fix: reviews","body":""}'
+    ;;
+  "api graphql")
+    case "$*" in
+      *"reviewThreads(first: 100"*)
+        printf '%s\n' '@THREADS@'
+        ;;
+      *"comments(first: 100"*)
+        printf '%s\n' '@PENDING@'
+        ;;
+      *)
+        echo "unexpected graphql args: $*" >&2
+        exit 99
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#
+    .replace("@CAPTURE@", capture)
+    .replace("@PENDING@", &pending)
+    .replace("@THREADS@", &threads)
+}
+
+#[test]
+fn pr_pending_review_inspect_recovers_a_truncated_hunk_from_the_exact_thread() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("truncated-hunk-calls.log");
+    let script = truncated_pending_snapshot_script(&capture.to_string_lossy());
+    let stub = stub.gh_stub(&script);
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let envelope = parse_envelope(&out.stdout);
+    assert_eq!(
+        envelope["data"]["snapshot"]["inline_comments"][0]["diff_side"],
+        "RIGHT"
+    );
+    let calls = fs::read_to_string(capture).expect("read gh calls");
+    assert!(calls.contains("reviewThreads(first: 100"), "{calls}");
+}
+
 #[test]
 fn pr_pending_review_inspect_digests_later_comment_pages() {
     let mut digests = Vec::new();

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -413,7 +413,30 @@ esac
     .replace("@SECOND_PAGE@", &second_page)
 }
 
+fn truncated_pending_review_receipt() -> (String, String, String, String) {
+    let semantic_body = "finding";
+    let manifest = vec![ReviewCommentManifestItem {
+        index: 0,
+        path: "src/lib.rs".to_string(),
+        line: Some(982),
+        side: "RIGHT".to_string(),
+        start_line: None,
+        start_side: None,
+        subject_type: "LINE".to_string(),
+        body_digest: sha256_digest(semantic_body.as_bytes()),
+    }];
+    let (review_run_id, state_marker) = receipt_marker("Summary", manifest);
+    let review_body = format!("Summary\n<!-- forge-cli:review-run:v1 run={review_run_id} -->");
+    let comment_body = format!(
+        "{semantic_body}\n<!-- forge-cli:review-finding:v1 run={review_run_id} digest={} -->",
+        sha256_digest(semantic_body.as_bytes())
+    );
+    (review_run_id, state_marker, review_body, comment_body)
+}
+
 fn truncated_pending_snapshot_script(capture: &str) -> String {
+    let (_review_run_id, state_marker, review_body, comment_body) =
+        truncated_pending_review_receipt();
     let pending = serde_json::json!({
         "data": {"node": {
             "id": "PRR_pending",
@@ -421,7 +444,7 @@ fn truncated_pending_snapshot_script(capture: &str) -> String {
             "author": {"login": "review-bot"},
             "state": "PENDING",
             "commit": {"oid": "head-new"},
-            "body": "Summary",
+            "body": review_body,
             "viewerDidAuthor": true,
             "viewerCanDelete": true,
             "comments": {
@@ -430,7 +453,7 @@ fn truncated_pending_snapshot_script(capture: &str) -> String {
                     "id": "PRRC_truncated",
                     "url": "https://github.com/acme/widgets/pull/42#discussion_r123",
                     "author": {"login": "review-bot"},
-                    "body": "finding",
+                    "body": comment_body,
                     "createdAt": "2026-07-20T12:00:00Z",
                     "path": "src/lib.rs",
                     "diffHunk": "@@ -970,1 +970,1 @@\n-old context\n+new context",
@@ -451,9 +474,25 @@ fn truncated_pending_snapshot_script(capture: &str) -> String {
     })
     .to_string();
     let threads = serde_json::json!({
-        "data": {"repository": {"pullRequest": {
-            "headRefOid": "head-new",
-            "reviewThreads": {
+        "data": {
+            "review": {
+                "id": "PRR_pending",
+                "url": "https://github.com/acme/widgets/pull/42#pullrequestreview-102",
+                "author": {"login": "review-bot"},
+                "state": "PENDING",
+                "commit": {"oid": "head-new"},
+                "body": review_body,
+                "viewerDidAuthor": true,
+                "viewerCanDelete": true,
+                "pullRequest": {
+                    "number": 42,
+                    "url": "https://github.com/acme/widgets/pull/42",
+                    "headRefOid": "head-new"
+                }
+            },
+            "repository": {"pullRequest": {
+                "headRefOid": "head-new",
+                "reviewThreads": {
                 "nodes": [{
                     "id": "PRRT_truncated",
                     "isResolved": false,
@@ -470,7 +509,7 @@ fn truncated_pending_snapshot_script(capture: &str) -> String {
                         "nodes": [{
                             "id": "PRRC_truncated",
                             "author": {"login": "review-bot"},
-                            "body": "finding",
+                            "body": comment_body,
                             "createdAt": "2026-07-20T12:00:00Z",
                             "url": "https://github.com/acme/widgets/pull/42#discussion_r123"
                         }],
@@ -478,10 +517,23 @@ fn truncated_pending_snapshot_script(capture: &str) -> String {
                     }
                 }],
                 "pageInfo": {"hasNextPage": false, "endCursor": null}
-            }
-        }}}
+                }
+            }}
+        }
     })
     .to_string();
+    let mut submitted: serde_json::Value =
+        serde_json::from_str(&pending).expect("truncated pending snapshot fixture");
+    submitted["data"]["node"]["state"] = "COMMENTED".into();
+    submitted["data"]["node"]["viewerCanDelete"] = false.into();
+    let submitted = submitted.to_string();
+    let mut submitted_threads: serde_json::Value =
+        serde_json::from_str(&threads).expect("truncated thread snapshot fixture");
+    submitted_threads["data"]["review"]["state"] = "COMMENTED".into();
+    submitted_threads["data"]["review"]["viewerCanDelete"] = false.into();
+    let submitted_threads = submitted_threads.to_string();
+    let submitted_flag = format!("{capture}.submitted");
+    let state_marker = serde_json::to_string(&state_marker).expect("serialize state marker");
     r#"#!/bin/sh
 set -eu
 printf '%s\n' "$*" >> "@CAPTURE@"
@@ -491,11 +543,26 @@ case "$1 $2" in
     ;;
   "api graphql")
     case "$*" in
+      *"pullRequest(number: \$pr) { comments(first: 100"*)
+        printf '%s\n' '{"data":{"viewer":{"login":"review-bot"},"repository":{"pullRequest":{"comments":{"nodes":[{"author":{"login":"review-bot"},"body":@STATE_MARKER@}],"pageInfo":{"hasNextPage":false,"endCursor":"state-tip"}}}}}}'
+        ;;
+      *"submitPullRequestReview(input:"*)
+        : > "@SUBMITTED_FLAG@"
+        printf '%s\n' '{"data":{"submitPullRequestReview":{"pullRequestReview":{"url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102"}}}}'
+        ;;
       *"reviewThreads(first: 100"*)
-        printf '%s\n' '@THREADS@'
+        if [ -e "@SUBMITTED_FLAG@" ]; then
+          printf '%s\n' '@SUBMITTED_THREADS@'
+        else
+          printf '%s\n' '@THREADS@'
+        fi
         ;;
       *"comments(first: 100"*)
-        printf '%s\n' '@PENDING@'
+        if [ -e "@SUBMITTED_FLAG@" ]; then
+          printf '%s\n' '@SUBMITTED@'
+        else
+          printf '%s\n' '@PENDING@'
+        fi
         ;;
       *)
         echo "unexpected graphql args: $*" >&2
@@ -512,6 +579,10 @@ esac
     .replace("@CAPTURE@", capture)
     .replace("@PENDING@", &pending)
     .replace("@THREADS@", &threads)
+    .replace("@SUBMITTED_THREADS@", &submitted_threads)
+    .replace("@SUBMITTED@", &submitted)
+    .replace("@SUBMITTED_FLAG@", &submitted_flag)
+    .replace("@STATE_MARKER@", &state_marker)
 }
 
 #[test]
@@ -546,6 +617,79 @@ fn pr_pending_review_inspect_recovers_a_truncated_hunk_from_the_exact_thread() {
     );
     let calls = fs::read_to_string(capture).expect("read gh calls");
     assert!(calls.contains("reviewThreads(first: 100"), "{calls}");
+}
+
+#[test]
+fn pr_pending_review_resume_submit_recovers_a_truncated_hunk_before_mutation() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("truncated-hunk-submit-calls.log");
+    let (review_run_id, _, _, _) = truncated_pending_review_receipt();
+    let script = truncated_pending_snapshot_script(&capture.to_string_lossy());
+    let stub = stub.gh_stub(&script);
+
+    let inspect = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+    assert_eq!(
+        inspect.code, 0,
+        "stdout={}\nstderr={}",
+        inspect.stdout, inspect.stderr
+    );
+    let digest = parse_envelope(&inspect.stdout)["data"]["snapshot"]["snapshot_digest"]
+        .as_str()
+        .expect("snapshot digest")
+        .to_string();
+
+    let output = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "resume-submit",
+            "42",
+            "--review",
+            "PRR_pending",
+            "--review-run-id",
+            &review_run_id,
+            "--expected-head",
+            "head-new",
+            "--expected-commit",
+            "head-new",
+            "--expected-snapshot",
+            &digest,
+            "--decision",
+            "comments-only",
+        ],
+    );
+
+    assert_eq!(
+        output.code, 0,
+        "stdout={}\nstderr={}",
+        output.stdout, output.stderr
+    );
+    let calls = fs::read_to_string(capture).expect("read gh calls");
+    assert!(calls.contains("reviewThreads(first: 100"), "{calls}");
+    assert_eq!(calls.matches("submitPullRequestReview(input:").count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Recover provider-valid GitHub pending reviews when an inline comment's `diffHunk` is truncated before its anchor. The change is limited to canonical pending-review snapshot construction in `forge-cli`; it does not weaken receipt, current-head, or mutation guards.

## Problem

- Expected: a viewer-owned current-head pending review can be snapshotted and resumed when GitHub's exact review thread still supplies its authoritative side.
- Actual: side inference fails when the pending-review `diffHunk` omits the anchor, so guarded submit/discard cannot produce their required snapshot digest.
- Impact: the released owner can strand a receipt-bound pending review even though the provider still exposes the exact comment and thread.

## Reproduction

1. Create a pending GitHub review with an inline comment whose anchor falls outside the provider-returned `diffHunk`.
2. Run `forge-cli pr pending-review inspect` for the exact review.
3. Observe `review_snapshot_incomplete` because the anchor side cannot be inferred from the truncated hunk.

## Issues Found

Refs #1548

## Fix Approach

- Defer unresolved line-side inference to the exact current-head review-thread surface.
- Once a second provider read is required, authenticate the pending review metadata and every inline comment from the first snapshot against that read before granting snapshot authority.
- Match exact provider comment identities and anchor fields while applying recovered side fields only where needed; support provider-valid file comments with no diff side.
- Bound pagination to 100 threads per page and 100 pages, stop after every requested root comment is found, and fail closed on head/review/comment drift, missing or duplicate comments, field drift, and cursor anomalies.

## Test-First Evidence

- RED: the focused regression failed with `review_snapshot_incomplete` at `anchor_line=982` before the production change.
- Evidence v2 is bound to baseline `e0be47fc5b678c708b15958f9ea9bab3e71c6558` and final signed head `bbc75c874a25bf4ebeff955cc597d7ffb0949b34` (delivery attempt 4).
- Final delivery tree: `96695248d1bf7efca635c333a53c298b1a3522b7`; diff digest: `sha256:3a46226ef403ec91ce9fe63f607956bf141c90de3d82ce11e8db879056d94923`.
- The verified record declares no residual affected-test gaps.

## Test plan

- Anchor paginator regressions: 5/5 passed (page-two recovery plus fail-closed head drift, repeated cursor, missing target, and duplicate target).
- Pending-review integration: 42/42 passed; guarded resume-submit mutation path: 1/1 passed.
- Focused recovery set: 7/7 passed, plus the line-and-file-comment recovery case 1/1.
- Direct `cargo test -p nils-forge-cli`: 890 unit tests passed. The integration rerun reached 498 passes with one known unrelated Forgejo loopback fixture failure; every affected case passed independently.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`: docs/leak audits, fmt, warnings-denied clippy, 1,389/1,389 nextest cases, and doctests passed.
- `.agents/scripts/pre-pr.sh --full`: all audits, 8 project skill shell suites, fmt, warnings-denied all-workspace clippy, 8,765/8,765 workspace tests (1 designed skip), leak probe, and doctests passed.

## Risk / Notes

- Medium provider-boundary risk: recovery composes two authenticated provider reads and compares their review and comment identities before permitting a mutation.
- No raw provider mutation, signing bypass, check waiver, or review-thread waiver is used.
