### PR TITLE
fix(agent-session): join wrapped rows in attach replay capture

### DIFF
--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -7660,9 +7660,16 @@ async fn capture_attach_snapshot_with_timeout(
     let tmux_session = record.tmux_session.clone();
     tokio::task::spawn_blocking(move || {
         let mut command = ProcessCommand::new(&tmux);
+        // -J joins tmux-wrapped rows back into logical lines (preserving the
+        // trailing spaces at each join), so the attaching client's terminal
+        // re-wraps them at its own width and marks continuation rows as
+        // wrapped. Replayed wrapped URLs and commands then stay one logical
+        // line for client-side selection and link detection, and scrollback
+        // captured at an earlier pane width re-wraps at the current width.
         command
             .arg("capture-pane")
             .arg("-p")
+            .arg("-J")
             .arg("-t")
             .arg(&tmux_session)
             .arg("-S")
@@ -21819,6 +21826,51 @@ exit 0
         assert_eq!(handoff.live.len(), 1);
         assert_eq!(handoff.live[0], Bytes::from_static(b"after-recapture"));
         assert_eq!(std::fs::read_to_string(calls).unwrap().lines().count(), 2);
+    }
+
+    #[tokio::test]
+    async fn attach_snapshot_capture_joins_wrapped_rows() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state_dir = tmp.path().join("state");
+        let args_log = tmp.path().join("capture-args");
+        seed_session(&state_dir, "joined", "codex", "hs-codex-joined");
+        let tmux = executable(
+            &tmp.path().join("tmux"),
+            &format!(
+                "#!/usr/bin/env sh\nprintf '%s\\n' \"$@\" > {args}\nprintf 'pane\\n'\nexit 0\n",
+                args = shell_words::quote(&args_log.to_string_lossy()),
+            ),
+        );
+        let context = CliContext {
+            state_dir,
+            host: None,
+        };
+        let record = load_session_record(&context, "joined").unwrap();
+
+        let capture = capture_attach_snapshot(&tmux, &record).await.unwrap();
+
+        assert_eq!(capture.as_deref(), Some("pane\n"));
+        // -J joins tmux-wrapped rows back into logical lines, so the attaching
+        // client's terminal re-wraps them at its own width and marks the
+        // continuation rows as wrapped. Without it, a wrapped URL or command in
+        // the replayed scrollback arrives as unrelated hard rows.
+        let args: Vec<String> = std::fs::read_to_string(&args_log)
+            .unwrap()
+            .lines()
+            .map(str::to_string)
+            .collect();
+        assert_eq!(
+            args,
+            vec![
+                "capture-pane",
+                "-p",
+                "-J",
+                "-t",
+                "hs-codex-joined",
+                "-S",
+                "-200"
+            ],
+        );
     }
 
     #[tokio::test]

--- a/crates/agent-session/src/serve.rs
+++ b/crates/agent-session/src/serve.rs
@@ -7609,8 +7609,10 @@ fn wait_process_with_timeout(
 /// instead of continuing from wherever the live cursor happened to be.
 const ATTACH_REPLAY_ORIGIN: &str = "\x1b[H\x1b[2J";
 
-/// Turn a `capture-pane -p` screen into bytes that are safe to inject into the
-/// raw PTY stream an attaching client reads.
+/// Turn a `capture-pane -p -J` screen into bytes that are safe to inject into
+/// the raw PTY stream an attaching client reads. With `-J` each row is a joined
+/// logical line: it can exceed the pane width (the client re-wraps it) and
+/// keeps the trailing spaces at former wrap points.
 ///
 /// `capture-pane -p` joins pane rows with a bare `\n`. In a PTY stream a lone LF
 /// only moves the cursor down one row and keeps its column, so replaying the


### PR DESCRIPTION
## Summary

The attach replay now captures tmux panes with `capture-pane -J`, so rows that
tmux wrapped at the pane edge are joined back into logical lines before the
CRLF replay. The attaching client's terminal re-wraps them at its own width
and marks continuation rows as wrapped, which keeps replayed wrapped URLs and
commands selectable and linkable as one logical line, and lets scrollback
captured at an earlier pane width re-wrap at the current width.

## Problem

`capture_attach_snapshot` ran `capture-pane -p -S -200` without `-J`, so a URL
or command that tmux wrapped arrived at the attaching client as independent
hard rows. Client-side wrap-aware selection copy and logical-line link
detection (serenvia/agent-console#394) cannot recover those rows because the
client terminal never sees a wrap flag for them; device switches under
`window-size latest` additionally leave mixed-width hard wraps in replayed
scrollback.

## Reproduction

1. In a console session, print a URL longer than the pane width.
2. Detach and reattach (or open the session from another client) so the
   content arrives via the attach replay.
3. Select-copy the URL in the client: the text contains embedded newlines;
   link detection sees fragments. Pinned by
   `serve::tests::attach_snapshot_capture_joins_wrapped_rows`, which failed on
   the baseline (args were `capture-pane -p -t <session> -S -200`).

## Issues Found

- Refs serenvia/agent-console#393 (option D of the wrapped-URL solution
  catalog; the UI-side fixes landed in serenvia/agent-console#394)

## Fix Approach

Add `-J` to the snapshot capture invocation. `-J` joins wrapped lines and
preserves the trailing spaces at each join, so `pty_ready_attach_replay`'s
normalization (known origin, CRLF rows, trailing-blank-row drop) is unchanged;
rows are simply logical lines now. Alt-screen TUI captures are unaffected in
practice because cursor-addressed paints carry no tmux wrap state.

## Test-First Evidence

`attach_snapshot_capture_joins_wrapped_rows` (fake tmux records `"$@"`) failed
red on the baseline with args lacking `-J`, then passed after the change.
Evidence record verified with `test-first-evidence verify` (bug-fix
classification, baseline `5ffcf3c0`).

## Test plan

- `cargo test -p nils-agent-session --lib attach_snapshot_capture_joins_wrapped_rows pty_ready snapshot_handoff`: 3 pass.
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`: pass (fmt,
  clippy, workspace tests, audits).

## Risk / Notes

- Replay visual fidelity: `-J` preserves trailing spaces at joins, so a
  logical line whose length lands on a width multiple can wrap one blank
  continuation row in the client; cosmetic, and the console's bottom pin keys
  off the last non-blank row.
- A logical line straddling the `-S -200` capture start is replayed from the
  capture boundary, same as the pre-change physical-row truncation.
- Live cursor-addressed repaints still carry no wrap state; this fix
  intentionally covers the replay/scrollback path only.
