### PR TITLE
fix(agent-hook): converge managed startup activity admission

### DIFF
--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -914,7 +914,7 @@ lane, and a typed runtime fault is handled per lane:
 | Lane | Events | Behavior on a typed runtime fault |
 | --- | --- | --- |
 | conversation | `UserPromptSubmit`, `SessionStart` | degrade to read-only with `coordination-degraded-read-only` |
-| audited read-only | `PreToolUse` whose in-process effect is exactly `read_only` | an activity fault warns and later authoritative rules still run |
+| audited read-only | `PreToolUse` whose in-process effect is exactly `read_only` | warn with `activity-degraded-audited-read-only`; later authoritative rules still run |
 | terminal | `Stop`, `StopFailure` | terminal warning with reconciliation-pending evidence |
 | mutation | every other event | unchanged fail-closed posture |
 
@@ -923,8 +923,9 @@ Only faults with a known recovery path are degradable:
 `runtime-version-skew`, and `activity-helper-unresolvable`. An unrecognized error
 keeps the existing fail-closed handling rather than being degraded on a guess.
 Within `agent-session.activity.v1`, the same bounded handling additionally
-recognizes its own helper and execution faults. An incomplete managed identity
-is never a degradation authority: it returns
+recognizes its own helper and execution faults. An incomplete managed identity,
+including selectorless identity while trusted managed metadata remains, is never
+a degradation authority: it returns
 `session-activity-identity-incomplete` and refuses provider work until the
 trusted launcher establishes the exact session/runtime pair.
 Bare `pwd` with no arguments or only `-L`/`-P`/`--logical`/`--physical` is the
