### PR TITLE
fix(agent-hook): explain unclassifiable shell retries

### DIFF
--- a/crates/agent-hook/src/dsh_policy.rs
+++ b/crates/agent-hook/src/dsh_policy.rs
@@ -57,6 +57,14 @@ impl Outcome {
         }
     }
 
+    fn block_with_context(group: DshCapabilityGroup, context: &str) -> Self {
+        Self {
+            action: DecisionAction::Block,
+            code: group.as_str().to_string(),
+            context: Some(context.to_string()),
+        }
+    }
+
     fn context(group: DshCapabilityGroup, context: impl Into<String>) -> Self {
         Self {
             action: DecisionAction::Context,
@@ -78,19 +86,25 @@ pub(crate) fn evaluate(
             return Ok(if group == DshCapabilityGroup::ForgeLabelReminder {
                 Outcome::allow(group)
             } else {
-                Outcome::block(group)
+                Outcome::block_with_context(group, SHELL_COMMAND_INVALID_CONTEXT)
             });
         };
         let invocations = parse_invocations(&command);
         if invocations
             .iter()
             .any(|invocation| invocation.unresolved_nested)
-            || sequential_shell_context_unknown(&invocations)
         {
             return Ok(if group == DshCapabilityGroup::ForgeLabelReminder {
                 Outcome::allow(group)
             } else {
-                Outcome::block(group)
+                Outcome::block_with_context(group, SHELL_COMMAND_UNCLASSIFIABLE_CONTEXT)
+            });
+        }
+        if sequential_shell_context_unknown(&invocations) {
+            return Ok(if group == DshCapabilityGroup::ForgeLabelReminder {
+                Outcome::allow(group)
+            } else {
+                Outcome::block_with_context(group, SHELL_CONTEXT_UNCLASSIFIABLE_CONTEXT)
             });
         }
         invocations
@@ -207,6 +221,9 @@ const MEMORY_WRITE_CONTEXT: &str = "Writing to agent memory: write only an untru
 const FORGE_LABEL_CONTEXT: &str = "forge-cli is about to create or deliver a record without --label. Consider labels from the repository catalog or taxonomy for triage and automation; labels remain optional, but an inline environment assignment is not authorization to suppress this reminder.";
 const SKILL_USAGE_CONTEXT: &str = "This request appears to match a skill-backed workflow. Use DSH's native skill catalog and skill tool before acting; load every explicitly named or clearly applicable skill and follow its complete instructions.";
 const PRE_PR_CONTEXT: &str = "delivery-readiness reminder: this feature branch has non-trivial changes relative to the default branch. Run the repository validation and review gates before delivery; a PR is the default unless the current request explicitly authorizes governed direct-main delivery.";
+const SHELL_COMMAND_INVALID_CONTEXT: &str = "The Bash tool call was blocked before command dispatch because its command field was missing, empty, oversized, or invalid. Retry now with one bounded command in a separate Bash tool call. No operator intervention is required.";
+const SHELL_COMMAND_UNCLASSIFIABLE_CONTEXT: &str = "The Bash tool call was blocked before command dispatch because nested or dynamic shell execution could not be classified safely. Retry now by invoking the final executable or executable repository script directly in one Bash tool call, without a bash/sh/eval wrapper or an indirect command variable. Split compound operations into separate Bash tool calls. No operator intervention is required.";
+const SHELL_CONTEXT_UNCLASSIFIABLE_CONTEXT: &str = "The Bash tool call was blocked before command dispatch because a preceding shell-state command such as `set`, `export`, or `cd` makes later commands impossible to classify safely. Retry now with separate Bash tool calls, one command per call; omit shell-state preambles and use the tool's `workdir` field instead of `cd`. No operator intervention is required.";
 
 fn sanitize_companion_env(command: &mut Command, retained_names: &[&str]) {
     let retained = retained_names

--- a/crates/agent-hook/src/evaluator.rs
+++ b/crates/agent-hook/src/evaluator.rs
@@ -1316,7 +1316,9 @@ fn aggregate(
                 replacement = outcome.replacement.clone();
             }
         }
-        if let Some(context) = outcome.context {
+        if let Some(context) = outcome.context
+            && !contexts.contains(&context)
+        {
             contexts.push(context);
         }
         if rank(outcome.action) > rank(action) {

--- a/crates/agent-hook/tests/dsh_policy.rs
+++ b/crates/agent-hook/tests/dsh_policy.rs
@@ -34,6 +34,32 @@ capability = {{ id = "dsh.policy.v1", group = "{group}" }}
     )
 }
 
+fn policy_for_groups(groups: &[&str]) -> String {
+    let mut policy = String::from(
+        r#"schema_version = "agent-hook.policy.v1"
+bundle_id = "dsh-runtime-kit-shell-diagnostics"
+version = "2026.08.28.1"
+"#,
+    );
+    for (index, group) in groups.iter().enumerate() {
+        policy.push_str(&format!(
+            r#"
+[[rules]]
+id = "dsh.shell-diagnostic-{index}"
+products = ["dsh"]
+events = ["PreToolUse"]
+matcher = "bash"
+priority = 10
+mode = "enforce"
+failure_posture = "closed"
+override_class = "locked"
+capability = {{ id = "dsh.policy.v1", group = "{group}" }}
+"#,
+        ));
+    }
+    policy
+}
+
 fn request(fixture: &Fixture, tool: &str, arguments: Value) -> String {
     request_for_session(fixture, "dsh-session-1", tool, arguments)
 }
@@ -1601,6 +1627,60 @@ fn command_dependent_groups_reject_sequential_shell_state_retargeting() {
             assert_eq!(output.stdout_json()["data"]["action"], "block");
         }
     }
+}
+
+#[test]
+fn sequential_shell_state_denial_explains_one_immediate_retry_path() {
+    let fixture = Fixture::new(&policy_for_groups(&[
+        "block-direct-git-commit",
+        "block-direct-git-worktree",
+        "block-direct-pr-create",
+        "block-direct-python",
+        "semantic-commit-body-gate",
+        "block-unsafe-default-delivery",
+        "checkout-lease-guard",
+    ]));
+    let output = fixture.run(
+        &["dispatch", "--product", "dsh", "--format", "json"],
+        Some(&request(
+            &fixture,
+            "bash",
+            json!({"command": "set -euo pipefail; git --version; gh --version; git status --short --branch"}),
+        )),
+    );
+
+    assert_eq!(output.code, 1, "envelope={}", output.stdout_text());
+    let decision = output.stdout_json();
+    assert_eq!(decision["data"]["action"], "block");
+    let reasons = decision["data"]["reasons"]
+        .as_array()
+        .expect("blocking reasons");
+    assert_eq!(reasons.len(), 7);
+    for (reason, expected) in reasons.iter().zip([
+        "block-direct-git-commit",
+        "block-direct-git-worktree",
+        "block-direct-pr-create",
+        "block-direct-python",
+        "semantic-commit-body-gate",
+        "block-unsafe-default-delivery",
+        "checkout-lease-guard",
+    ]) {
+        assert_eq!(reason["code"], expected);
+        assert_eq!(reason["disposition"], "block");
+    }
+    let context = decision["data"]["context"]
+        .as_str()
+        .expect("shell denial guidance");
+    assert!(context.contains("blocked before command dispatch"));
+    assert!(context.contains("set`, `export`, or `cd"));
+    assert!(context.contains("separate Bash tool calls"));
+    assert!(context.contains("tool's `workdir` field instead of `cd`"));
+    assert!(context.contains("Retry now"));
+    assert_eq!(
+        context.matches("blocked before command dispatch").count(),
+        1,
+        "guidance must be aggregated once: {context}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make DSH shell-policy denials explain why a combined shell-state command could not be classified, while preserving the existing fail-closed decision and policy-group diagnostics.

## Problem

- Expected: a pre-dispatch denial tells the agent what made classification uncertain and gives one bounded retry it can perform immediately.
- Actual: the decision exposed a fanout of policy codes without an actionable explanation, so agents had to guess whether to retry, change permissions, or stop.
- Impact: valid DSH work could stall even though the denial was recoverable by splitting shell-state setup from command probes.

## Reproduction

1. Submit a DSH Bash tool call equivalent to `set -euo pipefail; git --version; gh --version; git status --short --branch`.
2. Observe that policy blocks before command dispatch because the shell-state preamble prevents deterministic classification of later commands.
3. Before this change, the result contains policy-group failures but no typed explanation or immediate retry path.

## Issues Found

- Related acceptance tracker: https://github.com/serenvia/sympoies-infra/issues/213

## Fix Approach

- Attach bounded, privacy-safe context to invalid, unclassifiable, and shell-state-dependent command denials.
- Preserve every existing policy-group reason code and the blocking action.
- Deduplicate identical context when several policy groups evaluate the same command.

## Test-First Evidence

- RED: the focused regression failed before production edits because the old policy decision had no typed recovery context.
- GREEN: the exact deployed-like scenario now returns all existing group codes plus one bounded explanation and retry instruction.

## Test plan

- `cargo test -p nils-agent-hook --test dsh_policy sequential_shell_state_denial_explains_one_immediate_retry_path -- --exact --nocapture`
- `cargo test -p nils-agent-hook --test dsh_policy deterministic_command_groups_block_direct_and_nested_unsafe_forms -- --exact --nocapture`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (Clippy, 360 tests, doctests, documentation and temp-directory audits passed; one existing test remained skipped.)

## Risk / Notes

- Policy action and existing reason codes are unchanged; only bounded diagnostic context is added.
- Context constants contain no command arguments, paths, session data, or environment contents.