@@ -932,7 +933,9 @@ initial audited Bash probe; composition, operands, or unknown options remain `un
 durable `advisory` or `off` mode may warn for another activity fault, but this
 does not change any other rule or admit an enforce-mode mutation.
 
-A degraded decision carries the fault code first, then the lane code, so
+A degraded decision carries the fault code first, then the stable lane code
+(`coordination-degraded-read-only`, `activity-degraded-audited-read-only`, or
+`activity-degraded-advisory-off`), so
 diagnostics keep the precise cause. Its human context states one primary
 diagnosis and one safe next action instead of a comma-separated list of every
 selected policy; the full reason list remains available in `--format json` and on

--- a/crates/agent-hook/docs/specs/agent-hook-v1.md
+++ b/crates/agent-hook/docs/specs/agent-hook-v1.md
@@ -889,13 +889,15 @@ plus `locked` rule deny at random, because whether the child won the race
 depended on machine load, and a `locked` rule offers no override to recover
 with.
 
-`agent-session.activity.v1` retains one terminal-only degradation boundary.
+`agent-session.activity.v1` is metadata observation, not mutation authority.
 Failure to record a `Stop` observation returns the stable warning
 `activity-stop-reconciliation-required` instead of denying provider
 termination. This prevents a missing, stale, or temporarily unavailable
-activity store from creating a non-terminating Stop-hook loop. The same
-capability remains fail-closed for `UserPromptSubmit`, `PreToolUse`, and every
-other non-terminal event, and the terminal warning does not release or alter
+activity store from creating a non-terminating Stop-hook loop. A typed activity
+fault also warns for conversation, a closed-set audited read-only `PreToolUse`,
+and a request authenticated to durable `advisory` or `off` mode. Every other
+non-terminal request retains the configured failure posture. No activity
+warning releases or alters
 claims, leases, operations, brokers, worktrees, or session state. Any retained
 activity uncertainty therefore remains visible for typed external
 reconciliation after the provider runner exits. Codex `Stop` renders this
@@ -912,6 +914,7 @@ lane, and a typed runtime fault is handled per lane:
 | Lane | Events | Behavior on a typed runtime fault |
 | --- | --- | --- |
 | conversation | `UserPromptSubmit`, `SessionStart` | degrade to read-only with `coordination-degraded-read-only` |
+| audited read-only | `PreToolUse` whose in-process effect is exactly `read_only` | an activity fault warns and later authoritative rules still run |
 | terminal | `Stop`, `StopFailure` | terminal warning with reconciliation-pending evidence |
 | mutation | every other event | unchanged fail-closed posture |
 
@@ -919,6 +922,15 @@ Only faults with a known recovery path are degradable:
 `coordination-unavailable`, `coordination-untrusted`, `coordination-invalid`,
 `runtime-version-skew`, and `activity-helper-unresolvable`. An unrecognized error
 keeps the existing fail-closed handling rather than being degraded on a guess.
+Within `agent-session.activity.v1`, the same bounded handling additionally
+recognizes its own helper and execution faults. An incomplete managed identity
+is never a degradation authority: it returns
+`session-activity-identity-incomplete` and refuses provider work until the
+trusted launcher establishes the exact session/runtime pair.
+Bare `pwd` with no arguments or only `-L`/`-P`/`--logical`/`--physical` is the
+initial audited Bash probe; composition, operands, or unknown options remain `unknown`. A trusted
+durable `advisory` or `off` mode may warn for another activity fault, but this
+does not change any other rule or admit an enforce-mode mutation.
 
 A degraded decision carries the fault code first, then the lane code, so
 diagnostics keep the precise cause. Its human context states one primary
@@ -981,7 +993,8 @@ prevent. An override that does not resolve to an executable regular file is
 therefore treated as absent, and the daemon-pinned `PATH` decides instead. This is
 a deliberate change to a fail-closed boundary rather than a downgrade: anyone able
 to set `AGENT_SESSION_BIN` can already set `PATH`, and the pinned `PATH` is
-daemon-controlled. The discarded override is recorded as
+daemon-controlled. The resolved executable is pinned as an absolute path for
+the activity attempt. The discarded override is recorded as
 `activity-helper-unresolvable` so it cannot silently mask a misconfiguration, and
 an empty assignment is the normalized "resolve through the pinned `PATH`" value.
 

--- a/crates/agent-hook/src/adapter.rs
+++ b/crates/agent-hook/src/adapter.rs
@@ -928,6 +928,11 @@ fn target_paths(
     let mut execution = string_at(object, &["cwd", "working_directory"])
         .map(PathBuf::from)
         .filter(|path| path.is_absolute());
+    if matches!(matcher, Some("Bash" | "bash"))
+        && let Some(repo) = trusted_semantic_commit_repo(object, execution.as_deref())?
+    {
+        execution = Some(repo);
+    }
     let nested = object.get("tool_input").and_then(Value::as_object);
     let mut targets = if product == Product::Dsh {
         let Some(input) = nested else {
@@ -1168,8 +1173,97 @@ fn target_binding_material(binding: &TargetBinding) -> Result<Vec<u8>, HookError
 }
 
 pub(crate) fn command_text(object: &Map<String, Value>) -> Option<&str> {
-    string_at(object, &["command"])
-        .or_else(|| nested_string(object, "tool_input", &["command", "cmd"]))
+    let tool_input = object.get("tool_input").and_then(Value::as_object);
+    let dsh_arguments = object
+        .get("tool")
+        .and_then(Value::as_object)
+        .and_then(|tool| tool.get("arguments"))
+        .and_then(Value::as_object);
+    let candidates = [
+        object.get("command").and_then(Value::as_str),
+        tool_input
+            .and_then(|input| input.get("command"))
+            .and_then(Value::as_str),
+        tool_input
+            .and_then(|input| input.get("cmd"))
+            .and_then(Value::as_str),
+        dsh_arguments
+            .and_then(|input| input.get("command"))
+            .and_then(Value::as_str),
+        dsh_arguments
+            .and_then(|input| input.get("cmd"))
+            .and_then(Value::as_str),
+    ];
+    let mut selected = None;
+    for candidate in candidates.into_iter().flatten() {
+        if selected.is_some_and(|value| value != candidate) {
+            return None;
+        }
+        selected = Some(candidate);
+    }
+    selected
+}
+
+fn trusted_semantic_commit_repo(
+    object: &Map<String, Value>,
+    execution: Option<&Path>,
+) -> Result<Option<PathBuf>, HookError> {
+    let Some(command) = command_text(object) else {
+        return Ok(None);
+    };
+    let Ok(mut words) = crate::read_only::parse_simple_command(command) else {
+        return Ok(None);
+    };
+    if words.first().map(String::as_str) == Some("builtin")
+        && words.get(1).map(String::as_str) == Some("command")
+    {
+        words.drain(..2);
+    }
+    let Some(program) = words.first() else {
+        return Ok(None);
+    };
+    if Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        != Some("semantic-commit")
+        || !crate::effect::trusted_sibling(program)
+        || !matches!(
+            words.get(1).map(String::as_str),
+            Some("commit" | "fixup" | "squash" | "default-branch")
+        )
+    {
+        return Ok(None);
+    }
+
+    let mut repo = None;
+    for (index, argument) in words[2..].iter().enumerate() {
+        if argument.starts_with("--repo=") {
+            return Err(untrusted_target(
+                "trusted semantic-commit requires a separate --repo value",
+            ));
+        }
+        if argument != "--repo" {
+            continue;
+        }
+        if repo.is_some() {
+            return Err(untrusted_target(
+                "trusted semantic-commit requires exactly one --repo target",
+            ));
+        }
+        repo = words.get(index + 3).map(String::as_str);
+    }
+    let Some(repo) = repo else {
+        return Ok(None);
+    };
+    let repo = resolve_mutation_target(repo, execution)?;
+    let canonical = std::fs::canonicalize(repo)
+        .map_err(|_| untrusted_target("trusted semantic-commit --repo target is unavailable"))?;
+    if !canonical.is_dir() {
+        return Err(untrusted_target(
+            "trusted semantic-commit --repo target must be a directory",
+        ));
+    }
+    Ok(Some(canonical))
 }
 
 pub(crate) fn exact_main_agent_bootstrap_command(input: &[u8]) -> bool {
@@ -1317,15 +1411,6 @@ fn normalized_failure_reason(raw: Option<&str>) -> &'static str {
         Some("max_output_tokens") => "max_output_tokens",
         _ => "unknown",
     }
-}
-
-fn nested_string<'a>(
-    object: &'a Map<String, Value>,
-    parent: &str,
-    keys: &[&str],
-) -> Option<&'a str> {
-    let nested = object.get(parent)?.as_object()?;
-    string_at(nested, keys)
 }
 
 fn parse_provider_json(input: &[u8]) -> Result<Value, HookError> {

--- a/crates/agent-hook/src/effect.rs
+++ b/crates/agent-hook/src/effect.rs
@@ -98,6 +98,13 @@ fn classify_bash(raw: &[u8], request: &NormalizedRequest) -> OperationEffectClas
     else {
         return OperationEffectClass::Unknown;
     };
+    if name == "pwd"
+        && words[1..]
+            .iter()
+            .all(|arg| matches!(arg.as_str(), "-L" | "-P" | "--logical" | "--physical"))
+    {
+        return OperationEffectClass::ReadOnly;
+    }
     if name == "forge-cli" && words.get(1).map(String::as_str) == Some("repo") {
         return OperationEffectClass::ExternalMutation;
     }
@@ -560,6 +567,26 @@ mod tests {
     }
 
     #[test]
+    fn pwd_is_read_only_only_for_its_closed_argument_set() {
+        let directory = tempfile::tempdir().expect("execution directory");
+        let request = request_for(directory.path());
+        for command in ["pwd", "pwd -L", "/bin/pwd -P"] {
+            assert_eq!(
+                classify_command(command, &request),
+                OperationEffectClass::ReadOnly,
+                "command={command}"
+            );
+        }
+        for command in ["pwd target", "pwd --unknown", "pwd; touch changed"] {
+            assert_eq!(
+                classify_command(command, &request),
+                OperationEffectClass::Unknown,
+                "command={command}"
+            );
+        }
+    }
+
+    #[test]
     fn exact_default_branch_form_replaces_local_default_admission() {
         let (directory, head) = default_branch_fixture();
         let receipt = directory
@@ -756,5 +783,27 @@ mod tests {
                 "{label}: {command}"
             );
         }
+
+        let feature = tempfile::tempdir().expect("feature worktree");
+        let feature_git_dir = directory.path().join(".git/worktrees/feature");
+        fs::create_dir_all(&feature_git_dir).expect("feature git directory");
+        fs::write(feature_git_dir.join("HEAD"), "ref: refs/heads/feature\n").expect("feature HEAD");
+        fs::write(feature_git_dir.join("commondir"), "../..\n").expect("feature commondir");
+        fs::write(
+            feature.path().join(".git"),
+            format!("gitdir: {}\n", feature_git_dir.display()),
+        )
+        .expect("feature gitfile");
+        let managed_session_cwd = request_for(other_repo.path());
+        let explicit_repo = format!(
+            "{} commit --repo {} --type fix --subject convergence --body-bullet bounded",
+            trusted.display(),
+            feature.path().display()
+        );
+        assert_eq!(
+            classify_command(&explicit_repo, &managed_session_cwd),
+            OperationEffectClass::LocalReversible,
+            "an explicit governed --repo must outrank an unrelated managed-session cwd"
+        );
     }
 }

--- a/crates/agent-hook/src/effect.rs
+++ b/crates/agent-hook/src/effect.rs
@@ -92,19 +92,19 @@ fn classify_bash(raw: &[u8], request: &NormalizedRequest) -> OperationEffectClas
     let Some(program) = words.first() else {
         return OperationEffectClass::Unknown;
     };
-    let Some(name) = Path::new(program)
-        .file_name()
-        .and_then(|name| name.to_str())
-    else {
-        return OperationEffectClass::Unknown;
-    };
-    if name == "pwd"
+    if trusted_pwd(program)
         && words[1..]
             .iter()
             .all(|arg| matches!(arg.as_str(), "-L" | "-P" | "--logical" | "--physical"))
     {
         return OperationEffectClass::ReadOnly;
     }
+    let Some(name) = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return OperationEffectClass::Unknown;
+    };
     if name == "forge-cli" && words.get(1).map(String::as_str) == Some("repo") {
         return OperationEffectClass::ExternalMutation;
     }
@@ -430,7 +430,11 @@ fn full_object_id(value: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
-fn trusted_sibling(program: &str) -> bool {
+fn trusted_pwd(program: &str) -> bool {
+    matches!(program, "pwd" | "/bin/pwd" | "/usr/bin/pwd")
+}
+
+pub(crate) fn trusted_sibling(program: &str) -> bool {
     let candidate = if Path::new(program).components().count() > 1 {
         PathBuf::from(program)
     } else {
@@ -577,7 +581,13 @@ mod tests {
                 "command={command}"
             );
         }
-        for command in ["pwd target", "pwd --unknown", "pwd; touch changed"] {
+        for command in [
+            "pwd target",
+            "pwd --unknown",
+            "pwd; touch changed",
+            "./pwd",
+            "/tmp/pwd -P",
+        ] {
             assert_eq!(
                 classify_command(command, &request),
                 OperationEffectClass::Unknown,

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -391,6 +391,7 @@ fn evaluate_with_io(
     let operation_effect = if prepared.rules.iter().any(|prepared_rule| {
         prepared_rule.mode == RuleMode::Enforce
             && (prepared_rule.rule.timeout_posture == TimeoutPosture::EffectGated
+                || activity_capability(&prepared_rule.rule.capability)
                 || matches!(
                     prepared_rule.rule.capability,
                     Capability::DshPolicy {
@@ -403,6 +404,9 @@ fn evaluate_with_io(
     } else {
         OperationEffectClass::Unknown
     };
+    let coordination_mode = liveness
+        .as_ref()
+        .and_then(liveness::DispatchProjection::mode);
     let mut read_only_bypassed_rule_ids = BTreeSet::new();
     for prepared_rule in &prepared.rules {
         let rule = prepared_rule.rule;
@@ -507,12 +511,42 @@ fn evaluate_with_io(
             Ok(outcome) => outcome,
             Err(error)
                 if activity_recovery_candidate
-                    && matches!(rule.capability, Capability::SessionActivity { .. })
+                    && activity_capability(&rule.capability)
                     && activity_recovery_failure_is_deferrable(&error) =>
             {
                 simple(
                     DecisionAction::Allow,
                     "activity-recovery-deferred-to-coordination",
+                )
+            }
+            Err(error)
+                if activity_capability(&rule.capability)
+                    && error.code == "session-activity-identity-incomplete" =>
+            {
+                RuleOutcome {
+                    action: DecisionAction::Block,
+                    code: error.code,
+                    context: Some(
+                        "agent-hook managed identity is incomplete. The trusted runtime launcher must establish the exact session and runtime pair before provider work starts; do not retry from the model."
+                            .to_string(),
+                    ),
+                    replacement: None,
+                    provider_output: None,
+                }
+            }
+            Err(error)
+                if activity_failure_is_degradable(
+                    &rule.capability,
+                    request,
+                    operation_effect,
+                    coordination_mode,
+                    &error,
+                ) =>
+            {
+                activity_degradation_outcome(
+                    request,
+                    operation_effect == OperationEffectClass::ReadOnly,
+                    &error,
                 )
             }
             Err(error) if error.code == "capability-timeout" => timeout_outcome(
@@ -536,9 +570,6 @@ fn evaluate_with_io(
     }
 
     let decision = aggregate(loaded, request, enforced, shadow, recovery_applied)?;
-    let coordination_mode = liveness
-        .as_ref()
-        .and_then(liveness::DispatchProjection::mode);
     apply_session_coordination(
         Some(loaded),
         decision,
@@ -547,6 +578,84 @@ fn evaluate_with_io(
         prepared.session_coordination,
         CoordinationExecution::new(coordination_mode, operation_effect, coordination.unmanaged),
     )
+}
+
+fn activity_capability(capability: &Capability) -> bool {
+    matches!(
+        capability,
+        Capability::SessionActivity { .. }
+            | Capability::DshPolicy {
+                group: crate::policy_parity::DshCapabilityGroup::AgentActivity
+            }
+    )
+}
+
+fn activity_runtime_fault(error: &HookError) -> bool {
+    matches!(
+        error.code.as_str(),
+        ACTIVITY_HELPER_UNRESOLVABLE
+            | "session-activity-failed"
+            | "capability-timeout"
+            | "capability-wait-failed"
+            | "capability-input-failed"
+            | "capability-output-failed"
+            | "capability-unavailable"
+    )
+}
+
+fn activity_failure_is_degradable(
+    capability: &Capability,
+    request: &NormalizedRequest,
+    effect: OperationEffectClass,
+    mode: Option<nils_common::coordination_projection::CoordinationMode>,
+    error: &HookError,
+) -> bool {
+    use nils_common::coordination_projection::CoordinationMode;
+
+    if !activity_capability(capability) || !activity_runtime_fault(error) {
+        return false;
+    }
+    let read_only = effect == OperationEffectClass::ReadOnly;
+    let conversation =
+        crate::degradation::lane(request.event.as_str()) == crate::degradation::Lane::Conversation;
+    conversation
+        || read_only
+        || matches!(
+            mode,
+            Some(CoordinationMode::Advisory | CoordinationMode::Off)
+        )
+}
+
+fn activity_degradation_outcome(
+    request: &NormalizedRequest,
+    read_only: bool,
+    error: &HookError,
+) -> RuleOutcome {
+    let conversation =
+        crate::degradation::lane(request.event.as_str()) == crate::degradation::Lane::Conversation;
+    let availability = if conversation {
+        "Conversation remains available in a read-only degraded lane; no mutation authority was granted."
+    } else if read_only {
+        "This audited read-only operation remains available; no mutation authority was granted."
+    } else {
+        "Advisory/off coordination does not make activity metadata an admission authority; every other safety and mutation gate remains authoritative."
+    };
+    crate::observe::Record::new("activity", &error.code, crate::observe::Severity::Warn)
+        .provider(request.product, &request.event)
+        .disposition("warn")
+        .recovery(crate::observe::RECOVERY_HOOK_DOCTOR)
+        .emit();
+    RuleOutcome {
+        action: DecisionAction::Warn,
+        code: error.code.clone(),
+        context: Some(format!(
+            "agent-hook activity metadata is unavailable ({}). {availability} Next: {}.",
+            error.code,
+            crate::observe::RECOVERY_HOOK_DOCTOR
+        )),
+        replacement: None,
+        provider_output: None,
+    }
 }
 
 fn exact_capability_recovery_candidate_for_session_coordination(
@@ -723,7 +832,13 @@ fn evaluate_capability(
             crate::policy_parity::DshCapabilityGroup::AgentActivity => {
                 match run_session_activity(request, raw, execution_budget) {
                     Ok(()) => simple(DecisionAction::Allow, group.as_str()),
-                    Err(_) => simple(DecisionAction::Block, group.as_str()),
+                    Err(error) => {
+                        match terminal_activity_failure_decision(capability, request.event.as_str())
+                        {
+                            Some((action, code)) => simple(action, code),
+                            None => return Err(error),
+                        }
+                    }
                 }
             }
             crate::policy_parity::DshCapabilityGroup::SemanticConflict => {
@@ -791,7 +906,7 @@ pub(crate) fn terminal_activity_failure_decision(
     capability: &Capability,
     event: &str,
 ) -> Option<(DecisionAction, &'static str)> {
-    (event == "Stop" && matches!(capability, Capability::SessionActivity { .. }))
+    (event == "Stop" && activity_capability(capability))
         .then_some((DecisionAction::Warn, ACTIVITY_STOP_RECONCILIATION_REQUIRED))
 }
 
@@ -1394,10 +1509,10 @@ fn run_session_activity(
     let runtime_id = std::env::var("AGENT_SESSION_RUNTIME_ID")
         .ok()
         .filter(|value| !value.trim().is_empty());
-    if request.product == Product::Dsh && session_id.is_some() != runtime_id.is_some() {
+    if session_id.is_some() != runtime_id.is_some() {
         return Err(HookError::data(
             "session-activity-identity-incomplete",
-            "managed DSH activity requires both session and runtime identity",
+            "managed activity requires both session and runtime identity",
         ));
     }
     let (Some(session_id), Some(runtime_id)) = (session_id, runtime_id) else {
@@ -1406,7 +1521,7 @@ fn run_session_activity(
     let Some(event) = crate::adapter::normalize_activity_event(request, raw, &runtime_id)? else {
         return Ok(());
     };
-    let mut command = Command::new(resolve_activity_helper());
+    let mut command = Command::new(resolve_activity_helper()?);
     command
         .args(["activity", "event", "--stdin", &session_id])
         .stdin(Stdio::piped())
@@ -1437,26 +1552,30 @@ fn run_session_activity(
 /// `AGENT_SESSION_BIN` can already set `PATH`, and the pinned `PATH` is
 /// daemon-controlled. The discarded override is recorded as a typed
 /// classification so it cannot silently mask a misconfiguration.
-fn resolve_activity_helper() -> std::ffi::OsString {
-    let Some(override_path) = std::env::var_os(HELPER_BIN_ENV) else {
-        return ACTIVITY_HELPER.into();
-    };
-    let candidate = Path::new(&override_path);
-    if candidate.as_os_str().is_empty() {
-        return ACTIVITY_HELPER.into();
+fn resolve_activity_helper() -> Result<std::ffi::OsString, HookError> {
+    if let Some(override_path) = std::env::var_os(HELPER_BIN_ENV)
+        && !override_path.is_empty()
+    {
+        if executable_file(Path::new(&override_path)) {
+            return Ok(override_path);
+        }
+        crate::observe::Record::new(
+            "activity",
+            ACTIVITY_HELPER_UNRESOLVABLE,
+            crate::observe::Severity::Warn,
+        )
+        .disposition("path-fallback")
+        .recovery(crate::observe::RECOVERY_HOOK_DOCTOR)
+        .emit();
     }
-    if executable_file(candidate) {
-        return override_path;
-    }
-    crate::observe::Record::new(
-        "activity",
-        ACTIVITY_HELPER_UNRESOLVABLE,
-        crate::observe::Severity::Warn,
-    )
-    .disposition("path-fallback")
-    .recovery(crate::observe::RECOVERY_HOOK_DOCTOR)
-    .emit();
-    ACTIVITY_HELPER.into()
+    locate_activity_helper()
+        .map(PathBuf::into_os_string)
+        .ok_or_else(|| {
+            HookError::runtime(
+                ACTIVITY_HELPER_UNRESOLVABLE,
+                "the agent-session activity helper could not be resolved to an executable file",
+            )
+        })
 }
 
 /// Locate the helper that would actually run, or `None` when nothing resolves.

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -35,6 +35,8 @@ const TYPED_BOOTSTRAP_AUTHORIZATION_SCHEMA: &str =
 const TYPED_BOOTSTRAP_AUTHORIZATION_CODE: &str = "typed-main-agent-bootstrap-authorized";
 pub(crate) const ACTIVITY_STOP_RECONCILIATION_REQUIRED: &str =
     "activity-stop-reconciliation-required";
+const ACTIVITY_DEGRADED_AUDITED_READ_ONLY: &str = "activity-degraded-audited-read-only";
+const ACTIVITY_DEGRADED_ADVISORY_OFF: &str = "activity-degraded-advisory-off";
 /// Environment variable that overrides how the activity helper is resolved.
 const HELPER_BIN_ENV: &str = "AGENT_SESSION_BIN";
 /// `PATH`-resolvable name of the activity capability helper.
@@ -406,7 +408,15 @@ fn evaluate_with_io(
     };
     let coordination_mode = liveness
         .as_ref()
-        .and_then(liveness::DispatchProjection::mode);
+        .and_then(liveness::DispatchProjection::mode)
+        .or_else(|| {
+            prepared
+                .rules
+                .iter()
+                .any(|prepared| activity_capability(&prepared.rule.capability))
+                .then(liveness::coordination_failure_mode)
+                .flatten()
+        });
     let mut read_only_bypassed_rule_ids = BTreeSet::new();
     for prepared_rule in &prepared.rules {
         let rule = prepared_rule.rule;
@@ -501,6 +511,7 @@ fn evaluate_with_io(
             ));
             continue;
         }
+        let mut activity_lane_reason = None;
         let outcome = match evaluate_capability(
             &rule.capability,
             request,
@@ -512,7 +523,7 @@ fn evaluate_with_io(
             Err(error)
                 if activity_recovery_candidate
                     && activity_capability(&rule.capability)
-                    && activity_recovery_failure_is_deferrable(&error) =>
+                    && activity_runtime_fault(&error) =>
             {
                 simple(
                     DecisionAction::Allow,
@@ -543,11 +554,13 @@ fn evaluate_with_io(
                     &error,
                 ) =>
             {
-                activity_degradation_outcome(
+                let (outcome, lane_reason) = activity_degradation_outcome(
                     request,
                     operation_effect == OperationEffectClass::ReadOnly,
                     &error,
-                )
+                );
+                activity_lane_reason = Some(lane_reason);
+                outcome
             }
             Err(error) if error.code == "capability-timeout" => timeout_outcome(
                 loaded,
@@ -567,6 +580,9 @@ fn evaluate_with_io(
             ),
         };
         enforced.push((rule.id.clone(), outcome));
+        if let Some(code) = activity_lane_reason {
+            enforced.push((rule.id.clone(), simple(DecisionAction::Warn, code)));
+        }
     }
 
     let decision = aggregate(loaded, request, enforced, shadow, recovery_applied)?;
@@ -630,32 +646,44 @@ fn activity_degradation_outcome(
     request: &NormalizedRequest,
     read_only: bool,
     error: &HookError,
-) -> RuleOutcome {
+) -> (RuleOutcome, &'static str) {
     let conversation =
         crate::degradation::lane(request.event.as_str()) == crate::degradation::Lane::Conversation;
-    let availability = if conversation {
-        "Conversation remains available in a read-only degraded lane; no mutation authority was granted."
+    let (availability, lane_reason) = if conversation {
+        (
+            "Conversation remains available in a read-only degraded lane; no mutation authority was granted.",
+            crate::degradation::CONVERSATION_DEGRADED,
+        )
     } else if read_only {
-        "This audited read-only operation remains available; no mutation authority was granted."
+        (
+            "This audited read-only operation remains available; no mutation authority was granted.",
+            ACTIVITY_DEGRADED_AUDITED_READ_ONLY,
+        )
     } else {
-        "Advisory/off coordination does not make activity metadata an admission authority; every other safety and mutation gate remains authoritative."
+        (
+            "Advisory/off coordination does not make activity metadata an admission authority; every other safety and mutation gate remains authoritative.",
+            ACTIVITY_DEGRADED_ADVISORY_OFF,
+        )
     };
     crate::observe::Record::new("activity", &error.code, crate::observe::Severity::Warn)
         .provider(request.product, &request.event)
         .disposition("warn")
         .recovery(crate::observe::RECOVERY_HOOK_DOCTOR)
         .emit();
-    RuleOutcome {
-        action: DecisionAction::Warn,
-        code: error.code.clone(),
-        context: Some(format!(
-            "agent-hook activity metadata is unavailable ({}). {availability} Next: {}.",
-            error.code,
-            crate::observe::RECOVERY_HOOK_DOCTOR
-        )),
-        replacement: None,
-        provider_output: None,
-    }
+    (
+        RuleOutcome {
+            action: DecisionAction::Warn,
+            code: error.code.clone(),
+            context: Some(format!(
+                "agent-hook activity metadata is unavailable ({}). {availability} Next: {}.",
+                error.code,
+                crate::observe::RECOVERY_HOOK_DOCTOR
+            )),
+            replacement: None,
+            provider_output: None,
+        },
+        lane_reason,
+    )
 }
 
 fn exact_capability_recovery_candidate_for_session_coordination(
@@ -667,18 +695,6 @@ fn exact_capability_recovery_candidate_for_session_coordination(
         && request.event == "PreToolUse"
         && request.matcher.as_deref() == Some("Bash")
         && crate::adapter::exact_main_agent_capability_recovery_command(raw)
-}
-
-fn activity_recovery_failure_is_deferrable(error: &HookError) -> bool {
-    matches!(
-        error.code.as_str(),
-        "session-activity-failed"
-            | "capability-unavailable"
-            | "capability-timeout"
-            | "capability-wait-failed"
-            | "capability-input-failed"
-            | "capability-output-failed"
-    )
 }
 
 fn exact_bootstrap_candidate_for_session_coordination(
@@ -906,7 +922,7 @@ pub(crate) fn terminal_activity_failure_decision(
     capability: &Capability,
     event: &str,
 ) -> Option<(DecisionAction, &'static str)> {
-    (event == "Stop" && activity_capability(capability))
+    (matches!(event, "Stop" | "StopFailure") && activity_capability(capability))
         .then_some((DecisionAction::Warn, ACTIVITY_STOP_RECONCILIATION_REQUIRED))
 }
 
@@ -1516,7 +1532,14 @@ fn run_session_activity(
         ));
     }
     let (Some(session_id), Some(runtime_id)) = (session_id, runtime_id) else {
-        return Ok(());
+        return if crate::liveness::current_process_is_unmanaged() {
+            Ok(())
+        } else {
+            Err(HookError::data(
+                "session-activity-identity-incomplete",
+                "managed activity requires both session and runtime identity",
+            ))
+        };
     };
     let Some(event) = crate::adapter::normalize_activity_event(request, raw, &runtime_id)? else {
         return Ok(());
@@ -1556,8 +1579,8 @@ fn resolve_activity_helper() -> Result<std::ffi::OsString, HookError> {
     if let Some(override_path) = std::env::var_os(HELPER_BIN_ENV)
         && !override_path.is_empty()
     {
-        if executable_file(Path::new(&override_path)) {
-            return Ok(override_path);
+        if let Some(candidate) = canonical_executable(Path::new(&override_path)) {
+            return Ok(candidate.into_os_string());
         }
         crate::observe::Record::new(
             "activity",
@@ -1587,13 +1610,20 @@ pub(crate) fn locate_activity_helper() -> Option<PathBuf> {
     if let Some(override_path) = std::env::var_os(HELPER_BIN_ENV).filter(|value| !value.is_empty())
     {
         let candidate = PathBuf::from(override_path);
-        if executable_file(&candidate) {
+        if let Some(candidate) = canonical_executable(&candidate) {
             return Some(candidate);
         }
     }
     std::env::split_paths(&std::env::var_os("PATH")?)
         .map(|directory| directory.join(ACTIVITY_HELPER))
-        .find(|candidate| executable_file(candidate))
+        .find_map(|candidate| canonical_executable(&candidate))
+}
+
+fn canonical_executable(path: &Path) -> Option<PathBuf> {
+    executable_file(path)
+        .then(|| fs::canonicalize(path).ok())
+        .flatten()
+        .filter(|path| executable_file(path))
 }
 
 /// Whether a path is a regular file the effective user can execute.
@@ -2121,6 +2151,41 @@ mod tests {
                 set_env(name, value);
             }
         }
+    }
+
+    #[test]
+    fn activity_helper_resolution_survives_cwd_drift() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let current = std::env::current_dir().expect("current directory");
+        let temp = tempfile::Builder::new()
+            .prefix("activity-helper-")
+            .tempdir_in(&current)
+            .expect("tempdir");
+        let helper_root = temp.path();
+        let other = temp.path().join("other");
+        let bin = helper_root.join("bin");
+        fs::create_dir_all(&bin).expect("helper bin");
+        fs::create_dir_all(&other).expect("other cwd");
+        let helper = bin.join(ACTIVITY_HELPER);
+        fs::write(&helper, "#!/bin/sh\nexit 0\n").expect("helper");
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).expect("helper mode");
+
+        let relative = helper
+            .strip_prefix(&current)
+            .expect("helper relative to process cwd");
+        let resolved = canonical_executable(relative).expect("resolved helper");
+        assert!(resolved.is_absolute(), "resolved={}", resolved.display());
+        assert_eq!(
+            resolved,
+            fs::canonicalize(&helper).expect("canonical helper")
+        );
+
+        let status = Command::new(&resolved)
+            .current_dir(&other)
+            .status()
+            .expect("run resolved helper after cwd drift");
+        assert!(status.success());
     }
 
     #[test]

--- a/crates/agent-hook/src/lib.rs
+++ b/crates/agent-hook/src/lib.rs
@@ -1052,7 +1052,7 @@ fn emit_decision(format: DispatchFormat, decision: &NormalizedDecision) -> i32 {
             println!(
                 "agent-hook {} {}: {} ({} reasons, {} shadow)",
                 decision.product.as_str(),
-                decision.event,
+                public_event_label(&decision.event),
                 action_name(decision.action),
                 decision.reasons.len(),
                 decision.shadow.len()
@@ -1060,6 +1060,31 @@ fn emit_decision(format: DispatchFormat, decision: &NormalizedDecision) -> i32 {
         }
     }
     code
+}
+
+fn public_event_label(event: &str) -> &'static str {
+    match event {
+        "SessionStart" => "SessionStart",
+        "UserPromptSubmit" => "UserPromptSubmit",
+        "PermissionRequest" => "PermissionRequest",
+        "PreToolUse" => "PreToolUse",
+        "PostToolUse" => "PostToolUse",
+        "PostToolUseFailure" => "PostToolUseFailure",
+        "PreCompact" => "PreCompact",
+        "PostCompact" => "PostCompact",
+        "SubagentStart" => "SubagentStart",
+        "SubagentStop" => "SubagentStop",
+        "Stop" => "Stop",
+        "StopFailure" => "StopFailure",
+        "Notification" => "Notification",
+        "Elicitation" => "Elicitation",
+        "ElicitationResult" => "ElicitationResult",
+        "pre_llm_call" => "pre_llm_call",
+        "post_llm_call" => "post_llm_call",
+        "pre_approval_request" => "pre_approval_request",
+        "post_approval_response" => "post_approval_response",
+        _ => "unknown-event",
+    }
 }
 
 fn emit_dispatch_error(

--- a/crates/agent-hook/tests/activity_helper.rs
+++ b/crates/agent-hook/tests/activity_helper.rs
@@ -19,7 +19,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use nils_test_support::{EnvGuard, GlobalStateLock};
 use pretty_assertions::{assert_eq, assert_ne};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 use support::Fixture;
 
@@ -31,6 +31,16 @@ version = "2026.07.20.1"
 id = "coord.activity.prompt-stop"
 products = ["codex", "claude"]
 events = ["UserPromptSubmit", "PreToolUse", "Stop"]
+priority = 100
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "agent-session.activity.v1", reason_code = "activity-recorded" }
+
+[[rules]]
+id = "coord.activity.stop-failure"
+products = ["claude"]
+events = ["StopFailure"]
 priority = 100
 mode = "enforce"
 failure_posture = "closed"
@@ -201,8 +211,19 @@ fn a_completely_unresolvable_helper_degrades_instead_of_deadlocking() {
     assert_eq!(prompt.code, 0, "stderr={}", prompt.stderr_text());
     assert_eq!(prompt.stdout_json()["data"]["action"], "warn");
     assert_eq!(
-        prompt.stdout_json()["data"]["reasons"][0]["code"],
-        "activity-helper-unresolvable"
+        prompt.stdout_json()["data"]["reasons"],
+        json!([
+            {
+                "rule_id": "coord.activity.prompt-stop",
+                "code": "activity-helper-unresolvable",
+                "disposition": "warn"
+            },
+            {
+                "rule_id": "coord.activity.prompt-stop",
+                "code": "coordination-degraded-read-only",
+                "disposition": "warn"
+            }
+        ])
     );
 
     let stop = fixture.run_with_env(
@@ -219,6 +240,27 @@ fn a_completely_unresolvable_helper_degrades_instead_of_deadlocking() {
     assert_eq!(
         stop.stdout_json()["data"]["reasons"][0]["code"],
         "activity-stop-reconciliation-required"
+    );
+
+    let stop_failure = fixture.run_with_env(
+        &["dispatch", "--product", "claude", "--format", "json"],
+        Some(r#"{"hook_event_name":"StopFailure","error":"rate_limit"}"#),
+        &envs,
+    );
+    assert_eq!(
+        stop_failure.code,
+        0,
+        "StopFailure must terminate with a warning: {}",
+        stop_failure.stdout_text()
+    );
+    assert_eq!(stop_failure.stdout_json()["data"]["action"], "warn");
+    assert_eq!(
+        stop_failure.stdout_json()["data"]["reasons"],
+        json!([{
+            "rule_id": "coord.activity.stop-failure",
+            "code": "activity-stop-reconciliation-required",
+            "disposition": "warn"
+        }])
     );
 
     // A re-entered Stop must not block again either.
@@ -259,6 +301,50 @@ fn a_partial_managed_identity_is_never_silently_unmanaged() {
     assert_eq!(mutation.stdout_json()["data"]["action"], "block");
 }
 
+#[test]
+fn selectorless_managed_activity_requires_convergence_but_unmanaged_is_a_no_op() {
+    let fixture = Fixture::new(ACTIVITY_POLICY);
+    for payload in [
+        r#"{"hook_event_name":"UserPromptSubmit","prompt":"status"}"#,
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pwd"}}"#,
+    ] {
+        let managed = fixture.run_with_env(
+            &["dispatch", "--product", "codex", "--format", "json"],
+            Some(payload),
+            &[("AGENT_SESSION_COORDINATION_MODE", "enforce")],
+        );
+        assert_eq!(
+            managed.code,
+            1,
+            "payload={payload}: {}",
+            managed.stdout_text()
+        );
+        assert_eq!(managed.stdout_json()["data"]["action"], "block");
+        assert_eq!(
+            managed.stdout_json()["data"]["reasons"][0]["code"],
+            "session-activity-identity-incomplete"
+        );
+    }
+
+    let unmanaged = fixture.run_with_env_and_removals(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(r#"{"hook_event_name":"UserPromptSubmit","prompt":"status"}"#),
+        &[],
+        &["AGENT_SESSION_STATE_DIR"],
+    );
+    assert_eq!(
+        unmanaged.code,
+        0,
+        "a genuinely unmanaged request must remain a no-op: {}",
+        unmanaged.stdout_text()
+    );
+    assert_eq!(unmanaged.stdout_json()["data"]["action"], "allow");
+    assert_eq!(
+        unmanaged.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-recorded"
+    );
+}
+
 /// Activity is metadata, so losing its helper must not make a verified local
 /// status probe depend on the same broken capability needed to diagnose it.
 /// Unknown or state-changing Bash remains fail-closed because this exception
@@ -290,8 +376,19 @@ fn an_unresolvable_helper_allows_only_audited_read_only_pre_tool_use() {
     );
     assert_eq!(read_only.stdout_json()["data"]["action"], "warn");
     assert_eq!(
-        read_only.stdout_json()["data"]["reasons"][0]["code"],
-        "activity-helper-unresolvable"
+        read_only.stdout_json()["data"]["reasons"],
+        json!([
+            {
+                "rule_id": "coord.activity.prompt-stop",
+                "code": "activity-helper-unresolvable",
+                "disposition": "warn"
+            },
+            {
+                "rule_id": "coord.activity.prompt-stop",
+                "code": "activity-degraded-audited-read-only",
+                "disposition": "warn"
+            }
+        ])
     );
     let read_only_json = read_only.stdout_json();
     let context = read_only_json["data"]["context"]
@@ -314,6 +411,21 @@ fn an_unresolvable_helper_allows_only_audited_read_only_pre_tool_use() {
         mutation.stdout_text()
     );
     assert_eq!(mutation.stdout_json()["data"]["action"], "block");
+
+    let conflicting = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","command":"pwd","tool_input":{"command":"touch changed"}}"#,
+        ),
+        &envs,
+    );
+    assert_eq!(
+        conflicting.code,
+        1,
+        "conflicting command representations must remain blocked: {}",
+        conflicting.stdout_text()
+    );
+    assert_eq!(conflicting.stdout_json()["data"]["action"], "block");
 }
 
 /// Install the managed Claude ingress so the provider reaches `converged`, which

--- a/crates/agent-hook/tests/activity_helper.rs
+++ b/crates/agent-hook/tests/activity_helper.rs
@@ -30,7 +30,7 @@ version = "2026.07.20.1"
 [[rules]]
 id = "coord.activity.prompt-stop"
 products = ["codex", "claude"]
-events = ["UserPromptSubmit", "Stop"]
+events = ["UserPromptSubmit", "PreToolUse", "Stop"]
 priority = 100
 mode = "enforce"
 failure_posture = "closed"
@@ -193,6 +193,18 @@ fn a_completely_unresolvable_helper_degrades_instead_of_deadlocking() {
         ("PATH", empty_dir.to_str().expect("empty dir")),
     ];
 
+    let prompt = fixture.run_with_env(
+        &["dispatch", "--product", "claude", "--format", "json"],
+        Some(r#"{"hook_event_name":"UserPromptSubmit","prompt":"status"}"#),
+        &envs,
+    );
+    assert_eq!(prompt.code, 0, "stderr={}", prompt.stderr_text());
+    assert_eq!(prompt.stdout_json()["data"]["action"], "warn");
+    assert_eq!(
+        prompt.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-helper-unresolvable"
+    );
+
     let stop = fixture.run_with_env(
         &["dispatch", "--product", "claude", "--format", "json"],
         Some(r#"{"hook_event_name":"Stop","stop_hook_active":false}"#),
@@ -216,6 +228,92 @@ fn a_completely_unresolvable_helper_degrades_instead_of_deadlocking() {
         &envs,
     );
     assert_eq!(reentry.code, 0, "stderr={}", reentry.stderr_text());
+}
+
+/// A half-inherited selector is managed-but-invalid, never unmanaged. The
+/// startup/conversation surface refuses provider work with one bounded typed
+/// diagnosis until the trusted launcher supplies the exact pair.
+#[test]
+fn a_partial_managed_identity_is_never_silently_unmanaged() {
+    let fixture = Fixture::new(ACTIVITY_POLICY);
+    let prompt = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(r#"{"hook_event_name":"UserPromptSubmit","prompt":"status"}"#),
+        &[("AGENT_SESSION_ID", "inherited-session")],
+    );
+    assert_eq!(prompt.code, 1, "stderr={}", prompt.stderr_text());
+    assert_eq!(prompt.stdout_json()["data"]["action"], "block");
+    assert_eq!(
+        prompt.stdout_json()["data"]["reasons"][0]["code"],
+        "session-activity-identity-incomplete"
+    );
+
+    let mutation = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"touch changed"}}"#,
+        ),
+        &[("AGENT_SESSION_ID", "inherited-session")],
+    );
+    assert_eq!(mutation.code, 1, "stdout={}", mutation.stdout_text());
+    assert_eq!(mutation.stdout_json()["data"]["action"], "block");
+}
+
+/// Activity is metadata, so losing its helper must not make a verified local
+/// status probe depend on the same broken capability needed to diagnose it.
+/// Unknown or state-changing Bash remains fail-closed because this exception
+/// grants no owner, checkout, or coordination authority.
+#[test]
+fn an_unresolvable_helper_allows_only_audited_read_only_pre_tool_use() {
+    let fixture = Fixture::new(ACTIVITY_POLICY);
+    let empty_dir = fixture.root.join("empty-bin");
+    fs::create_dir_all(&empty_dir).expect("empty directory");
+    let envs = [
+        ("AGENT_SESSION_ID", "managed-session"),
+        ("AGENT_SESSION_RUNTIME_ID", "managed-runtime"),
+        ("PATH", empty_dir.to_str().expect("empty dir")),
+    ];
+
+    let read_only = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"pwd"}}"#,
+        ),
+        &envs,
+    );
+    assert_eq!(
+        read_only.code,
+        0,
+        "a missing metadata helper must not block pwd: stdout={} stderr={}",
+        read_only.stdout_text(),
+        read_only.stderr_text()
+    );
+    assert_eq!(read_only.stdout_json()["data"]["action"], "warn");
+    assert_eq!(
+        read_only.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-helper-unresolvable"
+    );
+    let read_only_json = read_only.stdout_json();
+    let context = read_only_json["data"]["context"]
+        .as_str()
+        .expect("bounded activity degradation context");
+    assert!(context.contains("metadata"), "context={context}");
+    assert!(context.contains("agent-hook doctor"), "context={context}");
+
+    let mutation = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(
+            r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"touch changed"}}"#,
+        ),
+        &envs,
+    );
+    assert_eq!(
+        mutation.code,
+        1,
+        "an activity fault must not authorize unknown or mutating Bash: {}",
+        mutation.stdout_text()
+    );
+    assert_eq!(mutation.stdout_json()["data"]["action"], "block");
 }
 
 /// Install the managed Claude ingress so the provider reaches `converged`, which

--- a/crates/agent-hook/tests/coordination_ingress.rs
+++ b/crates/agent-hook/tests/coordination_ingress.rs
@@ -248,6 +248,58 @@ fn exact_recovery_reaches_authenticated_coordination_when_activity_is_stale() {
 }
 
 #[test]
+fn exact_recovery_reaches_coordination_when_the_activity_helper_is_unresolvable() {
+    let fixture = Fixture::new(&activity_recovery_policy(true));
+    install_coordination_handler(&fixture);
+    let capture = fixture.root.join("missing-helper-recovery.json");
+    let payload = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "recover-without-activity-helper",
+        "cwd": fixture.root,
+        "tool_input": {
+            "command": "main-agent self recover --idempotency-key recover-12345678 --format json"
+        }
+    })
+    .to_string();
+    let recovered = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[
+            ("AGENT_SESSION_BIN", "/missing/agent-session"),
+            ("AGENT_SESSION_ID", "trusted"),
+            ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+            ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+            ("PATH", "/usr/bin:/bin"),
+            (
+                "COORDINATION_CAPTURE",
+                capture.to_str().expect("capture path"),
+            ),
+        ],
+    );
+    assert_eq!(
+        recovered.code,
+        0,
+        "missing activity helper must defer exact recovery: stdout={} stderr={}",
+        recovered.stdout_text(),
+        recovered.stderr_text()
+    );
+    assert_eq!(recovered.stdout_json()["data"]["action"], "allow");
+    assert_eq!(
+        recovered.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-recovery-deferred-to-coordination"
+    );
+    assert_eq!(
+        recovered.stdout_json()["data"]["reasons"][1]["code"],
+        "coordination-admitted"
+    );
+    assert_eq!(
+        fs::read_to_string(capture).expect("captured recovery request"),
+        payload
+    );
+}
+
+#[test]
 fn activity_recovery_degradation_requires_exact_shape_and_coordination() {
     let fixture = Fixture::new(&activity_recovery_policy(true));
     let activity = fixture.root.join("agent-session-stale-activity");
@@ -467,8 +519,24 @@ fn activity_metadata_failure_obeys_the_trusted_coordination_mode() {
             assert!(!capture.exists(), "enforce fault reached coordination");
         } else {
             assert_eq!(
-                decision.stdout_json()["data"]["reasons"][0]["code"],
-                "session-activity-failed",
+                decision.stdout_json()["data"]["reasons"],
+                json!([
+                    {
+                        "rule_id": "runtime.activity",
+                        "code": "session-activity-failed",
+                        "disposition": "warn"
+                    },
+                    {
+                        "rule_id": "runtime.activity",
+                        "code": "activity-degraded-advisory-off",
+                        "disposition": "warn"
+                    },
+                    {
+                        "rule_id": "runtime.coordination",
+                        "code": "coordination-admitted",
+                        "disposition": "allow"
+                    }
+                ]),
                 "mode={mode}"
             );
             assert!(capture.exists(), "mode={mode} skipped later authority");

--- a/crates/agent-hook/tests/coordination_ingress.rs
+++ b/crates/agent-hook/tests/coordination_ingress.rs
@@ -85,6 +85,41 @@ fn install_session_mode(fixture: &Fixture, mode: &str) {
     Fixture::set_private(&record);
 }
 
+fn install_current_broker(fixture: &Fixture, mode: &str) {
+    install_session_mode(fixture, mode);
+    let now = now_epoch();
+    let coordination = fixture.session_state.join("coordination");
+    fs::create_dir_all(&coordination).expect("coordination directory");
+    let registry = coordination.join("registry.json");
+    fs::write(
+        &registry,
+        serde_json::to_vec(&json!({
+            "schema_version": "agent-session.coordination-registry.v1",
+            "fingerprint_epoch": 1,
+            "fingerprint_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "brokers": {
+                "trusted": {
+                    "session_id": "trusted",
+                    "incarnation": "trusted-incarnation",
+                    "coordination_mode": mode,
+                    "state": "ready",
+                    "heartbeat_epoch": now
+                }
+            },
+            "claims": []
+        }))
+        .expect("registry JSON"),
+    )
+    .expect("registry");
+    Fixture::set_private(&registry);
+    let heartbeat = fixture
+        .session_state
+        .join("sessions/trusted/coordination/heartbeat");
+    fs::create_dir_all(heartbeat.parent().expect("heartbeat parent")).expect("heartbeat directory");
+    fs::write(&heartbeat, format!("trusted-incarnation:{now}\n")).expect("heartbeat");
+    Fixture::set_private(&heartbeat);
+}
+
 fn bootstrap_policy(extra_rule: &str) -> String {
     format!(
         r#"schema_version = "agent-hook.policy.v1"
@@ -214,8 +249,50 @@ fn exact_recovery_reaches_authenticated_coordination_when_activity_is_stale() {
 
 #[test]
 fn activity_recovery_degradation_requires_exact_shape_and_coordination() {
+    let fixture = Fixture::new(&activity_recovery_policy(true));
+    let activity = fixture.root.join("agent-session-stale-activity");
+    fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+    fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+        .expect("activity helper mode");
+    install_coordination_handler(&fixture);
+    let capture = fixture.root.join("read-only-coordination.json");
+    let payload = json!({
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "read-only-after-activity-fault",
+        "cwd": fixture.root,
+        "tool_input": {"command": "pwd"}
+    })
+    .to_string();
+    let admitted = fixture.run_with_env(
+        &["dispatch", "--product", "codex", "--format", "json"],
+        Some(&payload),
+        &[
+            (
+                "AGENT_SESSION_BIN",
+                activity.to_str().expect("activity path"),
+            ),
+            ("AGENT_SESSION_ID", "trusted"),
+            ("AGENT_SESSION_RUNTIME_ID", "stale-incarnation"),
+            ("AGENT_SESSION_COORDINATION_MODE", "enforce"),
+            (
+                "COORDINATION_CAPTURE",
+                capture.to_str().expect("capture path"),
+            ),
+        ],
+    );
+    assert_eq!(admitted.code, 0, "stdout={}", admitted.stdout_text());
+    assert_eq!(admitted.stdout_json()["data"]["action"], "warn");
+    assert_eq!(
+        admitted.stdout_json()["data"]["reasons"][0]["code"],
+        "session-activity-failed"
+    );
+    assert_eq!(
+        fs::read_to_string(&capture).expect("captured read-only request"),
+        payload
+    );
+
     let commands = [
-        "pwd",
         "main-agent self recover --idempotency-key short --format json",
         "main-agent self recover --idempotency-key recover-12345678 --format json; pwd",
     ];
@@ -332,6 +409,71 @@ fn activity_recovery_degradation_requires_exact_shape_and_coordination() {
         rejected.stdout_json()["data"]["reasons"][1]["code"],
         "runtime.coordination:capability-failure-closed"
     );
+}
+
+#[test]
+fn activity_metadata_failure_obeys_the_trusted_coordination_mode() {
+    for (mode, expected_code, expected_action) in [
+        ("advisory", 0, "warn"),
+        ("off", 0, "warn"),
+        ("enforce", 1, "block"),
+    ] {
+        let fixture = Fixture::new(&activity_recovery_policy(true));
+        install_current_broker(&fixture, mode);
+        install_coordination_handler(&fixture);
+        let activity = fixture.root.join("agent-session-stale-activity");
+        fs::write(&activity, "#!/bin/sh\nexit 65\n").expect("stale activity helper");
+        fs::set_permissions(&activity, fs::Permissions::from_mode(0o700))
+            .expect("activity helper mode");
+        let capture = fixture.root.join("coordination.json");
+        let payload = json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": format!("activity-fault-{mode}"),
+            "cwd": fixture.root,
+            "tool_input": {"command": "touch changed"}
+        })
+        .to_string();
+        let decision = fixture.run_with_env(
+            &["dispatch", "--product", "codex", "--format", "json"],
+            Some(&payload),
+            &[
+                (
+                    "AGENT_SESSION_BIN",
+                    activity.to_str().expect("activity path"),
+                ),
+                ("AGENT_SESSION_ID", "trusted"),
+                ("AGENT_SESSION_RUNTIME_ID", "trusted-incarnation"),
+                ("AGENT_SESSION_COORDINATION_MODE", mode),
+                (
+                    "COORDINATION_CAPTURE",
+                    capture.to_str().expect("capture path"),
+                ),
+            ],
+        );
+        assert_eq!(
+            decision.code,
+            expected_code,
+            "mode={mode}: {}",
+            decision.stdout_text()
+        );
+        assert_eq!(
+            decision.stdout_json()["data"]["action"],
+            expected_action,
+            "mode={mode}: {}",
+            decision.stdout_text()
+        );
+        if mode == "enforce" {
+            assert!(!capture.exists(), "enforce fault reached coordination");
+        } else {
+            assert_eq!(
+                decision.stdout_json()["data"]["reasons"][0]["code"],
+                "session-activity-failed",
+                "mode={mode}"
+            );
+            assert!(capture.exists(), "mode={mode} skipped later authority");
+        }
+    }
 }
 
 fn install_foreign_owner(fixture: &Fixture) {

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -583,7 +583,7 @@ fn dsh_agent_activity_emits_only_metadata_and_partial_identity_fails_closed() {
     assert_eq!(partial.stdout_json()["data"]["action"], "block");
     assert_eq!(
         partial.stdout_json()["data"]["reasons"][0]["code"],
-        "agent-activity"
+        "session-activity-identity-incomplete"
     );
 }
 

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -117,6 +117,35 @@ capability = {{ id = "dsh.policy.v1", group = "{group}" }}
     )
 }
 
+fn activity_then_direct_commit_policy() -> &'static str {
+    r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "dsh-runtime-kit-activity-authority"
+version = "2026.08.28.1"
+
+[[rules]]
+id = "dsh.activity"
+products = ["dsh"]
+events = ["PreToolUse"]
+matcher = "bash"
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "dsh.policy.v1", group = "agent-activity" }
+
+[[rules]]
+id = "dsh.authority"
+products = ["dsh"]
+events = ["PreToolUse"]
+matcher = "bash"
+priority = 20
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = { id = "dsh.policy.v1", group = "block-direct-git-commit" }
+"#
+}
+
 fn lifecycle_request(
     fixture: &Fixture,
     event: &str,
@@ -717,6 +746,72 @@ fn dsh_activity_helper_fault_matches_read_only_mode_and_terminal_contracts() {
         stop.stdout_json()["data"]["reasons"][0]["code"],
         "activity-stop-reconciliation-required"
     );
+}
+
+#[test]
+fn dsh_activity_degradation_preserves_later_authoritative_rules() {
+    for mode in ["advisory", "off"] {
+        for (command, action, authority_code, authority_disposition) in [
+            (
+                "git commit -m test",
+                "block",
+                "block-direct-git-commit",
+                "block",
+            ),
+            (
+                "printf ok",
+                "warn",
+                "block-direct-git-commit-allow",
+                "allow",
+            ),
+        ] {
+            let fixture = Fixture::new(activity_then_direct_commit_policy());
+            install_dsh_activity_mode(&fixture, mode);
+            let helper = fixture.root.join("failing-agent-session");
+            fs::write(&helper, "#!/bin/sh\nexit 65\n").expect("failing activity helper");
+            fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).expect("helper mode");
+            let output = fixture.run_with_env(
+                &["dispatch", "--product", "dsh", "--format", "json"],
+                Some(&request(&fixture, "bash", json!({"command": command}))),
+                &[
+                    ("AGENT_SESSION_ID", "managed-session"),
+                    ("AGENT_SESSION_RUNTIME_ID", "runtime-1"),
+                    ("AGENT_SESSION_COORDINATION_MODE", mode),
+                    (
+                        "AGENT_SESSION_BIN",
+                        helper.to_str().expect("helper path UTF-8"),
+                    ),
+                ],
+            );
+            assert_eq!(
+                output.stdout_json()["data"]["action"],
+                action,
+                "mode={mode} command={command} envelope={}",
+                output.stdout_text()
+            );
+            assert_eq!(
+                output.stdout_json()["data"]["reasons"],
+                json!([
+                    {
+                        "rule_id": "dsh.activity",
+                        "code": "session-activity-failed",
+                        "disposition": "warn"
+                    },
+                    {
+                        "rule_id": "dsh.activity",
+                        "code": "activity-degraded-advisory-off",
+                        "disposition": "warn"
+                    },
+                    {
+                        "rule_id": "dsh.authority",
+                        "code": authority_code,
+                        "disposition": authority_disposition
+                    }
+                ]),
+                "mode={mode} command={command}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -450,6 +450,58 @@ fn install_foreign_dsh_owner(fixture: &Fixture) {
     }
 }
 
+fn install_dsh_activity_mode(fixture: &Fixture, mode: &str) {
+    let now = now_epoch();
+    let session = fixture
+        .session_state
+        .join("sessions/managed-session/session.json");
+    fs::create_dir_all(session.parent().expect("session directory")).expect("session directory");
+    fs::write(
+        &session,
+        serde_json::to_vec(&json!({
+            "schema_version": "agent-session.session.v1",
+            "id": "managed-session",
+            "coordination_mode": mode,
+            "runtime": {"launch_id": "runtime-1"}
+        }))
+        .expect("session JSON"),
+    )
+    .expect("session record");
+    Fixture::set_private(&session);
+
+    let coordination = fixture.session_state.join("coordination");
+    fs::create_dir_all(&coordination).expect("coordination directory");
+    let registry = coordination.join("registry.json");
+    fs::write(
+        &registry,
+        serde_json::to_vec(&json!({
+            "schema_version": "agent-session.coordination-registry.v1",
+            "fingerprint_epoch": 1,
+            "fingerprint_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "brokers": {
+                "managed-session": {
+                    "session_id": "managed-session",
+                    "incarnation": "runtime-1",
+                    "coordination_mode": mode,
+                    "state": "ready",
+                    "heartbeat_epoch": now
+                }
+            },
+            "claims": []
+        }))
+        .expect("registry JSON"),
+    )
+    .expect("registry");
+    Fixture::set_private(&registry);
+    let heartbeat = fixture
+        .session_state
+        .join("sessions/managed-session/coordination/heartbeat");
+    fs::create_dir_all(heartbeat.parent().expect("heartbeat directory"))
+        .expect("heartbeat directory");
+    fs::write(&heartbeat, format!("runtime-1:{now}\n")).expect("heartbeat");
+    Fixture::set_private(&heartbeat);
+}
+
 #[test]
 fn task_3_2_groups_are_dispatchable_only_for_dsh_pre_tool_use() {
     let accepted = Fixture::new(&policy("block-direct-git-commit", "dsh"));
@@ -584,6 +636,86 @@ fn dsh_agent_activity_emits_only_metadata_and_partial_identity_fails_closed() {
     assert_eq!(
         partial.stdout_json()["data"]["reasons"][0]["code"],
         "session-activity-identity-incomplete"
+    );
+}
+
+#[test]
+fn dsh_activity_helper_fault_matches_read_only_mode_and_terminal_contracts() {
+    for (mode, command, expected_code, expected_action) in [
+        ("enforce", "pwd", 0, "warn"),
+        ("enforce", "touch changed", 1, "block"),
+        ("advisory", "touch changed", 0, "warn"),
+        ("off", "touch changed", 0, "warn"),
+    ] {
+        let fixture = Fixture::new(&task_3_4_policy(
+            "agent-activity",
+            "PreToolUse",
+            Some("bash"),
+        ));
+        install_dsh_activity_mode(&fixture, mode);
+        let helper = fixture.root.join("failing-agent-session");
+        fs::write(&helper, "#!/bin/sh\nexit 65\n").expect("failing activity helper");
+        fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).expect("helper mode");
+        let output = fixture.run_with_env(
+            &["dispatch", "--product", "dsh", "--format", "json"],
+            Some(&request(&fixture, "bash", json!({"command": command}))),
+            &[
+                ("AGENT_SESSION_ID", "managed-session"),
+                ("AGENT_SESSION_RUNTIME_ID", "runtime-1"),
+                ("AGENT_SESSION_COORDINATION_MODE", mode),
+                (
+                    "AGENT_SESSION_BIN",
+                    helper.to_str().expect("helper path UTF-8"),
+                ),
+            ],
+        );
+        assert_eq!(
+            output.code,
+            expected_code,
+            "mode={mode} command={command} envelope={}",
+            output.stdout_text()
+        );
+        assert_eq!(
+            output.stdout_json()["data"]["action"],
+            expected_action,
+            "mode={mode} command={command} envelope={}",
+            output.stdout_text()
+        );
+        if expected_action == "warn" {
+            assert_eq!(
+                output.stdout_json()["data"]["reasons"][0]["code"],
+                "session-activity-failed",
+                "mode={mode} command={command}"
+            );
+        }
+    }
+
+    let fixture = Fixture::new(&task_3_4_policy("agent-activity", "Stop", None));
+    let helper = fixture.root.join("failing-agent-session");
+    fs::write(&helper, "#!/bin/sh\nexit 65\n").expect("failing activity helper");
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o700)).expect("helper mode");
+    let stop = fixture.run_with_env(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&lifecycle_request(
+            &fixture,
+            "agent/turn-stopping",
+            None,
+            None,
+        )),
+        &[
+            ("AGENT_SESSION_ID", "managed-session"),
+            ("AGENT_SESSION_RUNTIME_ID", "runtime-1"),
+            (
+                "AGENT_SESSION_BIN",
+                helper.to_str().expect("helper path UTF-8"),
+            ),
+        ],
+    );
+    assert_eq!(stop.code, 0, "stop={}", stop.stdout_text());
+    assert_eq!(stop.stdout_json()["data"]["action"], "warn");
+    assert_eq!(
+        stop.stdout_json()["data"]["reasons"][0]["code"],
+        "activity-stop-reconciliation-required"
     );
 }
 

--- a/crates/agent-hook/tests/security_review.rs
+++ b/crates/agent-hook/tests/security_review.rs
@@ -1,9 +1,10 @@
 mod support;
 
 use std::fs;
+use std::io::Write;
 use std::os::unix::fs::{PermissionsExt, symlink};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use pretty_assertions::{assert_eq, assert_ne};
 use serde_json::{Value, json};
@@ -879,6 +880,71 @@ fn explicit_mutation_target_cannot_be_masked_by_the_execution_checkout() {
 }
 
 #[test]
+fn trusted_semantic_commit_repo_binds_coordination_to_the_claimed_target() {
+    let bash_owner_policy = owner_policy().replace(
+        "matcher = \"Write|Edit|NotebookEdit|apply_patch\"",
+        "matcher = \"Write|Edit|NotebookEdit|apply_patch|Bash\"",
+    );
+    let (fixture, checkout_a, checkout_b) = foreign_owner_fixture_with(&bash_owner_policy, false);
+    let release = fixture.root.join("release");
+    fs::create_dir(&release).expect("release directory");
+    let agent_hook = release.join("agent-hook");
+    fs::copy(env!("CARGO_BIN_EXE_agent-hook"), &agent_hook).expect("copied agent-hook");
+    fs::set_permissions(&agent_hook, fs::Permissions::from_mode(0o700)).expect("agent-hook mode");
+    let semantic_commit = release.join("semantic-commit");
+    fs::write(&semantic_commit, "#!/bin/sh\nexit 0\n").expect("semantic-commit companion");
+    fs::set_permissions(&semantic_commit, fs::Permissions::from_mode(0o700))
+        .expect("semantic-commit mode");
+    let payload = json!({
+        "hook_event_name":"PreToolUse",
+        "tool_name":"Bash",
+        "cwd":checkout_a,
+        "tool_input":{"command":format!(
+            "{} commit --repo {} --type fix --subject bounded --body-bullet Bounded",
+            semantic_commit.display(),
+            checkout_b.display()
+        )}
+    })
+    .to_string();
+    let mut child = Command::new(&agent_hook);
+    child
+        .args(["dispatch", "--product", "codex", "--format", "json"])
+        .current_dir(&fixture.root)
+        .env_clear()
+        .env("HOME", &fixture.home)
+        .env("PATH", "/usr/bin:/bin")
+        .env("XDG_CONFIG_HOME", &fixture.config_home)
+        .env("XDG_STATE_HOME", &fixture.state_home)
+        .env("AGENT_SESSION_STATE_DIR", &fixture.session_state)
+        .env("AGENT_SESSION_ID", "current")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = child.spawn().expect("copied agent-hook spawn");
+    child
+        .stdin
+        .take()
+        .expect("agent-hook stdin")
+        .write_all(payload.as_bytes())
+        .expect("agent-hook input");
+    let raw = child.wait_with_output().expect("agent-hook output");
+    let output: Value = serde_json::from_slice(&raw.stdout).unwrap_or_else(|error| {
+        panic!(
+            "invalid agent-hook JSON: {error}; status={} stderr={}",
+            raw.status,
+            String::from_utf8_lossy(&raw.stderr)
+        )
+    });
+    assert_eq!(
+        raw.status.code(),
+        Some(1),
+        "explicit --repo must bind the claimed target: {output}"
+    );
+    assert_eq!(output["data"]["action"], "block");
+    assert_eq!(output["data"]["reasons"][0]["code"], "owner-active-foreign");
+}
+
+#[test]
 fn notebook_edit_uses_notebook_path_for_owner_liveness() {
     let (fixture, checkout_a, checkout_b) = same_repository_foreign_owner_fixture();
     assert_foreign_target_blocks(
@@ -1087,7 +1153,20 @@ fn undocumented_codex_apply_patch_alias_fails_closed() {
 }
 
 fn same_repository_foreign_owner_fixture() -> (Fixture, std::path::PathBuf, std::path::PathBuf) {
-    let fixture = Fixture::new(&owner_policy());
+    same_repository_foreign_owner_fixture_with(&owner_policy())
+}
+
+fn same_repository_foreign_owner_fixture_with(
+    policy: &str,
+) -> (Fixture, std::path::PathBuf, std::path::PathBuf) {
+    foreign_owner_fixture_with(policy, true)
+}
+
+fn foreign_owner_fixture_with(
+    policy: &str,
+    shared_repository_context: bool,
+) -> (Fixture, std::path::PathBuf, std::path::PathBuf) {
+    let fixture = Fixture::new(policy);
     let checkout_a = fixture.root.join("checkout-a");
     let checkout_b = fixture.root.join("checkout-b");
     for checkout in [&checkout_a, &checkout_b] {
@@ -1101,6 +1180,16 @@ fn same_repository_foreign_owner_fixture() -> (Fixture, std::path::PathBuf, std:
     }
     let now = now_epoch();
     let key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let claims = if shared_repository_context {
+        json!([
+            {"schema_version":"agent-session.work-context.v1","session_id":"current","session_incarnation":"inc-current","state":"active","worktrees":[fingerprint(key,1,&checkout_a)],"repositories":["owner/repo"],"provider_refs":[],"scopes":[],"expires_at_epoch":now+300},
+            {"schema_version":"agent-session.work-context.v1","session_id":"peer","session_incarnation":"inc-peer","state":"active","worktrees":[fingerprint(key,1,&checkout_b)],"repositories":["owner/repo"],"provider_refs":[],"scopes":[],"expires_at_epoch":now+300}
+        ])
+    } else {
+        json!([
+            {"schema_version":"agent-session.work-context.v1","session_id":"peer","session_incarnation":"inc-peer","state":"active","worktrees":[fingerprint(key,1,&checkout_b)],"repositories":["owner/peer"],"provider_refs":[],"scopes":[],"expires_at_epoch":now+300}
+        ])
+    };
     write_registry(
         &fixture,
         key,
@@ -1108,10 +1197,7 @@ fn same_repository_foreign_owner_fixture() -> (Fixture, std::path::PathBuf, std:
             "current": {"session_id":"current","incarnation":"inc-current","state":"ready","heartbeat_epoch":now},
             "peer": {"session_id":"peer","incarnation":"inc-peer","state":"ready","heartbeat_epoch":now}
         }),
-        json!([
-            {"schema_version":"agent-session.work-context.v1","session_id":"current","session_incarnation":"inc-current","state":"active","worktrees":[fingerprint(key,1,&checkout_a)],"repositories":["owner/repo"],"provider_refs":[],"scopes":[],"expires_at_epoch":now+300},
-            {"schema_version":"agent-session.work-context.v1","session_id":"peer","session_incarnation":"inc-peer","state":"active","worktrees":[fingerprint(key,1,&checkout_b)],"repositories":["owner/repo"],"provider_refs":[],"scopes":[],"expires_at_epoch":now+300}
-        ]),
+        claims,
     );
     for (session, incarnation) in [("current", "inc-current"), ("peer", "inc-peer")] {
         let heartbeat = heartbeat_path(&fixture, session);

--- a/crates/agent-hook/tests/security_review.rs
+++ b/crates/agent-hook/tests/security_review.rs
@@ -895,53 +895,83 @@ fn trusted_semantic_commit_repo_binds_coordination_to_the_claimed_target() {
     fs::write(&semantic_commit, "#!/bin/sh\nexit 0\n").expect("semantic-commit companion");
     fs::set_permissions(&semantic_commit, fs::Permissions::from_mode(0o700))
         .expect("semantic-commit mode");
+    let explicit_repo = fs::canonicalize(&checkout_b).expect("canonical explicit repo");
+    let full_command = format!(
+        "{} commit --repo {} --type fix --subject bounded --body-bullet Bounded",
+        semantic_commit.display(),
+        explicit_repo.display()
+    );
     let payload = json!({
         "hook_event_name":"PreToolUse",
         "tool_name":"Bash",
         "cwd":checkout_a,
-        "tool_input":{"command":format!(
-            "{} commit --repo {} --type fix --subject bounded --body-bullet Bounded",
-            semantic_commit.display(),
-            checkout_b.display()
-        )}
+        "tool_input":{"command":full_command}
     })
     .to_string();
-    let mut child = Command::new(&agent_hook);
-    child
-        .args(["dispatch", "--product", "codex", "--format", "json"])
-        .current_dir(&fixture.root)
-        .env_clear()
-        .env("HOME", &fixture.home)
-        .env("PATH", "/usr/bin:/bin")
-        .env("XDG_CONFIG_HOME", &fixture.config_home)
-        .env("XDG_STATE_HOME", &fixture.state_home)
-        .env("AGENT_SESSION_STATE_DIR", &fixture.session_state)
-        .env("AGENT_SESSION_ID", "current")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = child.spawn().expect("copied agent-hook spawn");
-    child
-        .stdin
-        .take()
-        .expect("agent-hook stdin")
-        .write_all(payload.as_bytes())
-        .expect("agent-hook input");
-    let raw = child.wait_with_output().expect("agent-hook output");
-    let output: Value = serde_json::from_slice(&raw.stdout).unwrap_or_else(|error| {
-        panic!(
-            "invalid agent-hook JSON: {error}; status={} stderr={}",
-            raw.status,
-            String::from_utf8_lossy(&raw.stderr)
-        )
-    });
-    assert_eq!(
-        raw.status.code(),
-        Some(1),
-        "explicit --repo must bind the claimed target: {output}"
-    );
-    assert_eq!(output["data"]["action"], "block");
-    assert_eq!(output["data"]["reasons"][0]["code"], "owner-active-foreign");
+    let trace_path = fixture.state_home.join("agent-hook/trace.jsonl");
+
+    for (format, expected_code) in [("json", 1), ("text", 1), ("provider", 0)] {
+        let _ = fs::remove_file(&trace_path);
+        let mut child = Command::new(&agent_hook);
+        child
+            .args([
+                "dispatch",
+                "--product",
+                "codex",
+                "--format",
+                format,
+                "--trace",
+            ])
+            .current_dir(&fixture.root)
+            .env_clear()
+            .env("HOME", &fixture.home)
+            .env("PATH", "/usr/bin:/bin")
+            .env("XDG_CONFIG_HOME", &fixture.config_home)
+            .env("XDG_STATE_HOME", &fixture.state_home)
+            .env("AGENT_SESSION_STATE_DIR", &fixture.session_state)
+            .env("AGENT_SESSION_ID", "current")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        let mut child = child.spawn().expect("copied agent-hook spawn");
+        child
+            .stdin
+            .take()
+            .expect("agent-hook stdin")
+            .write_all(payload.as_bytes())
+            .expect("agent-hook input");
+        let raw = child.wait_with_output().expect("agent-hook output");
+        let stdout = String::from_utf8(raw.stdout).expect("agent-hook stdout UTF-8");
+        let stderr = String::from_utf8(raw.stderr).expect("agent-hook stderr UTF-8");
+        assert_eq!(
+            raw.status.code(),
+            Some(expected_code),
+            "format={format} explicit --repo must bind the claimed target: {stdout} {stderr}"
+        );
+        if format == "json" {
+            let output: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+                panic!("invalid agent-hook JSON: {error}; stderr={stderr}")
+            });
+            assert_eq!(output["data"]["action"], "block");
+            assert_eq!(output["data"]["reasons"][0]["code"], "owner-active-foreign");
+        }
+
+        let trace = fs::read_to_string(&trace_path).expect("agent-hook trace");
+        for (surface, contents) in [
+            ("stdout", stdout.as_str()),
+            ("stderr", stderr.as_str()),
+            ("trace", trace.as_str()),
+        ] {
+            assert!(
+                !contents.contains(explicit_repo.to_str().expect("explicit repo UTF-8")),
+                "format={format} {surface} exposed the explicit repository: {contents}"
+            );
+            assert!(
+                !contents.contains(&full_command),
+                "format={format} {surface} exposed the full command: {contents}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Repairs `nils-agent-hook` startup admission so typed activity-observation faults remain metadata: audited read-only probes and durable advisory/off requests can continue, while enforce-mode mutations retain their owner and transaction proof requirements. Partial session/runtime identity is rejected with a bounded launcher-owned diagnosis, and the resolved activity helper is pinned for each attempt.

## Problem

- Expected: Activity metadata failure must not block audited read-only diagnosis or trusted advisory/off work; enforce mutations must still fail closed.
- Actual: A missing activity helper returned `capability-failure-closed` before effect and coordination-mode classification, blocking even `pwd` and sending the model into retry loops.
- Impact: Managed-session startup could stall before useful provider work, while explicit repository context could be obscured by an unrelated inherited cwd.

## Reproduction

1. Configure a managed Codex activity rule and make the activity helper unresolvable.
2. Dispatch `PreToolUse` for Bash `pwd`.
3. Observe exit 1 and `capability-failure-closed` before the fix; the paired `touch changed` case also blocks.

## Issues Found

- Refs [serenvia/sympoies-infra#330](https://github.com/serenvia/sympoies-infra/issues/330)

## Fix Approach

- Classify the closed `pwd` argument set as audited read-only and degrade only typed activity-runtime faults.
- Admit trusted advisory/off activity faults without granting mutation authority; retain enforce-mode fail-closed behavior.
- Reject incomplete managed identity before provider work and keep existing held-runtime broker convergence as the sole launch identity mechanism.
- Honor an explicit governed `--repo` over an unrelated request cwd without weakening worktree or delivery guards.
- Canonicalize helper and command identities, preserve ordered degradation reasons, and keep Codex, Claude, and DSH terminal/advisory behavior on one documented contract.
- Render text events through a closed static-literal label map so field-insensitive analysis cannot confuse private canonical paths with public output; JSON/provider schemas remain unchanged.

## Test-First Evidence

- RED: `cargo test -p nils-agent-hook --test activity_helper an_unresolvable_helper_allows_only_audited_read_only_pre_tool_use -- --exact --nocapture` exited 101 because `pwd` was blocked with `capability-failure-closed`.
- GREEN: The same regression now warns/allows `pwd` while the paired mutation remains blocked.
- Review-repair REDs also captured exact recovery blocking, caller-controlled `pwd` trust, DSH helper-fault blocking, unrelated `--repo` coordination, selectorless managed identity, and relative helper cwd drift before their production fixes.
- The final DSH two-rule authority-ordering test was proof-only: existing production behavior was already GREEN, so no product RED is claimed for that test.
- CodeQL alert #85 supplied the static-flow RED for the final review repair. The runtime was already non-leaking; the regression now proves that the explicit canonical repository and full command are absent from JSON, text, provider, stderr, and trace output.
- The verified v2 evidence record is bound to baseline `ba5d855a50203d7146b0689928dae197aeb7a184` and final delivery head `f09b00b286793c2752614e3a2973f4bd00a33aa4` (delivery attempt 4).

## Test plan

- Review-repair focused suites — 155/155 passed.
- Final DSH authority-ordering regression — 1/1 passed; full `dsh_policy` suite 47/47 passed.
- CodeQL non-disclosure regression — 1/1 passed for JSON, text, provider, stderr, and trace surfaces.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — docs, fmt, Clippy, doctest, and 369 nextest cases passed with zero failures/errors (run `943ba9d3-529e-4b19-866d-57e3e36e677a`).
- Full specialist review plus bounded follow-ups resolved all ten provider review threads at the final head.

## Risk / Notes

- Medium: this changes a hook admission boundary. The patch is limited to typed activity faults, a closed read-only command set, and authenticated coordination modes.
- Enforce-mode mutations and incomplete managed identity remain fail-closed.
- One low-impact performance observation (a duplicate metadata probe for a stale helper override) is accepted as a non-blocking residual pending evidence that it is material.
- CodeQL alert #85 was a field-insensitive false positive; the current head makes the output invariant statically visible and adds explicit non-disclosure coverage. No security residual remains in that scope.
- Released-binary and downstream runtime startup acceptance remains tracked by `serenvia/sympoies-infra#330`.
