### PR TITLE
feat(review): unify provider review publication

### DIFF
--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -4846,7 +4846,7 @@ _forge__cli() {
             return 0
             ;;
         forge__cli__pr__review)
-            opts="-h --decision --comment --comment-file --lens --issue --mirror-issue --submit-review --expected-head --thread-file --format --remote --provider --host --repo --store-root --dry-run --help validate help"
+            opts="-h --decision --comment --comment-file --lens --issue --mirror-issue --submit-review --expected-head --thread-file --specialist-report --metadata-only --native-review-url --format --remote --provider --host --repo --store-root --dry-run --help validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4877,6 +4877,10 @@ _forge__cli() {
                     return 0
                     ;;
                 --thread-file)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --native-review-url)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -5526,7 +5530,7 @@ _forge__cli() {
             return 0
             ;;
         forge__cli__pr__review__validate)
-            opts="-h --comment --comment-file --thread-file --check-diff --format --remote --provider --host --repo --store-root --dry-run --help"
+            opts="-h --comment --comment-file --thread-file --check-diff --specialist-report --format --remote --provider --host --repo --store-root --dry-run --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 4 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/bash/forge-cli
+++ b/completions/bash/forge-cli
@@ -4846,7 +4846,7 @@ _forge__cli() {
             return 0
             ;;
         forge__cli__pr__review)
-            opts="-h --decision --comment --comment-file --lens --issue --mirror-issue --submit-review --expected-head --thread-file --specialist-report --metadata-only --native-review-url --format --remote --provider --host --repo --store-root --dry-run --help validate help"
+            opts="-h --decision --comment --comment-file --lens --issue --mirror-issue --submit-review --expected-head --thread-file --specialist-report --metadata-only --native-review-url --native-review-author --format --remote --provider --host --repo --store-root --dry-run --help validate help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -4881,6 +4881,10 @@ _forge__cli() {
                     return 0
                     ;;
                 --native-review-url)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --native-review-author)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/bash/review-specialists
+++ b/completions/bash/review-specialists
@@ -55,7 +55,7 @@ _review__specialists() {
             return 0
             ;;
         review__specialists__bundle)
-            opts="-h --format --mode --input --out-dir --display-threshold --profile --repo --ref --link-base --reviewable --lens --lens-verdict --scope --evidence-reviewed --thread-out --help"
+            opts="-h --format --mode --input --out-dir --display-threshold --profile --repo --ref --link-base --reviewable --lens --lens-verdict --scope --evidence-reviewed --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -129,21 +129,6 @@ _review__specialists() {
                     ;;
                 --evidence-reviewed)
                     COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --thread-out)
-                    local oldifs
-                    if [ -n "${IFS+x}" ]; then
-                        oldifs="$IFS"
-                    fi
-                    IFS=$'\n'
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    if [ -n "${oldifs+x}" ]; then
-                        IFS="$oldifs"
-                    fi
-                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
-                        compopt -o filenames
-                    fi
                     return 0
                     ;;
                 *)
@@ -224,7 +209,7 @@ _review__specialists() {
             return 0
             ;;
         review__specialists__render)
-            opts="-h --format --profile --input --out --repo --ref --link-base --reviewable --lens --lens-verdict --scope --evidence-reviewed --thread-out --help"
+            opts="-h --format --profile --input --out --repo --ref --link-base --thread-out --reviewable --lens --lens-verdict --scope --evidence-reviewed --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -280,6 +265,21 @@ _review__specialists() {
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
+                --thread-out)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
+                    return 0
+                    ;;
                 --reviewable)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -298,21 +298,6 @@ _review__specialists() {
                     ;;
                 --evidence-reviewed)
                     COMPREPLY=($(compgen -f "${cur}"))
-                    return 0
-                    ;;
-                --thread-out)
-                    local oldifs
-                    if [ -n "${IFS+x}" ]; then
-                        oldifs="$IFS"
-                    fi
-                    IFS=$'\n'
-                    COMPREPLY=($(compgen -f "${cur}"))
-                    if [ -n "${oldifs+x}" ]; then
-                        IFS="$oldifs"
-                    fi
-                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
-                        compopt -o filenames
-                    fi
                     return 0
                     ;;
                 *)

--- a/completions/bash/review-specialists
+++ b/completions/bash/review-specialists
@@ -55,7 +55,7 @@ _review__specialists() {
             return 0
             ;;
         review__specialists__bundle)
-            opts="-h --format --mode --input --out-dir --display-threshold --profile --repo --ref --link-base --help"
+            opts="-h --format --mode --input --out-dir --display-threshold --profile --repo --ref --link-base --reviewable --lens --lens-verdict --scope --evidence-reviewed --thread-out --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -96,7 +96,7 @@ _review__specialists() {
                     return 0
                     ;;
                 --profile)
-                    COMPREPLY=($(compgen -W "terminal report issue-body pr-comment evidence" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "terminal report issue-body pr-comment provider-review evidence" -- "${cur}"))
                     return 0
                     ;;
                 --repo)
@@ -109,6 +109,41 @@ _review__specialists() {
                     ;;
                 --link-base)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --reviewable)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --lens)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --lens-verdict)
+                    COMPREPLY=($(compgen -W "pass findings blocked follow-up-pass" -- "${cur}"))
+                    return 0
+                    ;;
+                --scope)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --evidence-reviewed)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --thread-out)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 *)
@@ -189,7 +224,7 @@ _review__specialists() {
             return 0
             ;;
         review__specialists__render)
-            opts="-h --format --profile --input --out --repo --ref --link-base --help"
+            opts="-h --format --profile --input --out --repo --ref --link-base --reviewable --lens --lens-verdict --scope --evidence-reviewed --thread-out --help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -200,7 +235,7 @@ _review__specialists() {
                     return 0
                     ;;
                 --profile)
-                    COMPREPLY=($(compgen -W "terminal report issue-body pr-comment evidence" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "terminal report issue-body pr-comment provider-review evidence" -- "${cur}"))
                     return 0
                     ;;
                 --input)
@@ -243,6 +278,41 @@ _review__specialists() {
                     ;;
                 --link-base)
                     COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --reviewable)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --lens)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --lens-verdict)
+                    COMPREPLY=($(compgen -W "pass findings blocked follow-up-pass" -- "${cur}"))
+                    return 0
+                    ;;
+                --scope)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --evidence-reviewed)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --thread-out)
+                    local oldifs
+                    if [ -n "${IFS+x}" ]; then
+                        oldifs="$IFS"
+                    fi
+                    IFS=$'\n'
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    if [ -n "${oldifs+x}" ]; then
+                        IFS="$oldifs"
+                    fi
+                    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+                        compopt -o filenames
+                    fi
                     return 0
                     ;;
                 *)

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -274,6 +274,7 @@ request-changes\:"Record a request-changes outcome in the posted review comment"
 '--expected-head=[Full PR head SHA that was reviewed. Required with \`--submit-review\` and bound to both the pending-review preflight and provider mutation]:SHA:_default' \
 '--thread-file=[Create or validate review threads from a JSON array of actionable findings (max 50 threads; 16 KiB body each). Requires --submit-review when posting; may be inherited by \`validate\` without posting. Omit this for summary-only reviews. Repair findings, then resolve via \`pr review-threads resolve\`]:PATH:_default' \
 '--native-review-url=[Authoritative native review URL. Required with --metadata-only]:URL:_default' \
+'--native-review-author=[Expected GitHub login that authored the authoritative native review. Required with --metadata-only and verified by provider read-back before the personal-identity metadata breadcrumb is posted]:LOGIN:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -271,7 +271,7 @@ request-changes\:"Record a request-changes outcome in the posted review comment"
 '--comment-file=[Read review outcome comment body from a file. Use \`-\` for stdin]:PATH:_default' \
 '*--lens=[Review lens name to include in output and issue mirror metadata]:LENS:_default' \
 '--issue=[Issue number that should receive the optional activity mirror]:ISSUE_NUMBER:_default' \
-'--expected-head=[Full PR head SHA that was reviewed. Required with \`--submit-review\` and bound to both the pending-review preflight and provider mutation]:SHA:_default' \
+'--expected-head=[Full PR head SHA that was reviewed. Required with \`--submit-review\` or \`--metadata-only\`; bound to the provider head and native review commit]:SHA:_default' \
 '--thread-file=[Create or validate review threads from a JSON array of actionable findings (max 50 threads; 16 KiB body each). Requires --submit-review when posting; may be inherited by \`validate\` without posting. Omit this for summary-only reviews. Repair findings, then resolve via \`pr review-threads resolve\`]:PATH:_default' \
 '--native-review-url=[Authoritative native review URL. Required with --metadata-only]:URL:_default' \
 '--native-review-author=[Expected GitHub login that authored the authoritative native review. Required with --metadata-only and verified by provider read-back before the personal-identity metadata breadcrumb is posted]:LOGIN:_default' \

--- a/completions/zsh/_forge-cli
+++ b/completions/zsh/_forge-cli
@@ -273,6 +273,7 @@ request-changes\:"Record a request-changes outcome in the posted review comment"
 '--issue=[Issue number that should receive the optional activity mirror]:ISSUE_NUMBER:_default' \
 '--expected-head=[Full PR head SHA that was reviewed. Required with \`--submit-review\` and bound to both the pending-review preflight and provider mutation]:SHA:_default' \
 '--thread-file=[Create or validate review threads from a JSON array of actionable findings (max 50 threads; 16 KiB body each). Requires --submit-review when posting; may be inherited by \`validate\` without posting. Omit this for summary-only reviews. Repair findings, then resolve via \`pr review-threads resolve\`]:PATH:_default' \
+'--native-review-url=[Authoritative native review URL. Required with --metadata-only]:URL:_default' \
 '--format=[Output format (defaults to text)]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
 '--remote=[Git remote whose URL feeds provider detection (default\: \`origin\`)]:REMOTE:_default' \
@@ -282,6 +283,8 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--store-root=[Root directory of the file-backed store used by \`--provider local\`. Overrides the \`FORGE_CLI_LOCAL_STORE\` env var]:path:_files' \
 '--mirror-issue[Mirror a compact activity note to \`--issue\` (required; omitting it returns the \`issue_required\` envelope at runtime)]' \
 '--submit-review[Submit a native provider review event instead of posting an outcome comment. On GitHub this POSTs \`.../pulls/<id>/reviews\`, creating the \`#pullrequestreview-\` object; \`--decision\` maps to the review event (comments-only→COMMENT, approve→APPROVE, request-changes→REQUEST_CHANGES). The review is authored by the invoking token'\''s identity (e.g. a reviewer bot via FORGE_BOT_PROFILE). A body is required for COMMENT and REQUEST_CHANGES and optional for APPROVE. GitHub-only in v1]' \
+'--specialist-report[Validate the body as the canonical specialist Review Report shape]' \
+'--metadata-only[Post only a concise personal-identity metadata breadcrumb for an already-published authoritative native review]' \
 '--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
@@ -309,6 +312,7 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--repo=[Override the remote-derived repository path. Accepted shapes\: GitHub \`owner/name\`; GitLab \`group\[/subgroup...\]/project\`; Local \`local\:<slug>\` or \`<slug>\`]:REPOSITORY:_default' \
 '--store-root=[Root directory of the file-backed store used by \`--provider local\`. Overrides the \`FORGE_CLI_LOCAL_STORE\` env var]:path:_files' \
 '--check-diff[Check thread path / line coordinates against the live GitHub PR diff]' \
+'--specialist-report[Enforce the canonical specialist Review Report marker, fields, and table]' \
 '--dry-run[Validate and describe the planned operation without applying its mutation. Read-only preflight calls may still run]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \

--- a/completions/zsh/_review-specialists
+++ b/completions/zsh/_review-specialists
@@ -57,12 +57,18 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 _arguments "${_arguments_options[@]}" : \
 '--format=[Output format]:FORMAT:((text\:"Human-readable text output (default)"
 json\:"Single-record JSON envelope (snake_case)"))' \
-'--profile=[Render profile]:PROFILE:(terminal report issue-body pr-comment evidence)' \
+'--profile=[Render profile]:PROFILE:(terminal report issue-body pr-comment provider-review evidence)' \
 '--input=[Merged findings JSON from \`review-specialists merge --format json\`]:FILE:_files' \
 '--out=[Output path. If omitted, text profiles print the rendered body]:FILE:_files' \
 '--repo=[Repository slug for GitHub source links, e.g. owner/repo]:REPO:_default' \
 '--ref=[Ref for source links]:GIT_REF:_default' \
 '--link-base=[Custom link base. Defaults to https\://github.com/<repo>/blob when --repo is provided]:LINK_BASE:_default' \
+'--reviewable=[PR/MR identifier or URL shown in the provider review body]:REVIEWABLE:_default' \
+'--lens=[Exactly one reviewer lens represented by this report]:LENS:_default' \
+'--lens-verdict=[Single-lens verdict represented by this report]:LENS_VERDICT:(pass findings blocked follow-up-pass)' \
+'--scope=[Compact description of files or behavior reviewed]:TEXT:_default' \
+'--evidence-reviewed=[Compact validation, diff, or provider evidence summary]:TEXT:_default' \
+'--thread-out=[Write actionable GitHub review-thread specs derived from the same findings]:FILE:_files' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
@@ -75,10 +81,16 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '*--input=[Specialist finding JSONL input file]:FILE:_files' \
 '--out-dir=[Bundle output directory]:DIR:_files -/' \
 '--display-threshold=[Minimum confidence for displayed findings]:DISPLAY_THRESHOLD:_default' \
-'--profile=[Optional additional render profile to write]:PROFILE:(terminal report issue-body pr-comment evidence)' \
+'--profile=[Optional additional render profile to write]:PROFILE:(terminal report issue-body pr-comment provider-review evidence)' \
 '--repo=[Repository slug for GitHub source links, e.g. owner/repo]:REPO:_default' \
 '--ref=[Ref for source links]:GIT_REF:_default' \
 '--link-base=[Custom link base. Defaults to https\://github.com/<repo>/blob when --repo is provided]:LINK_BASE:_default' \
+'--reviewable=[PR/MR identifier or URL shown in the provider review body]:REVIEWABLE:_default' \
+'--lens=[Exactly one reviewer lens represented by this report]:LENS:_default' \
+'--lens-verdict=[Single-lens verdict represented by this report]:LENS_VERDICT:(pass findings blocked follow-up-pass)' \
+'--scope=[Compact description of files or behavior reviewed]:TEXT:_default' \
+'--evidence-reviewed=[Compact validation, diff, or provider evidence summary]:TEXT:_default' \
+'--thread-out=[Write actionable GitHub review-thread specs derived from the same findings]:FILE:_files' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0

--- a/completions/zsh/_review-specialists
+++ b/completions/zsh/_review-specialists
@@ -63,12 +63,12 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--repo=[Repository slug for GitHub source links, e.g. owner/repo]:REPO:_default' \
 '--ref=[Ref for source links]:GIT_REF:_default' \
 '--link-base=[Custom link base. Defaults to https\://github.com/<repo>/blob when --repo is provided]:LINK_BASE:_default' \
+'--thread-out=[Write actionable GitHub review-thread specs derived from the same findings]:FILE:_files' \
 '--reviewable=[PR/MR identifier or URL shown in the provider review body]:REVIEWABLE:_default' \
 '--lens=[Exactly one reviewer lens represented by this report]:LENS:_default' \
 '--lens-verdict=[Single-lens verdict represented by this report]:LENS_VERDICT:(pass findings blocked follow-up-pass)' \
 '--scope=[Compact description of files or behavior reviewed]:TEXT:_default' \
 '--evidence-reviewed=[Compact validation, diff, or provider evidence summary]:TEXT:_default' \
-'--thread-out=[Write actionable GitHub review-thread specs derived from the same findings]:FILE:_files' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0
@@ -90,7 +90,6 @@ json\:"Single-record JSON envelope (snake_case)"))' \
 '--lens-verdict=[Single-lens verdict represented by this report]:LENS_VERDICT:(pass findings blocked follow-up-pass)' \
 '--scope=[Compact description of files or behavior reviewed]:TEXT:_default' \
 '--evidence-reviewed=[Compact validation, diff, or provider evidence summary]:TEXT:_default' \
-'--thread-out=[Write actionable GitHub review-thread specs derived from the same findings]:FILE:_files' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
 && ret=0

--- a/crates/agent-workflow-primitives/README.md
+++ b/crates/agent-workflow-primitives/README.md
@@ -62,6 +62,10 @@ review-evidence init --out /tmp/review --subject "PR #123"
 review-specialists validate --input findings.jsonl --format json
 review-specialists merge --input findings.jsonl --summary-out review.md
 review-specialists merge --mode delivery --input findings.jsonl --format json
+review-specialists render --profile provider-review --input findings.merged.json \
+  --reviewable 'PR #123' --lens testing --lens-verdict findings \
+  --scope 'changed test paths' --evidence-reviewed 'focused tests and diff' \
+  --out review.md --thread-out review-threads.json
 model-cross-check init --out /tmp/cross-check --prompt "review patch" --primary-model gpt-5.4 --checker-model gpt-5.5
 skill-usage init --out /tmp/skill --skill tools/devex/review-evidence --intent "record review" --user-request-summary "review this PR"
 skill-usage init --out /tmp/workflow --owner-kind workflow --owner-id deliver-pr --intent "deliver change" --user-request-summary "deliver this PR"
@@ -132,6 +136,15 @@ review-specialists render --profile issue-body --input findings.merged.json \
 review-specialists bundle --input findings.jsonl --out-dir target/review-specialists/bundle \
   --profile issue-body
 ```
+
+`provider-review` is the canonical provider-visible specialist profile. It
+always emits the `agent-kit:specialist-review-report:v1` marker, one
+`## Review Report` summary, and the findings table. Set `actionable: true` on a
+finding only when the owner must make a code, doc, test, or config change;
+`--thread-out` writes one GitHub line thread when `line` is present or one file
+thread when it is absent. Summary and thread artifacts are derived from the
+same merged input. The older `pr-comment` profile is a compatibility alias to
+the same renderer and can no longer produce the bullet format.
 
 ## `heuristic-inbox verify` redaction guardrail
 

--- a/crates/agent-workflow-primitives/src/review_specialists.rs
+++ b/crates/agent-workflow-primitives/src/review_specialists.rs
@@ -1420,7 +1420,32 @@ fn format_location(finding: &NormalizedFinding, context: &RenderContext) -> Stri
 }
 
 fn markdown_escape(input: &str) -> String {
-    input.replace('|', "\\|").replace('\n', " ")
+    let mut escaped = String::with_capacity(input.len());
+    let mut backslash_run = 0usize;
+    for ch in input.chars() {
+        match ch {
+            '|' => {
+                if backslash_run.is_multiple_of(2) {
+                    escaped.push('\\');
+                }
+                escaped.push('|');
+                backslash_run = 0;
+            }
+            '\n' | '\r' => {
+                escaped.push(' ');
+                backslash_run = 0;
+            }
+            '\\' => {
+                escaped.push(ch);
+                backslash_run += 1;
+            }
+            _ => {
+                escaped.push(ch);
+                backslash_run = 0;
+            }
+        }
+    }
+    escaped
 }
 
 fn read_merged(path: &Path) -> Result<MergeResult, CliError> {

--- a/crates/agent-workflow-primitives/src/review_specialists.rs
+++ b/crates/agent-workflow-primitives/src/review_specialists.rs
@@ -90,7 +90,45 @@ struct IssueBodyView {
 
 #[derive(Debug, Serialize)]
 struct PrCommentView {
-    findings_block: String,
+    reviewable: String,
+    lens: String,
+    verdict: String,
+    scope: String,
+    evidence_reviewed: String,
+    findings: Vec<ProviderReviewFindingRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProviderReviewFindingRow {
+    severity: String,
+    confidence: String,
+    summary: String,
+    evidence: String,
+    recommendation: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct ProviderReviewContext {
+    reviewable: String,
+    lens: String,
+    verdict: String,
+    scope: String,
+    evidence_reviewed: String,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+struct ProviderReviewThread {
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<u64>,
+    subject_type: String,
+    body: String,
+}
+
+#[derive(Debug)]
+struct ProviderReviewArtifacts {
+    body: String,
+    threads: Vec<ProviderReviewThread>,
 }
 
 const FINDINGS_SCHEMA: &str = "review-specialists.findings.v1";
@@ -201,9 +239,23 @@ fn command_render(args: RenderArgs) -> i32 {
             args.git_ref.as_deref(),
             args.link_base.as_deref(),
         );
-        render_profile(&merged, args.profile, context).and_then(|rendered| {
+        let provider_context = provider_review_context(&args.provider_review, &merged);
+        render_profile(&merged, args.profile, context, provider_context).and_then(|rendered| {
             if let Some(out) = &args.out {
                 write_text(out, &rendered.body)?;
+            }
+            if let Some(thread_out) = &args.provider_review.thread_out {
+                if !matches!(
+                    args.profile,
+                    RenderProfile::ProviderReview | RenderProfile::PrComment
+                ) {
+                    return Err(CliError::usage(
+                        "thread-out-requires-provider-review",
+                        "--thread-out requires --profile provider-review or --profile pr-comment",
+                        None,
+                    ));
+                }
+                write_json_pretty(thread_out, &rendered.threads)?;
             }
             Ok(rendered)
         })
@@ -402,6 +454,7 @@ fn build_bundle(args: &BundleArgs) -> Result<BundleResult, CliError> {
 
     let mut profile_artifact = None;
     if let Some(profile) = args.profile {
+        let provider_context = provider_review_context(&args.provider_review, &merged);
         let rendered = render_profile(
             &merged,
             profile,
@@ -410,12 +463,14 @@ fn build_bundle(args: &BundleArgs) -> Result<BundleResult, CliError> {
                 args.git_ref.as_deref(),
                 args.link_base.as_deref(),
             ),
+            provider_context,
         )?;
         let file_name = match profile {
             RenderProfile::Terminal => "terminal.txt",
             RenderProfile::Report => "specialist-review.md",
             RenderProfile::IssueBody => "issue-body.md",
             RenderProfile::PrComment => "pr-comment.md",
+            RenderProfile::ProviderReview => "provider-review.md",
             RenderProfile::Evidence => "evidence.json",
         };
         let path = args.out_dir.join(file_name);
@@ -423,6 +478,14 @@ fn build_bundle(args: &BundleArgs) -> Result<BundleResult, CliError> {
         profile_artifact = Some(display_path(&path));
         if !artifacts.iter().any(|item| item == &display_path(&path)) {
             artifacts.push(display_path(&path));
+        }
+        if matches!(
+            profile,
+            RenderProfile::ProviderReview | RenderProfile::PrComment
+        ) {
+            let threads_path = args.out_dir.join("review-threads.json");
+            write_json_pretty(&threads_path, &rendered.threads)?;
+            artifacts.push(display_path(&threads_path));
         }
     }
 
@@ -507,6 +570,7 @@ fn parse_finding_line(
         "root_cause_fingerprint",
         "specialist",
         "test_suggestion",
+        "actionable",
     ]
     .into_iter()
     .collect();
@@ -574,6 +638,8 @@ fn parse_finding_line(
         input,
         line_number,
     )?;
+    let actionable =
+        optional_bool(object.get("actionable"), "actionable", input, line_number)?.unwrap_or(false);
     let explicit_fingerprint =
         optional_string(object.get("fingerprint"), "fingerprint", input, line_number)?;
     let root_cause_fingerprint = optional_string(
@@ -628,6 +694,7 @@ fn parse_finding_line(
         root_cause_fingerprint,
         specialist,
         test_suggestion,
+        actionable,
         source_file: display_path(input),
         source_line: line_number,
     })
@@ -709,6 +776,23 @@ fn optional_positive_u64(
             display_path(input),
             line_number,
             "line must be a positive integer when present".to_string(),
+        )),
+    }
+}
+
+fn optional_bool(
+    value: Option<&Value>,
+    key: &str,
+    input: &Path,
+    line_number: usize,
+) -> Result<Option<bool>, RowError> {
+    match value {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        _ => Err(RowError::new(
+            display_path(input),
+            line_number,
+            format!("{key} must be a boolean when present"),
         )),
     }
 }
@@ -979,17 +1063,26 @@ fn render_profile(
     merged: &MergeResult,
     profile: RenderProfile,
     context: RenderContext,
+    provider_context: ProviderReviewContext,
 ) -> Result<RenderResult, CliError> {
-    let body = match profile {
-        RenderProfile::Terminal => render_terminal(merged, context),
-        RenderProfile::Report => render_report(merged, context),
-        RenderProfile::IssueBody => render_issue_body(merged, context),
-        RenderProfile::PrComment => render_pr_comment(merged, context),
-        RenderProfile::Evidence => render_evidence_json(merged)?,
+    let (body, threads) = match profile {
+        RenderProfile::Terminal => (render_terminal(merged, context), Vec::new()),
+        RenderProfile::Report => (render_report(merged, context), Vec::new()),
+        RenderProfile::IssueBody => (render_issue_body(merged, context), Vec::new()),
+        RenderProfile::PrComment | RenderProfile::ProviderReview => {
+            let artifacts = render_provider_review_artifacts_with_render_context(
+                merged,
+                &provider_context,
+                &context,
+            )?;
+            (artifacts.body, artifacts.threads)
+        }
+        RenderProfile::Evidence => (render_evidence_json(merged)?, Vec::new()),
     };
     Ok(RenderResult {
         profile,
         body,
+        threads,
         counts: merged.counts.clone(),
     })
 }
@@ -1145,35 +1238,101 @@ fn render_issue_body(merged: &MergeResult, context: RenderContext) -> String {
         .expect("issue_body template renders")
 }
 
+#[cfg(test)]
 fn render_pr_comment(merged: &MergeResult, context: RenderContext) -> String {
-    let findings_block = if merged.findings.is_empty() {
-        "No displayed specialist findings.".to_string()
-    } else {
-        let mut lines = Vec::new();
-        for finding in &merged.findings {
-            lines.push(format!(
-                "- **{}** {}: {} ({:.2}, {})",
-                finding.primary.severity,
-                format_location(&finding.primary, &context),
-                finding.primary.summary,
-                finding.primary.confidence,
-                finding.primary.specialist,
-            ));
-            lines.push(format!(
-                "  Recommendation: {}",
-                finding.primary.recommendation
-            ));
-        }
-        lines.join("\n")
+    let provider_context = ProviderReviewContext {
+        reviewable: "not provided".to_string(),
+        lens: "unspecified".to_string(),
+        verdict: if merged.findings.is_empty() {
+            "pass".to_string()
+        } else {
+            "findings".to_string()
+        },
+        scope: "not provided".to_string(),
+        evidence_reviewed: if merged.input_files.is_empty() {
+            "no input files".to_string()
+        } else {
+            merged.input_files.join(", ")
+        },
     };
-    let view = PrCommentView { findings_block };
+    render_provider_review_artifacts_with_render_context(merged, &provider_context, &context)
+        .expect("provider review template renders")
+        .body
+}
+
+#[cfg(test)]
+fn render_provider_review_artifacts(
+    merged: &MergeResult,
+    context: &ProviderReviewContext,
+) -> Result<ProviderReviewArtifacts, CliError> {
+    render_provider_review_artifacts_with_render_context(merged, context, &RenderContext::default())
+}
+
+fn render_provider_review_artifacts_with_render_context(
+    merged: &MergeResult,
+    context: &ProviderReviewContext,
+    render_context: &RenderContext,
+) -> Result<ProviderReviewArtifacts, CliError> {
+    let findings = merged
+        .findings
+        .iter()
+        .map(|finding| ProviderReviewFindingRow {
+            severity: finding.primary.severity.to_string(),
+            confidence: format!("{:.2}", finding.primary.confidence),
+            summary: markdown_escape(&finding.primary.summary),
+            evidence: markdown_escape(&format!(
+                "{} — {}",
+                format_location(&finding.primary, render_context),
+                finding.primary.evidence
+            )),
+            recommendation: markdown_escape(&finding.primary.recommendation),
+        })
+        .collect();
+    let view = PrCommentView {
+        reviewable: markdown_escape(&context.reviewable),
+        lens: markdown_escape(&context.lens),
+        verdict: markdown_escape(&context.verdict),
+        scope: markdown_escape(&context.scope),
+        evidence_reviewed: markdown_escape(&context.evidence_reviewed),
+        findings,
+    };
     let mut engine = Engine::builder().build();
     engine
         .register_template(PR_COMMENT_TEMPLATE_NAME, PR_COMMENT_TEMPLATE)
         .expect("pr_comment template registers");
-    engine
+    let body = engine
         .render(PR_COMMENT_TEMPLATE_NAME, &view)
-        .expect("pr_comment template renders")
+        .map_err(|err| {
+            CliError::runtime(
+                "provider-review-render-failed",
+                format!("failed to render provider review: {err}"),
+                None,
+            )
+        })?;
+    let threads = merged
+        .findings
+        .iter()
+        .filter(|finding| finding.primary.actionable)
+        .map(|finding| ProviderReviewThread {
+            path: finding.primary.path.clone(),
+            line: finding.primary.line,
+            subject_type: if finding.primary.line.is_some() {
+                "LINE".to_string()
+            } else {
+                "FILE".to_string()
+            },
+            body: format!(
+                "**{}** ({}, {:.2})\n\n{}\n\nRecommendation: {}\n\n<!-- agent-kit:finding:{} -->",
+                finding.primary.summary,
+                finding.primary.severity,
+                finding.primary.confidence,
+                finding.primary.evidence,
+                finding.primary.recommendation,
+                finding.fingerprint,
+            ),
+        })
+        .collect();
+    Ok(ProviderReviewArtifacts { body, threads })
 }
 
 fn render_evidence_json(merged: &MergeResult) -> Result<String, CliError> {
@@ -1591,6 +1750,33 @@ struct CommonArgs {
     format: OutputFormat,
 }
 
+#[derive(Debug, Args, Default)]
+struct ProviderReviewArgs {
+    /// PR/MR identifier or URL shown in the provider review body.
+    #[arg(long, value_name = "REVIEWABLE")]
+    reviewable: Option<String>,
+
+    /// Exactly one reviewer lens represented by this report.
+    #[arg(long, value_name = "LENS")]
+    lens: Option<String>,
+
+    /// Single-lens verdict represented by this report.
+    #[arg(long = "lens-verdict", value_enum)]
+    lens_verdict: Option<ProviderLensVerdict>,
+
+    /// Compact description of files or behavior reviewed.
+    #[arg(long, value_name = "TEXT")]
+    scope: Option<String>,
+
+    /// Compact validation, diff, or provider evidence summary.
+    #[arg(long = "evidence-reviewed", value_name = "TEXT")]
+    evidence_reviewed: Option<String>,
+
+    /// Write actionable GitHub review-thread specs derived from the same findings.
+    #[arg(long = "thread-out", value_name = "FILE", value_hint = ValueHint::FilePath)]
+    thread_out: Option<PathBuf>,
+}
+
 #[derive(Debug, Args)]
 struct ValidateArgs {
     #[command(flatten)]
@@ -1667,6 +1853,9 @@ struct RenderArgs {
     /// Custom link base. Defaults to https://github.com/<repo>/blob when --repo is provided.
     #[arg(long)]
     link_base: Option<String>,
+
+    #[command(flatten)]
+    provider_review: ProviderReviewArgs,
 }
 
 #[derive(Debug, Args)]
@@ -1705,6 +1894,9 @@ struct BundleArgs {
     /// Custom link base. Defaults to https://github.com/<repo>/blob when --repo is provided.
     #[arg(long)]
     link_base: Option<String>,
+
+    #[command(flatten)]
+    provider_review: ProviderReviewArgs,
 }
 
 #[derive(Debug, Args)]
@@ -1768,7 +1960,28 @@ enum RenderProfile {
     Report,
     IssueBody,
     PrComment,
+    ProviderReview,
     Evidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+enum ProviderLensVerdict {
+    Pass,
+    Findings,
+    Blocked,
+    FollowUpPass,
+}
+
+impl ProviderLensVerdict {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Pass => "pass",
+            Self::Findings => "findings",
+            Self::Blocked => "blocked",
+            Self::FollowUpPass => "follow-up-pass",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, ValueEnum)]
@@ -1820,6 +2033,8 @@ struct NormalizedFinding {
     specialist: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     test_suggestion: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    actionable: bool,
     source_file: String,
     source_line: usize,
 }
@@ -1833,6 +2048,10 @@ struct MergedFinding {
     confirming_specialists: Vec<String>,
     confirming_count: usize,
     source_rows: Vec<SourceRow>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1914,6 +2133,8 @@ impl ValidateResult {
 struct RenderResult {
     profile: RenderProfile,
     body: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    threads: Vec<ProviderReviewThread>,
     counts: FindingCounts,
 }
 
@@ -2045,6 +2266,9 @@ impl MergedFindingBuilder {
     }
 
     fn finish(self) -> MergedFinding {
+        let actionable = self.rows.iter().any(|finding| finding.actionable);
+        let mut primary = self.primary;
+        primary.actionable = actionable;
         let mut confirming: BTreeSet<String> = BTreeSet::new();
         let mut source_rows = Vec::new();
         for finding in self.rows {
@@ -2063,10 +2287,10 @@ impl MergedFindingBuilder {
                 .then_with(|| left.specialist.cmp(&right.specialist))
         });
         MergedFinding {
-            fingerprint: self.primary.fingerprint.clone(),
+            fingerprint: primary.fingerprint.clone(),
             lifecycle_fingerprint: (self.mode == ReviewMode::Delivery)
                 .then_some(self.lifecycle_fingerprint),
-            primary: self.primary,
+            primary,
             confirming_specialists: confirming.iter().cloned().collect(),
             confirming_count: confirming.len(),
             source_rows,
@@ -2099,6 +2323,44 @@ impl RenderContext {
             link_base: resolved_base,
             git_ref: git_ref.map(ToOwned::to_owned),
         }
+    }
+}
+
+fn provider_review_context(
+    args: &ProviderReviewArgs,
+    merged: &MergeResult,
+) -> ProviderReviewContext {
+    ProviderReviewContext {
+        reviewable: args
+            .reviewable
+            .clone()
+            .unwrap_or_else(|| "not provided".to_string()),
+        lens: args
+            .lens
+            .clone()
+            .unwrap_or_else(|| "unspecified".to_string()),
+        verdict: args
+            .lens_verdict
+            .map(ProviderLensVerdict::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| {
+                if merged.findings.is_empty() {
+                    "pass".to_string()
+                } else {
+                    "findings".to_string()
+                }
+            }),
+        scope: args
+            .scope
+            .clone()
+            .unwrap_or_else(|| "not provided".to_string()),
+        evidence_reviewed: args.evidence_reviewed.clone().unwrap_or_else(|| {
+            if merged.input_files.is_empty() {
+                "no input files".to_string()
+            } else {
+                merged.input_files.join(", ")
+            }
+        }),
     }
 }
 
@@ -2306,6 +2568,7 @@ mod tests {
             root_cause_fingerprint: None,
             specialist: specialist.to_string(),
             test_suggestion: None,
+            actionable: false,
             source_file: "fixture.jsonl".to_string(),
             source_line: 1,
         };
@@ -2476,6 +2739,65 @@ mod tests {
     fn pr_comment_mixed_matches_golden() {
         let out = render_pr_comment(&mixed_merge_result(), RenderContext::default());
         assert_or_bless("pr_comment_mixed.md", &out);
+    }
+
+    #[test]
+    fn provider_review_artifacts_include_only_explicitly_actionable_findings() {
+        let mut merged = mixed_merge_result();
+        merged.findings[0].primary.actionable = true;
+        merged.findings[1].primary.actionable = false;
+        let context = ProviderReviewContext {
+            reviewable: "PR #44".to_string(),
+            lens: "testing".to_string(),
+            verdict: "findings".to_string(),
+            scope: "changed review publication paths".to_string(),
+            evidence_reviewed: "focused tests and diff".to_string(),
+        };
+
+        let artifacts =
+            render_provider_review_artifacts(&merged, &context).expect("provider artifacts render");
+
+        assert!(
+            artifacts
+                .body
+                .contains("<!-- agent-kit:specialist-review-report:v1 -->")
+        );
+        assert!(
+            artifacts
+                .body
+                .contains("| Finding | Severity | Confidence | Evidence | Recommendation |")
+        );
+        assert_eq!(artifacts.threads.len(), 1);
+        assert_eq!(artifacts.threads[0].path, "src/lib.rs");
+        assert_eq!(artifacts.threads[0].line, Some(42));
+        assert_eq!(artifacts.threads[0].subject_type, "LINE");
+        assert!(
+            artifacts.threads[0]
+                .body
+                .contains(&merged.findings[0].fingerprint)
+        );
+    }
+
+    #[test]
+    fn provider_review_artifacts_emit_file_threads_without_a_line_anchor() {
+        let mut merged = mixed_merge_result();
+        merged.findings.truncate(1);
+        merged.findings[0].primary.actionable = true;
+        merged.findings[0].primary.line = None;
+        let context = ProviderReviewContext {
+            reviewable: "PR #44".to_string(),
+            lens: "testing".to_string(),
+            verdict: "findings".to_string(),
+            scope: "src/lib.rs".to_string(),
+            evidence_reviewed: "diff".to_string(),
+        };
+
+        let artifacts =
+            render_provider_review_artifacts(&merged, &context).expect("provider artifacts render");
+
+        assert_eq!(artifacts.threads.len(), 1);
+        assert_eq!(artifacts.threads[0].line, None);
+        assert_eq!(artifacts.threads[0].subject_type, "FILE");
     }
 
     // -----------------------------------------------------------------
@@ -2754,6 +3076,7 @@ mod tests {
             root_cause_fingerprint: None,
             specialist: "reviewer-testing".to_string(),
             test_suggestion: None,
+            actionable: false,
             source_file: "/repo/findings.jsonl".to_string(),
             source_line: 1,
         };

--- a/crates/agent-workflow-primitives/src/review_specialists.rs
+++ b/crates/agent-workflow-primitives/src/review_specialists.rs
@@ -233,6 +233,23 @@ fn command_merge(args: MergeArgs) -> i32 {
 
 fn command_render(args: RenderArgs) -> i32 {
     let format = args.common.format;
+    if args.thread_out.is_some()
+        && !matches!(
+            args.profile,
+            RenderProfile::ProviderReview | RenderProfile::PrComment
+        )
+    {
+        return render_error(
+            RENDER_SCHEMA_VERSION,
+            RENDER_COMMAND,
+            format,
+            CliError::usage(
+                "thread-out-requires-provider-review",
+                "--thread-out requires --profile provider-review or --profile pr-comment",
+                None,
+            ),
+        );
+    }
     match read_merged(&args.input).and_then(|merged| {
         let context = RenderContext::from_args(
             args.repo.as_deref(),
@@ -244,17 +261,7 @@ fn command_render(args: RenderArgs) -> i32 {
             if let Some(out) = &args.out {
                 write_text(out, &rendered.body)?;
             }
-            if let Some(thread_out) = &args.provider_review.thread_out {
-                if !matches!(
-                    args.profile,
-                    RenderProfile::ProviderReview | RenderProfile::PrComment
-                ) {
-                    return Err(CliError::usage(
-                        "thread-out-requires-provider-review",
-                        "--thread-out requires --profile provider-review or --profile pr-comment",
-                        None,
-                    ));
-                }
+            if let Some(thread_out) = &args.thread_out {
                 write_json_pretty(thread_out, &rendered.threads)?;
             }
             Ok(rendered)
@@ -1312,24 +1319,31 @@ fn render_provider_review_artifacts_with_render_context(
     let threads = merged
         .findings
         .iter()
-        .filter(|finding| finding.primary.actionable)
-        .map(|finding| ProviderReviewThread {
-            path: finding.primary.path.clone(),
-            line: finding.primary.line,
-            subject_type: if finding.primary.line.is_some() {
-                "LINE".to_string()
-            } else {
-                "FILE".to_string()
-            },
-            body: format!(
-                "**{}** ({}, {:.2})\n\n{}\n\nRecommendation: {}\n\n<!-- agent-kit:finding:{} -->",
-                finding.primary.summary,
-                finding.primary.severity,
-                finding.primary.confidence,
-                finding.primary.evidence,
-                finding.primary.recommendation,
-                finding.fingerprint,
-            ),
+        .filter_map(|finding| {
+            let source = finding.actionable_source.as_ref().or_else(|| {
+                finding
+                    .primary
+                    .actionable
+                    .then_some(&finding.primary)
+            })?;
+            Some(ProviderReviewThread {
+                path: source.path.clone(),
+                line: source.line,
+                subject_type: if source.line.is_some() {
+                    "LINE".to_string()
+                } else {
+                    "FILE".to_string()
+                },
+                body: format!(
+                    "**{}** ({}, {:.2})\n\n{}\n\nRecommendation: {}\n\n<!-- agent-kit:finding:{} -->",
+                    source.summary,
+                    source.severity,
+                    source.confidence,
+                    source.evidence,
+                    source.recommendation,
+                    finding.fingerprint,
+                ),
+            })
         })
         .collect();
     Ok(ProviderReviewArtifacts { body, threads })
@@ -1771,10 +1785,6 @@ struct ProviderReviewArgs {
     /// Compact validation, diff, or provider evidence summary.
     #[arg(long = "evidence-reviewed", value_name = "TEXT")]
     evidence_reviewed: Option<String>,
-
-    /// Write actionable GitHub review-thread specs derived from the same findings.
-    #[arg(long = "thread-out", value_name = "FILE", value_hint = ValueHint::FilePath)]
-    thread_out: Option<PathBuf>,
 }
 
 #[derive(Debug, Args)]
@@ -1853,6 +1863,10 @@ struct RenderArgs {
     /// Custom link base. Defaults to https://github.com/<repo>/blob when --repo is provided.
     #[arg(long)]
     link_base: Option<String>,
+
+    /// Write actionable GitHub review-thread specs derived from the same findings.
+    #[arg(long = "thread-out", value_name = "FILE", value_hint = ValueHint::FilePath)]
+    thread_out: Option<PathBuf>,
 
     #[command(flatten)]
     provider_review: ProviderReviewArgs,
@@ -2045,6 +2059,8 @@ struct MergedFinding {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     lifecycle_fingerprint: Option<String>,
     primary: NormalizedFinding,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    actionable_source: Option<NormalizedFinding>,
     confirming_specialists: Vec<String>,
     confirming_count: usize,
     source_rows: Vec<SourceRow>,
@@ -2266,9 +2282,19 @@ impl MergedFindingBuilder {
     }
 
     fn finish(self) -> MergedFinding {
-        let actionable = self.rows.iter().any(|finding| finding.actionable);
-        let mut primary = self.primary;
-        primary.actionable = actionable;
+        let primary = self.primary;
+        let actionable_source = self
+            .rows
+            .iter()
+            .filter(|finding| finding.actionable)
+            .cloned()
+            .reduce(|current, candidate| {
+                if is_higher_priority(&candidate, &current) {
+                    candidate
+                } else {
+                    current
+                }
+            });
         let mut confirming: BTreeSet<String> = BTreeSet::new();
         let mut source_rows = Vec::new();
         for finding in self.rows {
@@ -2291,6 +2317,7 @@ impl MergedFindingBuilder {
             lifecycle_fingerprint: (self.mode == ReviewMode::Delivery)
                 .then_some(self.lifecycle_fingerprint),
             primary,
+            actionable_source,
             confirming_specialists: confirming.iter().cloned().collect(),
             confirming_count: confirming.len(),
             source_rows,
@@ -2577,6 +2604,7 @@ mod tests {
             fingerprint,
             lifecycle_fingerprint: None,
             primary,
+            actionable_source: None,
             confirming_specialists: vec![specialist.to_string()],
             confirming_count: 1,
             source_rows: vec![SourceRow {
@@ -2745,6 +2773,7 @@ mod tests {
     fn provider_review_artifacts_include_only_explicitly_actionable_findings() {
         let mut merged = mixed_merge_result();
         merged.findings[0].primary.actionable = true;
+        merged.findings[0].actionable_source = Some(merged.findings[0].primary.clone());
         merged.findings[1].primary.actionable = false;
         let context = ProviderReviewContext {
             reviewable: "PR #44".to_string(),
@@ -2784,6 +2813,7 @@ mod tests {
         merged.findings.truncate(1);
         merged.findings[0].primary.actionable = true;
         merged.findings[0].primary.line = None;
+        merged.findings[0].actionable_source = Some(merged.findings[0].primary.clone());
         let context = ProviderReviewContext {
             reviewable: "PR #44".to_string(),
             lens: "testing".to_string(),
@@ -2798,6 +2828,64 @@ mod tests {
         assert_eq!(artifacts.threads.len(), 1);
         assert_eq!(artifacts.threads[0].line, None);
         assert_eq!(artifacts.threads[0].subject_type, "FILE");
+    }
+
+    #[test]
+    fn provider_review_threads_preserve_the_explicitly_actionable_source_row() {
+        let mut primary = build_finding(
+            Severity::High,
+            0.95,
+            "maintainability",
+            "src/primary.rs",
+            Some(11),
+            "Higher confidence summary",
+            "Keep the primary recommendation.",
+        )
+        .primary;
+        primary.root_cause_fingerprint = Some("shared-root-cause".to_string());
+        let mut actionable = build_finding(
+            Severity::Medium,
+            0.80,
+            "testing",
+            "src/actionable.rs",
+            Some(22),
+            "Actionable summary",
+            "Fix the actionable row.",
+        )
+        .primary;
+        actionable.root_cause_fingerprint = Some("shared-root-cause".to_string());
+        actionable.actionable = true;
+
+        let mut builder = MergedFindingBuilder::new(
+            primary.clone(),
+            "shared-root-cause".to_string(),
+            ReviewMode::Delivery,
+        );
+        builder.push(primary);
+        builder.push(actionable);
+        let merged_finding = builder.finish();
+        assert_eq!(merged_finding.primary.path, "src/primary.rs");
+
+        let mut merged = empty_merge_result();
+        merged.schema = DELIVERY_MERGED_SCHEMA.to_string();
+        merged.input_files = vec!["findings.jsonl".to_string()];
+        merged.findings = vec![merged_finding];
+        let artifacts = render_provider_review_artifacts(
+            &merged,
+            &ProviderReviewContext {
+                reviewable: "PR #44".to_string(),
+                lens: "testing".to_string(),
+                verdict: "findings".to_string(),
+                scope: "merged source selection".to_string(),
+                evidence_reviewed: "unit regression".to_string(),
+            },
+        )
+        .expect("provider artifacts render");
+
+        assert_eq!(artifacts.threads.len(), 1);
+        assert_eq!(artifacts.threads[0].path, "src/actionable.rs");
+        assert_eq!(artifacts.threads[0].line, Some(22));
+        assert!(artifacts.threads[0].body.contains("Actionable summary"));
     }
 
     // -----------------------------------------------------------------

--- a/crates/agent-workflow-primitives/templates/review_specialists/pr_comment.md.tera
+++ b/crates/agent-workflow-primitives/templates/review_specialists/pr_comment.md.tera
@@ -1,5 +1,18 @@
-## Specialist Review Findings
+<!-- agent-kit:specialist-review-report:v1 -->
+## Review Report
 
-{{ findings_block }}
+- Reviewable: {{ reviewable }}
+- Lens: {{ lens }}
+- Lens verdict: {{ verdict }}
+- Scope: {{ scope }}
+- Evidence reviewed: {{ evidence_reviewed }}
 
-This is a deterministic render of specialist findings, not a merge or close decision.
+| Finding | Severity | Confidence | Evidence | Recommendation |
+| --- | --- | ---: | --- | --- |
+{%- if findings %}
+{%- for finding in findings %}
+| {{ finding.summary }} | {{ finding.severity }} | {{ finding.confidence }} | {{ finding.evidence }} | {{ finding.recommendation }} |
+{%- endfor %}
+{%- else %}
+| No findings | none | 0.00 | No actionable or informational findings. | none |
+{%- endif %}

--- a/crates/agent-workflow-primitives/tests/golden/review_specialists/pr_comment_empty.md
+++ b/crates/agent-workflow-primitives/tests/golden/review_specialists/pr_comment_empty.md
@@ -1,5 +1,12 @@
-## Specialist Review Findings
+<!-- agent-kit:specialist-review-report:v1 -->
+## Review Report
 
-No displayed specialist findings.
+- Reviewable: not provided
+- Lens: unspecified
+- Lens verdict: pass
+- Scope: not provided
+- Evidence reviewed: no input files
 
-This is a deterministic render of specialist findings, not a merge or close decision.
+| Finding | Severity | Confidence | Evidence | Recommendation |
+| --- | --- | ---: | --- | --- |
+| No findings | none | 0.00 | No actionable or informational findings. | none |

--- a/crates/agent-workflow-primitives/tests/golden/review_specialists/pr_comment_mixed.md
+++ b/crates/agent-workflow-primitives/tests/golden/review_specialists/pr_comment_mixed.md
@@ -1,8 +1,13 @@
-## Specialist Review Findings
+<!-- agent-kit:specialist-review-report:v1 -->
+## Review Report
 
-- **high** src/lib.rs:42: Missing test for new branch (0.85, testing)
-  Recommendation: Add a unit test exercising the new branch.
-- **medium** src/util.rs:10: Function is too long (0.72, maintainability)
-  Recommendation: Split the helper into smaller functions.
+- Reviewable: not provided
+- Lens: unspecified
+- Lens verdict: findings
+- Scope: not provided
+- Evidence reviewed: findings-a.jsonl, findings-b.jsonl
 
-This is a deterministic render of specialist findings, not a merge or close decision.
+| Finding | Severity | Confidence | Evidence | Recommendation |
+| --- | --- | ---: | --- | --- |
+| Missing test for new branch | high | 0.85 | src/lib.rs:42 — evidence for Missing test for new branch | Add a unit test exercising the new branch. |
+| Function is too long | medium | 0.72 | src/util.rs:10 — evidence for Function is too long | Split the helper into smaller functions. |

--- a/crates/agent-workflow-primitives/tests/integration/review_specialists.rs
+++ b/crates/agent-workflow-primitives/tests/integration/review_specialists.rs
@@ -463,6 +463,54 @@ fn review_specialists_provider_review_writes_canonical_body_and_line_file_thread
 }
 
 #[test]
+fn review_specialists_rejects_thread_output_before_writing_any_render_artifact() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let merged_path = tmp.path().join("merged.json");
+    fs::write(
+        &merged_path,
+        r#"{"schema":"review-specialists.merged.v1","input_files":[],"display_threshold":0.6,"counts":{"total":0,"displayed":0,"suppressed":0,"by_severity":{}},"findings":[]}"#,
+    )
+    .expect("merged");
+    let merged_arg = path_arg(&merged_path);
+    let body_path = tmp.path().join("report.md");
+    let body_arg = path_arg(&body_path);
+    let threads_path = tmp.path().join("threads.json");
+    let threads_arg = path_arg(&threads_path);
+
+    let render = run(
+        "review-specialists",
+        tmp.path(),
+        &[
+            "render",
+            "--profile",
+            "report",
+            "--input",
+            &merged_arg,
+            "--out",
+            &body_arg,
+            "--thread-out",
+            &threads_arg,
+        ],
+    );
+
+    assert_eq!(render.code, 64, "stderr={}", render.stderr_text());
+    assert!(!body_path.exists(), "invalid render must not write --out");
+    assert!(
+        !threads_path.exists(),
+        "invalid render must not write --thread-out"
+    );
+}
+
+#[test]
+fn review_specialists_bundle_help_does_not_advertise_render_only_thread_out() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let help = run("review-specialists", tmp.path(), &["bundle", "--help"]);
+
+    assert_eq!(help.code, 0, "stderr={}", help.stderr_text());
+    assert!(!help.stdout_text().contains("--thread-out"));
+}
+
+#[test]
 fn review_specialists_skill_helper_parity_fixture_renders_report() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let input = path_arg(&fixture("skill-helper-parity.jsonl"));

--- a/crates/agent-workflow-primitives/tests/integration/review_specialists.rs
+++ b/crates/agent-workflow-primitives/tests/integration/review_specialists.rs
@@ -362,6 +362,107 @@ fn review_specialists_render_evidence_includes_traceability_metadata() {
 }
 
 #[test]
+fn review_specialists_provider_review_writes_canonical_body_and_line_file_threads() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let input = tmp.path().join("findings.jsonl");
+    fs::write(
+        &input,
+        concat!(
+            r#"{"severity":"high","confidence":0.9,"path":"src/lib.rs","line":42,"category":"correctness","summary":"Line defect","evidence":"The changed branch is wrong.","recommendation":"Fix the branch.","specialist":"testing","actionable":true}"#,
+            "\n",
+            r#"{"severity":"medium","confidence":0.8,"path":"src/config.rs","category":"maintainability","summary":"File defect","evidence":"The file violates its invariant.","recommendation":"Restore the invariant.","specialist":"testing","actionable":true}"#,
+            "\n",
+        ),
+    )
+    .expect("write findings");
+    let input_arg = path_arg(&input);
+    let merge = run(
+        "review-specialists",
+        tmp.path(),
+        &["merge", "--input", &input_arg, "--format", "json"],
+    );
+    assert_eq!(merge.code, 0, "stderr={}", merge.stderr_text());
+    let merged_path = tmp.path().join("merged.json");
+    fs::write(&merged_path, merge.stdout_text()).expect("merged");
+    let merged_arg = path_arg(&merged_path);
+    let body_path = tmp.path().join("review.md");
+    let body_arg = path_arg(&body_path);
+    let threads_path = tmp.path().join("threads.json");
+    let threads_arg = path_arg(&threads_path);
+
+    let render = run(
+        "review-specialists",
+        tmp.path(),
+        &[
+            "render",
+            "--profile",
+            "provider-review",
+            "--input",
+            &merged_arg,
+            "--out",
+            &body_arg,
+            "--thread-out",
+            &threads_arg,
+            "--reviewable",
+            "PR #44",
+            "--lens",
+            "testing",
+            "--lens-verdict",
+            "findings",
+            "--scope",
+            "review publication",
+            "--evidence-reviewed",
+            "focused tests",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert_eq!(render.code, 0, "stderr={}", render.stderr_text());
+    let body = fs::read_to_string(&body_path).expect("body");
+    assert!(body.contains("<!-- agent-kit:specialist-review-report:v1 -->"));
+    assert!(body.contains("| Finding | Severity | Confidence | Evidence | Recommendation |"));
+    assert!(!body.contains("## Specialist Review Findings"));
+    let threads: Value = serde_json::from_str(&fs::read_to_string(&threads_path).expect("threads"))
+        .expect("thread json");
+    assert_eq!(threads[0]["subject_type"], "LINE");
+    assert_eq!(threads[0]["line"], 42);
+    assert_eq!(threads[1]["subject_type"], "FILE");
+    assert!(threads[1].get("line").is_none());
+
+    let alias_body_path = tmp.path().join("alias.md");
+    let alias_body_arg = path_arg(&alias_body_path);
+    let alias = run(
+        "review-specialists",
+        tmp.path(),
+        &[
+            "render",
+            "--profile",
+            "pr-comment",
+            "--input",
+            &merged_arg,
+            "--out",
+            &alias_body_arg,
+            "--reviewable",
+            "PR #44",
+            "--lens",
+            "testing",
+            "--lens-verdict",
+            "findings",
+            "--scope",
+            "review publication",
+            "--evidence-reviewed",
+            "focused tests",
+        ],
+    );
+    assert_eq!(alias.code, 0, "stderr={}", alias.stderr_text());
+    assert_eq!(
+        fs::read_to_string(alias_body_path).expect("alias body"),
+        body
+    );
+}
+
+#[test]
 fn review_specialists_skill_helper_parity_fixture_renders_report() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let input = path_arg(&fixture("skill-helper-parity.jsonl"));

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -23,8 +23,10 @@ cargo run -p nils-forge-cli -- label audit --catalog labels.yaml --format json
 cargo run -p nils-forge-cli -- pr deliver --kind feature --dry-run --format json
 cargo run -p nils-forge-cli -- pr review 123 --decision comments-only --comment-file review.md --mirror-issue --issue 456 --format json
 cargo run -p nils-forge-cli -- pr review validate --comment-file review.md --thread-file review-threads.json --format json
+cargo run -p nils-forge-cli -- pr review validate --specialist-report --comment-file review.md --thread-file review-threads.json --format json
 cargo run -p nils-forge-cli -- pr review validate 123 --check-diff --comment-file review.md --thread-file review-threads.json --format json
 cargo run -p nils-forge-cli -- pr review 123 --decision comments-only --submit-review --expected-head <sha> --comment-file review.md --thread-file review-threads.json --format json
+cargo run -p nils-forge-cli -- pr review 123 --decision approve --metadata-only --native-review-url <review-url> --issue 456 --mirror-issue --format json
 cargo run -p nils-forge-cli -- pr reviews 123 --format json
 cargo run -p nils-forge-cli -- pr pending-review inspect 123 --review PRR_pending --format json
 cargo run -p nils-forge-cli -- pr pending-review resume-submit 123 --review PRR_pending --review-run-id <digest> --expected-head <sha> --expected-commit <sha> --expected-snapshot <digest> --decision comments-only --format json
@@ -68,6 +70,15 @@ This source boundary does not itself publish or authorize a release.
 each. Use `pr review validate` for local schema/privacy checks, and add
 `--check-diff` with a PR id when you want GitHub changed-file/line validation
 before posting. Put non-blocking notes in the review body.
+
+Add `--specialist-report` when the body must satisfy the canonical specialist
+Review Report marker, fields, verdict vocabulary, and findings table. This is
+opt-in so generic review comments remain valid. When an owner App has already
+published the authoritative native review, use `--metadata-only` with that
+same-PR `--native-review-url`; forge-cli posts only a concise personal metadata
+breadcrumb and, when requested, an issue mirror linked to the native review.
+Metadata-only mode rejects bodies, threads, native submission, and a mismatched
+repository or PR URL before mutation.
 
 `forge-cli` does NOT introduce a `--json` boolean flag. Use
 `--format text|json` exclusively.

--- a/crates/forge-cli/README.md
+++ b/crates/forge-cli/README.md
@@ -26,7 +26,7 @@ cargo run -p nils-forge-cli -- pr review validate --comment-file review.md --thr
 cargo run -p nils-forge-cli -- pr review validate --specialist-report --comment-file review.md --thread-file review-threads.json --format json
 cargo run -p nils-forge-cli -- pr review validate 123 --check-diff --comment-file review.md --thread-file review-threads.json --format json
 cargo run -p nils-forge-cli -- pr review 123 --decision comments-only --submit-review --expected-head <sha> --comment-file review.md --thread-file review-threads.json --format json
-cargo run -p nils-forge-cli -- pr review 123 --decision approve --metadata-only --native-review-url <review-url> --issue 456 --mirror-issue --format json
+cargo run -p nils-forge-cli -- pr review 123 --decision approve --metadata-only --native-review-url <review-url> --native-review-author <app-login> --issue 456 --mirror-issue --format json
 cargo run -p nils-forge-cli -- pr reviews 123 --format json
 cargo run -p nils-forge-cli -- pr pending-review inspect 123 --review PRR_pending --format json
 cargo run -p nils-forge-cli -- pr pending-review resume-submit 123 --review PRR_pending --review-run-id <digest> --expected-head <sha> --expected-commit <sha> --expected-snapshot <digest> --decision comments-only --format json
@@ -75,10 +75,11 @@ Add `--specialist-report` when the body must satisfy the canonical specialist
 Review Report marker, fields, verdict vocabulary, and findings table. This is
 opt-in so generic review comments remain valid. When an owner App has already
 published the authoritative native review, use `--metadata-only` with that
-same-PR `--native-review-url`; forge-cli posts only a concise personal metadata
-breadcrumb and, when requested, an issue mirror linked to the native review.
-Metadata-only mode rejects bodies, threads, native submission, and a mismatched
-repository or PR URL before mutation.
+same-PR `--native-review-url` and its expected `--native-review-author` App
+login; forge-cli reads the review back and verifies its URL, decision state,
+and author before posting a concise personal metadata breadcrumb and, when
+requested, an issue mirror. Metadata-only mode rejects bodies, threads, native
+submission, or a mismatched provider review before mutation.
 
 `forge-cli` does NOT introduce a `--json` boolean flag. Use
 `--format text|json` exclusively.

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -322,12 +322,12 @@ operations:
       - { name: --issue,          type: integer, required: false }
       - { name: --mirror-issue,   type: bool,    default: false }
       - { name: --submit-review,  type: bool,    default: false } # GitHub-only: submit a native review event (#pullrequestreview-) instead of an outcome comment; --decision maps to event (comments-only->COMMENT, approve->APPROVE, request-changes->REQUEST_CHANGES); body required for COMMENT/REQUEST_CHANGES, optional for APPROVE
-      - { name: --expected-head,  type: string,  required: false } # Required with --submit-review and invalid without it; compared with the complete pending-review snapshot head before mutation and bound to the REST commit_id / GraphQL commitOID
+      - { name: --expected-head,  type: string,  required: false } # Required with --submit-review or --metadata-only and invalid without either; compared with the provider PR head before mutation and bound to the submitted/read-back native review commit
       - { name: --thread-file,    type: path,    required: false } # GitHub-only JSON array of actionable review-thread specs; requires --submit-review; max 256 KiB, 50 specs, 1024-byte paths, 16 KiB bodies. Use only for findings that should be repaired then resolved via pr review-threads resolve.
       - { name: --specialist-report, type: bool, default: false } # Opt-in canonical agent-kit specialist marker/fields/verdict/table validation.
-      - { name: --metadata-only, type: bool, default: false } # GitHub-only concise personal metadata for an already-published authoritative native review; conflicts with body/thread/submission flags.
+      - { name: --metadata-only, type: bool, default: false } # GitHub-only concise personal metadata for an already-published authoritative native review; requires --expected-head and conflicts with body/thread/submission flags.
       - { name: --native-review-url, type: string, required: false } # Required with --metadata-only and must identify this exact repo/PR's #pullrequestreview- object.
-      - { name: --native-review-author, type: string, required: false } # Required with --metadata-only; exact expected App login, verified with provider read-back together with URL and decision state before mutation.
+      - { name: --native-review-author, type: string, required: false } # Required with --metadata-only; exact expected App login, verified with provider read-back together with URL, decision state, and commit_id before mutation.
     validations:
       - no_local_path # review comment body, thread spec bodies/paths, AND the generated issue mirror (lens values are user-controlled), validated before any post
       - no_agent_attribution # review comment body, thread spec bodies, AND the generated issue mirror, validated before any post (thread paths carry no prose)
@@ -337,15 +337,15 @@ operations:
     #   id_not_pull_request (DATA 65)  — GitHub <id> is not a pull request (the guard saw HTTP 404)
     #   invalid_review_thread_spec (DATA 65) — malformed, oversized, or locally invalid thread spec fields
     #   thread_file_requires_submit_review (DATA 65) — --thread-file without --submit-review
-    #   expected_review_head_required (DATA 65) — --submit-review without --expected-head
-    #   expected_review_head_requires_submit_review (DATA 65) — --expected-head without --submit-review
-    #   github_review_head_changed (DATA 65) — the provider head differs from --expected-head; returned before native review mutation
+    #   expected_review_head_required (DATA 65) — --submit-review or --metadata-only without --expected-head
+    #   expected_review_head_requires_submit_review (DATA 65) — --expected-head without --submit-review or --metadata-only
+    #   github_review_head_changed (DATA 65) — the provider head differs from --expected-head; returned before native review or metadata mutation
     #   invalid_specialist_review_report (DATA 65) — --specialist-report body lacks the canonical marker, required fields/verdict, or findings table
     #   native_review_url_required (DATA 65) — --metadata-only without --native-review-url
     #   native_review_author_required (DATA 65) — --metadata-only without --native-review-author
     #   invalid_native_review_url (DATA 65) — native review URL does not bind to this GitHub repository and PR
     #   native_review_url_requires_metadata_only / native_review_author_requires_metadata_only (DATA 65) — native review identity input without --metadata-only
-    #   native_review_verification_failed (DATA 65) — provider read-back does not match the exact review id, URL, decision state, or expected App author
+    #   native_review_verification_failed (DATA 65) — provider read-back does not match the exact review id, URL, decision state, expected App author, or --expected-head commit
     #   metadata_only_conflict (DATA 65) — --metadata-only combined with body/thread/native submission inputs
     #   provider_unsupported (USAGE 64) — --submit-review, --thread-file, or --metadata-only on gitlab/local (native review/thread creation and existing-review metadata are GitHub-only in v1)
     #   github_pending_review_exists (RUNTIME 1) — summary-only native review submission found a viewer-owned pending review. Threaded review transactions instead inspect an exact receipt-bound draft and resume it.
@@ -360,8 +360,8 @@ operations:
     # not id_not_pull_request, since it may have hit a valid PR.
     backends:
       github:
-        - { program: gh, argv: [api, "repos/{repo}/pulls/{id}", --jq, ".number"] } # PR-existence guard; <id> must be a pull request before posting (also rendered in --dry-run as guard_plan)
-        - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews/{review_id}"] } # with --metadata-only: read back the exact review and require matching id, html_url, decision state, and --native-review-author before any comment mutation (rendered in --dry-run as native_review_verification_plan)
+        - { program: gh, argv: [api, "repos/{repo}/pulls/{id}", --jq, ".number|.head.sha"] } # PR-existence guard; metadata-only selects .head.sha and requires it to equal --expected-head before posting (rendered in --dry-run as guard_plan)
+        - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews/{review_id}"] } # with --metadata-only: read back the exact review and require matching id, html_url, decision state, --native-review-author, and commit_id=--expected-head before any comment mutation (rendered in --dry-run as native_review_verification_plan)
         - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body={comment_or_file}", --jq, ".html_url"] } # default (outcome comment)
         - { program: gh, argv: [api, graphql, -f, "query=<pending reviews with viewer ownership>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}"] } # summary-only --submit-review: a viewer-owned pending review returns github_pending_review_exists. Threaded transactions use this as the complete membership read before exact-node inspection/resume.
         - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews", --method, POST, --raw-field, "body={comment_or_file}", --raw-field, "event={EVENT}", --raw-field, "commit_id={expected_head}", --jq, ".html_url"] } # with --submit-review (native review event); body field omitted for a body-less APPROVE; commit_id binds the mutation to --expected-head; review authored by the inherited gh token's identity
@@ -403,7 +403,7 @@ operations:
         lenses: list<string>
         metadata_only?: bool # true only for the concise existing-native-review metadata path
         native_review_url?: string # authoritative same-repo/same-PR native review URL supplied to --metadata-only
-        native_review_author?: string # expected App login verified by provider read-back for --metadata-only
+        native_review_author?: string # expected App login verified with URL, decision state, and commit_id by provider read-back for --metadata-only
         native_review_verification_plan?: list<string> # dry-run only: exact native-review read-back argv
         review_threads?: "list<{ id: string, url: string, path: string, line?: integer, subject_type: enum<LINE|FILE> }>"
         threads_skipped_idempotent?: integer # cross-run duplicates skipped: findings whose (path, body) already had a live (non-resolved, non-outdated) thread on the current head; omitted when 0. When every finding is a duplicate the review event is skipped, so submitted_review is false

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -327,6 +327,7 @@ operations:
       - { name: --specialist-report, type: bool, default: false } # Opt-in canonical agent-kit specialist marker/fields/verdict/table validation.
       - { name: --metadata-only, type: bool, default: false } # GitHub-only concise personal metadata for an already-published authoritative native review; conflicts with body/thread/submission flags.
       - { name: --native-review-url, type: string, required: false } # Required with --metadata-only and must identify this exact repo/PR's #pullrequestreview- object.
+      - { name: --native-review-author, type: string, required: false } # Required with --metadata-only; exact expected App login, verified with provider read-back together with URL and decision state before mutation.
     validations:
       - no_local_path # review comment body, thread spec bodies/paths, AND the generated issue mirror (lens values are user-controlled), validated before any post
       - no_agent_attribution # review comment body, thread spec bodies, AND the generated issue mirror, validated before any post (thread paths carry no prose)
@@ -341,7 +342,10 @@ operations:
     #   github_review_head_changed (DATA 65) — the provider head differs from --expected-head; returned before native review mutation
     #   invalid_specialist_review_report (DATA 65) — --specialist-report body lacks the canonical marker, required fields/verdict, or findings table
     #   native_review_url_required (DATA 65) — --metadata-only without --native-review-url
+    #   native_review_author_required (DATA 65) — --metadata-only without --native-review-author
     #   invalid_native_review_url (DATA 65) — native review URL does not bind to this GitHub repository and PR
+    #   native_review_url_requires_metadata_only / native_review_author_requires_metadata_only (DATA 65) — native review identity input without --metadata-only
+    #   native_review_verification_failed (DATA 65) — provider read-back does not match the exact review id, URL, decision state, or expected App author
     #   metadata_only_conflict (DATA 65) — --metadata-only combined with body/thread/native submission inputs
     #   provider_unsupported (USAGE 64) — --submit-review or --thread-file on gitlab/local (native review/thread creation is GitHub-only in v1)
     #   github_pending_review_exists (RUNTIME 1) — summary-only native review submission found a viewer-owned pending review. Threaded review transactions instead inspect an exact receipt-bound draft and resume it.
@@ -398,6 +402,8 @@ operations:
         lenses: list<string>
         metadata_only?: bool # true only for the concise existing-native-review metadata path
         native_review_url?: string # authoritative same-repo/same-PR native review URL supplied to --metadata-only
+        native_review_author?: string # expected App login verified by provider read-back for --metadata-only
+        native_review_verification_plan?: list<string> # dry-run only: exact native-review read-back argv
         review_threads?: "list<{ id: string, url: string, path: string, line?: integer, subject_type: enum<LINE|FILE> }>"
         threads_skipped_idempotent?: integer # cross-run duplicates skipped: findings whose (path, body) already had a live (non-resolved, non-outdated) thread on the current head; omitted when 0. When every finding is a duplicate the review event is skipped, so submitted_review is false
 

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -347,7 +347,7 @@ operations:
     #   native_review_url_requires_metadata_only / native_review_author_requires_metadata_only (DATA 65) — native review identity input without --metadata-only
     #   native_review_verification_failed (DATA 65) — provider read-back does not match the exact review id, URL, decision state, or expected App author
     #   metadata_only_conflict (DATA 65) — --metadata-only combined with body/thread/native submission inputs
-    #   provider_unsupported (USAGE 64) — --submit-review or --thread-file on gitlab/local (native review/thread creation is GitHub-only in v1)
+    #   provider_unsupported (USAGE 64) — --submit-review, --thread-file, or --metadata-only on gitlab/local (native review/thread creation and existing-review metadata are GitHub-only in v1)
     #   github_pending_review_exists (RUNTIME 1) — summary-only native review submission found a viewer-owned pending review. Threaded review transactions instead inspect an exact receipt-bound draft and resume it.
     #   github_native_review_rejected (RUNTIME 1) — GitHub rejected native review submission with HTTP 422; retry with an eligible reviewer identity or omit --submit-review for an outcome comment fallback
     #   pending_review_transaction_incomplete (DATA 65) — a receipt-bound pending review was created or updated but the next step was not confirmed. The draft and inline content are preserved; rerunning the identical command resumes it.
@@ -361,6 +361,7 @@ operations:
     backends:
       github:
         - { program: gh, argv: [api, "repos/{repo}/pulls/{id}", --jq, ".number"] } # PR-existence guard; <id> must be a pull request before posting (also rendered in --dry-run as guard_plan)
+        - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews/{review_id}"] } # with --metadata-only: read back the exact review and require matching id, html_url, decision state, and --native-review-author before any comment mutation (rendered in --dry-run as native_review_verification_plan)
         - { program: gh, argv: [api, "repos/{repo}/issues/{id}/comments", --method, POST, --raw-field, "body={comment_or_file}", --jq, ".html_url"] } # default (outcome comment)
         - { program: gh, argv: [api, graphql, -f, "query=<pending reviews with viewer ownership>", -f, "owner={owner}", -f, "name={repo}", -F, "pr={id}"] } # summary-only --submit-review: a viewer-owned pending review returns github_pending_review_exists. Threaded transactions use this as the complete membership read before exact-node inspection/resume.
         - { program: gh, argv: [api, "repos/{repo}/pulls/{id}/reviews", --method, POST, --raw-field, "body={comment_or_file}", --raw-field, "event={EVENT}", --raw-field, "commit_id={expected_head}", --jq, ".html_url"] } # with --submit-review (native review event); body field omitted for a body-less APPROVE; commit_id binds the mutation to --expected-head; review authored by the inherited gh token's identity

--- a/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
+++ b/crates/forge-cli/docs/specs/forge-cli-ops-v1.yaml
@@ -324,6 +324,9 @@ operations:
       - { name: --submit-review,  type: bool,    default: false } # GitHub-only: submit a native review event (#pullrequestreview-) instead of an outcome comment; --decision maps to event (comments-only->COMMENT, approve->APPROVE, request-changes->REQUEST_CHANGES); body required for COMMENT/REQUEST_CHANGES, optional for APPROVE
       - { name: --expected-head,  type: string,  required: false } # Required with --submit-review and invalid without it; compared with the complete pending-review snapshot head before mutation and bound to the REST commit_id / GraphQL commitOID
       - { name: --thread-file,    type: path,    required: false } # GitHub-only JSON array of actionable review-thread specs; requires --submit-review; max 256 KiB, 50 specs, 1024-byte paths, 16 KiB bodies. Use only for findings that should be repaired then resolved via pr review-threads resolve.
+      - { name: --specialist-report, type: bool, default: false } # Opt-in canonical agent-kit specialist marker/fields/verdict/table validation.
+      - { name: --metadata-only, type: bool, default: false } # GitHub-only concise personal metadata for an already-published authoritative native review; conflicts with body/thread/submission flags.
+      - { name: --native-review-url, type: string, required: false } # Required with --metadata-only and must identify this exact repo/PR's #pullrequestreview- object.
     validations:
       - no_local_path # review comment body, thread spec bodies/paths, AND the generated issue mirror (lens values are user-controlled), validated before any post
       - no_agent_attribution # review comment body, thread spec bodies, AND the generated issue mirror, validated before any post (thread paths carry no prose)
@@ -336,6 +339,10 @@ operations:
     #   expected_review_head_required (DATA 65) — --submit-review without --expected-head
     #   expected_review_head_requires_submit_review (DATA 65) — --expected-head without --submit-review
     #   github_review_head_changed (DATA 65) — the provider head differs from --expected-head; returned before native review mutation
+    #   invalid_specialist_review_report (DATA 65) — --specialist-report body lacks the canonical marker, required fields/verdict, or findings table
+    #   native_review_url_required (DATA 65) — --metadata-only without --native-review-url
+    #   invalid_native_review_url (DATA 65) — native review URL does not bind to this GitHub repository and PR
+    #   metadata_only_conflict (DATA 65) — --metadata-only combined with body/thread/native submission inputs
     #   provider_unsupported (USAGE 64) — --submit-review or --thread-file on gitlab/local (native review/thread creation is GitHub-only in v1)
     #   github_pending_review_exists (RUNTIME 1) — summary-only native review submission found a viewer-owned pending review. Threaded review transactions instead inspect an exact receipt-bound draft and resume it.
     #   github_native_review_rejected (RUNTIME 1) — GitHub rejected native review submission with HTTP 422; retry with an eligible reviewer identity or omit --submit-review for an outcome comment fallback
@@ -389,6 +396,8 @@ operations:
         issue_comment_url: string?
         mirrored: bool
         lenses: list<string>
+        metadata_only?: bool # true only for the concise existing-native-review metadata path
+        native_review_url?: string # authoritative same-repo/same-PR native review URL supplied to --metadata-only
         review_threads?: "list<{ id: string, url: string, path: string, line?: integer, subject_type: enum<LINE|FILE> }>"
         threads_skipped_idempotent?: integer # cross-run duplicates skipped: findings whose (path, body) already had a live (non-resolved, non-outdated) thread on the current head; omitted when 0. When every finding is a duplicate the review event is skipped, so submitted_review is false
 
@@ -401,12 +410,14 @@ operations:
       - { name: --comment-file, type: path,    required: false }
       - { name: --thread-file,  type: path,    required: false }
       - { name: --check-diff,   type: bool,    default: false } # GitHub-only in v1; validates thread paths/lines against live PR diff
+      - { name: --specialist-report, type: bool, default: false } # Require the canonical agent-kit specialist Review Report shape.
     validations:
       - no_local_path # review comment body plus thread spec bodies/paths
       - no_agent_attribution # review comment body plus thread spec bodies
       - no_escaped_control_markdown # review comment body plus thread spec bodies/paths
     # Op-specific error kinds:
     #   invalid_review_thread_spec (DATA 65) — malformed, oversized, or locally invalid thread spec fields
+    #   invalid_specialist_review_report (DATA 65) — body lacks the canonical specialist marker, fields/verdict, or findings table
     #   review_validate_id_required (DATA 65) — --check-diff without <id>
     #   review_thread_file_not_changed (DATA 65) — a thread spec path is absent from the live GitHub PR file list
     #   review_thread_line_not_in_diff (DATA 65) — a line thread points at a line that is not commentable on the requested diff side
@@ -426,7 +437,7 @@ operations:
         number: integer?
         check_diff: bool
         diff_plan: list<string>? # dry-run only when --check-diff is set
-        comment: { present: bool, bytes: integer, lines: integer }
+        comment: { present: bool, bytes: integer, lines: integer, specialist_report: bool }
         review_threads:
           count: integer
           diff_checked: bool

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -870,19 +870,23 @@ distinctions that cannot be proven offline.
   closed `pass|findings|blocked|follow-up-pass` verdict vocabulary, and the
   canonical findings table with at least one exactly-five-cell row. Generic
   review comments omit this flag and remain valid.
-- `--metadata-only --native-review-url <url> --native-review-author <login>`
+- `--metadata-only --expected-head <sha> --native-review-url <url>
+  --native-review-author <login>`
   (GitHub-only) records concise
   personal-identity metadata after an owner App has already published the
   authoritative native review. The URL must identify a
   `#pullrequestreview-<id>` object on the selected repository and PR. Before
-  mutation, forge-cli reads that exact review back and verifies its URL,
-  decision state, and App author login. The PR
+  mutation, forge-cli verifies the PR still has `--expected-head`, then reads
+  that exact review back and verifies its URL, decision state, App author
+  login, and `commit_id`. The PR
   comment and optional issue mirror contain only PR, decision, lenses, and the
   native review link; they never include the native Review Report body.
-  Metadata-only mode rejects caller bodies, `--specialist-report`, threads,
-  `--submit-review`, and `--expected-head` before mutation. Output adds
-  `data.metadata_only=true`, `data.native_review_url`, and
-  `data.native_review_author`.
+  Metadata-only mode rejects caller bodies, `--specialist-report`, threads, and
+  `--submit-review` before mutation. Omitting the expected head returns
+  `expected_review_head_required`; provider-head drift returns
+  `github_review_head_changed`; a review bound to another commit returns
+  `native_review_verification_failed`. Output adds `data.metadata_only=true`,
+  `data.head_sha`, `data.native_review_url`, and `data.native_review_author`.
 - With `--submit-review --expected-head <sha>` (GitHub-only in v1) the command
   instead submits a native
   pull request review event: it POSTs `gh api repos/{repo}/pulls/{id}/reviews`
@@ -909,8 +913,8 @@ distinctions that cannot be proven offline.
   rendered in `--dry-run` as
   `data.pending_review_guard_plan` and `data.plan`. Omitting the expected head
   returns `expected_review_head_required` (`DATA 65`); supplying it without
-  `--submit-review` returns `expected_review_head_requires_submit_review`
-  (`DATA 65`). `--submit-review` on
+  `--submit-review` or `--metadata-only` returns
+  `expected_review_head_requires_submit_review` (`DATA 65`). `--submit-review` on
   GitLab / Local returns `provider_unsupported` (`USAGE 64`).
   If GitHub rejects the native review submission with HTTP 422, the command
   returns `github_native_review_rejected` (`RUNTIME 1`) and preserves the raw
@@ -1009,7 +1013,7 @@ distinctions that cannot be proven offline.
   metadata_only?, native_review_url?, native_review_author?,
   native_review_verification_plan?,
   review_threads?, threads_skipped_idempotent? }`. `head_sha` is present for
-  `--submit-review`; `threads_skipped_idempotent` is present (non-zero) when
+  `--submit-review` and `--metadata-only`; `threads_skipped_idempotent` is present (non-zero) when
   cross-run duplicates were skipped.
 
 ### `pr review validate`

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -868,17 +868,21 @@ distinctions that cannot be proven offline.
   forge-cli requires exactly one marker and `## Review Report` heading,
   non-empty Reviewable/Lens/Lens verdict/Scope/Evidence reviewed fields, the
   closed `pass|findings|blocked|follow-up-pass` verdict vocabulary, and the
-  canonical findings table with at least one row. Generic review comments omit
-  this flag and remain valid.
-- `--metadata-only --native-review-url <url>` (GitHub-only) records concise
+  canonical findings table with at least one exactly-five-cell row. Generic
+  review comments omit this flag and remain valid.
+- `--metadata-only --native-review-url <url> --native-review-author <login>`
+  (GitHub-only) records concise
   personal-identity metadata after an owner App has already published the
   authoritative native review. The URL must identify a
-  `#pullrequestreview-<id>` object on the selected repository and PR. The PR
+  `#pullrequestreview-<id>` object on the selected repository and PR. Before
+  mutation, forge-cli reads that exact review back and verifies its URL,
+  decision state, and App author login. The PR
   comment and optional issue mirror contain only PR, decision, lenses, and the
   native review link; they never include the native Review Report body.
   Metadata-only mode rejects caller bodies, `--specialist-report`, threads,
   `--submit-review`, and `--expected-head` before mutation. Output adds
-  `data.metadata_only=true` and `data.native_review_url`.
+  `data.metadata_only=true`, `data.native_review_url`, and
+  `data.native_review_author`.
 - With `--submit-review --expected-head <sha>` (GitHub-only in v1) the command
   instead submits a native
   pull request review event: it POSTs `gh api repos/{repo}/pulls/{id}/reviews`

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -863,6 +863,22 @@ distinctions that cannot be proven offline.
 - By default `--decision` is recorded in the envelope and generated issue mirror
   body only (the outcome-comment form); it does not call provider-native
   approve/request-changes APIs.
+- `--specialist-report` opts the supplied body into the canonical
+  `agent-kit:specialist-review-report:v1` contract. Before any provider call,
+  forge-cli requires exactly one marker and `## Review Report` heading,
+  non-empty Reviewable/Lens/Lens verdict/Scope/Evidence reviewed fields, the
+  closed `pass|findings|blocked|follow-up-pass` verdict vocabulary, and the
+  canonical findings table with at least one row. Generic review comments omit
+  this flag and remain valid.
+- `--metadata-only --native-review-url <url>` (GitHub-only) records concise
+  personal-identity metadata after an owner App has already published the
+  authoritative native review. The URL must identify a
+  `#pullrequestreview-<id>` object on the selected repository and PR. The PR
+  comment and optional issue mirror contain only PR, decision, lenses, and the
+  native review link; they never include the native Review Report body.
+  Metadata-only mode rejects caller bodies, `--specialist-report`, threads,
+  `--submit-review`, and `--expected-head` before mutation. Output adds
+  `data.metadata_only=true` and `data.native_review_url`.
 - With `--submit-review --expected-head <sha>` (GitHub-only in v1) the command
   instead submits a native
   pull request review event: it POSTs `gh api repos/{repo}/pulls/{id}/reviews`
@@ -986,6 +1002,7 @@ distinctions that cannot be proven offline.
 - Output schema:
   `data = { provider, number, decision, submitted_review, head_sha?,
   pr_comment_url, issue_number, issue_comment_url, mirrored, lenses,
+  metadata_only?, native_review_url?,
   review_threads?, threads_skipped_idempotent? }`. `head_sha` is present for
   `--submit-review`; `threads_skipped_idempotent` is present (non-zero) when
   cross-run duplicates were skipped.
@@ -997,6 +1014,10 @@ distinctions that cannot be proven offline.
   activity. It accepts `--comment <text>` / `--comment-file <path>` and
   `--thread-file <path>` using the same body limits, JSON shape, local-path
   guard, escaped-control guard, and size limits as `pr review`.
+- With `--specialist-report`, the preflight also applies the canonical marker,
+  field, verdict, and findings-table validation described above. A mismatch
+  returns `invalid_specialist_review_report` (`DATA 65`) before diff or provider
+  access.
 - Without `--check-diff`, validation is local-only and works for GitHub, GitLab,
   and Local provider contexts. This is the format/content dry-run path for
   agents that want to validate `review-report.md` and `review-threads.json`
@@ -1015,7 +1036,7 @@ distinctions that cannot be proven offline.
   `data.review_threads.diff_checked=false`.
 - JSON output includes
   `data = { provider, number?, check_diff, comment, review_threads }`, where
-  `comment = { present, bytes, lines }` and
+  `comment = { present, bytes, lines, specialist_report }` and
   `review_threads = { count, diff_checked, specs[] }`. Each normalized
   `specs[]` entry includes `{ index, path, line?, side, start_line?, start_side?,
   subject_type, body_bytes }`.

--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -1006,7 +1006,8 @@ distinctions that cannot be proven offline.
 - Output schema:
   `data = { provider, number, decision, submitted_review, head_sha?,
   pr_comment_url, issue_number, issue_comment_url, mirrored, lenses,
-  metadata_only?, native_review_url?,
+  metadata_only?, native_review_url?, native_review_author?,
+  native_review_verification_plan?,
   review_threads?, threads_skipped_idempotent? }`. `head_sha` is present for
   `--submit-review`; `threads_skipped_idempotent` is present (non-zero) when
   cross-run duplicates were skipped.

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -687,8 +687,8 @@ pub struct PrReviewArgs {
     /// REQUEST_CHANGES and optional for APPROVE. GitHub-only in v1.
     #[arg(long = "submit-review", action = ArgAction::SetTrue)]
     pub submit_review: bool,
-    /// Full PR head SHA that was reviewed. Required with `--submit-review` and
-    /// bound to both the pending-review preflight and provider mutation.
+    /// Full PR head SHA that was reviewed. Required with `--submit-review` or
+    /// `--metadata-only`; bound to the provider head and native review commit.
     #[arg(
         long = "expected-head",
         value_name = "SHA",

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -642,6 +642,9 @@ pub struct PrReviewValidateArgs {
     /// Check thread path / line coordinates against the live GitHub PR diff.
     #[arg(long = "check-diff", action = ArgAction::SetTrue)]
     pub check_diff: bool,
+    /// Enforce the canonical specialist Review Report marker, fields, and table.
+    #[arg(long = "specialist-report", action = ArgAction::SetTrue)]
+    pub specialist_report: bool,
 }
 
 /// `pr review` arguments. This is a provider posting primitive: callers pass
@@ -699,6 +702,16 @@ pub struct PrReviewArgs {
     /// `pr review-threads resolve`.
     #[arg(long = "thread-file", value_name = "PATH")]
     pub thread_file: Option<String>,
+    /// Validate the body as the canonical specialist Review Report shape.
+    #[arg(long = "specialist-report", action = ArgAction::SetTrue)]
+    pub specialist_report: bool,
+    /// Post only a concise personal-identity metadata breadcrumb for an
+    /// already-published authoritative native review.
+    #[arg(long = "metadata-only", action = ArgAction::SetTrue)]
+    pub metadata_only: bool,
+    /// Authoritative native review URL. Required with --metadata-only.
+    #[arg(long = "native-review-url", value_name = "URL")]
+    pub native_review_url: Option<String>,
 }
 
 /// `pr comments` arguments.

--- a/crates/forge-cli/src/cli.rs
+++ b/crates/forge-cli/src/cli.rs
@@ -712,6 +712,15 @@ pub struct PrReviewArgs {
     /// Authoritative native review URL. Required with --metadata-only.
     #[arg(long = "native-review-url", value_name = "URL")]
     pub native_review_url: Option<String>,
+    /// Expected GitHub login that authored the authoritative native review.
+    /// Required with --metadata-only and verified by provider read-back before
+    /// the personal-identity metadata breadcrumb is posted.
+    #[arg(
+        long = "native-review-author",
+        value_name = "LOGIN",
+        value_parser = clap::builder::NonEmptyStringValueParser::new()
+    )]
+    pub native_review_author: Option<String>,
 }
 
 /// `pr comments` arguments.

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -82,6 +82,10 @@ pub struct PrReviewPayload {
     pub issue_comment_url: Option<String>,
     pub mirrored: bool,
     pub lenses: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false_bool")]
+    pub metadata_only: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub native_review_url: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub review_threads: Vec<CreatedReviewThread>,
     /// Number of finding threads skipped as cross-run idempotent duplicates:
@@ -95,6 +99,10 @@ pub struct PrReviewPayload {
 
 fn is_zero_usize(value: &usize) -> bool {
     *value == 0
+}
+
+fn is_false_bool(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -125,6 +133,9 @@ struct PrReviewDryRunPayload {
     issue_plan: Option<Vec<String>>,
     mirror_issue: bool,
     lenses: Vec<String>,
+    metadata_only: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_review_url: Option<String>,
     planned_review_threads: usize,
     target_plan: Option<Vec<String>>,
     thread_plan: Vec<Vec<String>>,
@@ -147,6 +158,7 @@ struct ReviewCommentValidation {
     present: bool,
     bytes: usize,
     lines: usize,
+    specialist_report: bool,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -296,6 +308,50 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     }
     let id = args.id.ok_or_else(review_id_required_err)?;
 
+    let native_review_url = if args.metadata_only {
+        if ctx.provider != Provider::GitHub {
+            return Err(ForgeError::provider_unsupported(
+                schema_err(),
+                "--metadata-only is GitHub-only because it records an existing native pull-request review",
+                None,
+            ));
+        }
+        if args.submit_review
+            || args.thread_file.is_some()
+            || args.comment.is_some()
+            || args.comment_file.is_some()
+            || args.expected_head.is_some()
+            || args.specialist_report
+        {
+            return Err(ForgeError::validation(
+                schema_err(),
+                "metadata_only_conflict",
+                "--metadata-only cannot be combined with a review body, specialist validation, native submission, expected head, or thread file",
+                None,
+            ));
+        }
+        let native_review_url = args.native_review_url.as_deref().ok_or_else(|| {
+            ForgeError::validation(
+                schema_err(),
+                "native_review_url_required",
+                "--metadata-only requires --native-review-url <URL>",
+                None,
+            )
+        })?;
+        validate_native_review_url(&ctx, id, native_review_url)?;
+        Some(native_review_url.to_string())
+    } else {
+        if args.native_review_url.is_some() {
+            return Err(ForgeError::validation(
+                schema_err(),
+                "native_review_url_requires_metadata_only",
+                "--native-review-url is only valid with --metadata-only",
+                None,
+            ));
+        }
+        None
+    };
+
     let thread_specs_requested = args.thread_file.is_some();
     if thread_specs_requested && !args.submit_review {
         return Err(ForgeError::validation(
@@ -342,11 +398,21 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         Vec::new()
     };
 
-    let body = pr_comment::read_body_with_file_flag(
-        args.comment.as_deref(),
-        args.comment_file.as_deref(),
-        "--comment-file",
-    )?;
+    let body = if let Some(native_review_url) = native_review_url.as_deref() {
+        build_review_metadata_body(
+            ctx.provider,
+            id,
+            args.decision,
+            &args.lenses,
+            native_review_url,
+        )
+    } else {
+        pr_comment::read_body_with_file_flag(
+            args.comment.as_deref(),
+            args.comment_file.as_deref(),
+            "--comment-file",
+        )?
+    };
     let body_present = !body.trim().is_empty();
     // GitHub permits a body-less APPROVE review, so the empty-body guard is
     // relaxed only for a native approve submission. Every other case — outcome
@@ -366,6 +432,9 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         no_agent_attribution(&body, "review comment")?;
         no_escaped_control_markdown(&body)?;
     }
+    if args.specialist_report {
+        validate_specialist_review_report(&body)?;
+    }
 
     // Validate the generated issue-mirror body BEFORE any backend mutation
     // (validate-before-side-effect). It embeds user-controlled `--lens` values,
@@ -374,13 +443,9 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     // provider issue or fails only after the PR comment was already posted,
     // leaving an outcome comment with no mirror.
     let mirror_issue = if let Some(issue_number) = mirror_issue_number {
-        let preview = build_issue_mirror_body(
-            ctx.provider,
-            id,
-            args.decision,
-            &args.lenses,
-            MIRROR_URL_PENDING,
-        );
+        let preview_url = native_review_url.as_deref().unwrap_or(MIRROR_URL_PENDING);
+        let preview =
+            build_issue_mirror_body(ctx.provider, id, args.decision, &args.lenses, preview_url);
         no_local_path(&preview, "issue mirror")?;
         no_agent_attribution(&preview, "issue mirror")?;
         no_escaped_control_markdown(&preview)?;
@@ -506,13 +571,11 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             (None, None, None)
         };
         let issue_plan = mirror_issue.map(|issue| {
-            let mirror_body = build_issue_mirror_body(
-                ctx.provider,
-                id,
-                args.decision,
-                &args.lenses,
-                "<pr-comment-url-unavailable-in-dry-run>",
-            );
+            let mirror_url = native_review_url
+                .as_deref()
+                .unwrap_or("<pr-comment-url-unavailable-in-dry-run>");
+            let mirror_body =
+                build_issue_mirror_body(ctx.provider, id, args.decision, &args.lenses, mirror_url);
             build_issue_comment_call(&ctx, issue, &mirror_body).plan_argv()
         });
         return Ok(emit_success(
@@ -533,6 +596,8 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 issue_plan,
                 mirror_issue: args.mirror_issue,
                 lenses: args.lenses.clone(),
+                metadata_only: args.metadata_only,
+                native_review_url: native_review_url.clone(),
                 planned_review_threads: thread_specs.len(),
                 target_plan,
                 thread_plan,
@@ -675,13 +740,9 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             // validated up front against MIRROR_URL_PENDING; the only difference
             // here is the provider-returned `pr_comment_url`, which is never
             // user-controlled, so it needs no re-validation after the post.
-            let mirror_body = build_issue_mirror_body(
-                ctx.provider,
-                id,
-                args.decision,
-                &args.lenses,
-                &pr_comment_url,
-            );
+            let mirror_url = native_review_url.as_deref().unwrap_or(&pr_comment_url);
+            let mirror_body =
+                build_issue_mirror_body(ctx.provider, id, args.decision, &args.lenses, mirror_url);
             let issue_call = build_issue_comment_call(&ctx, issue_number, &mirror_body);
             let issue_output = runner.run(&issue_call)?;
             first_url(&issue_output.stdout)
@@ -702,6 +763,8 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             issue_comment_url,
             mirrored: args.mirror_issue,
             lenses: args.lenses,
+            metadata_only: args.metadata_only,
+            native_review_url,
             review_threads,
             threads_skipped_idempotent,
         },
@@ -754,6 +817,9 @@ fn run_validate_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         no_agent_attribution(&body, "review comment")?;
         no_escaped_control_markdown(&body)?;
     }
+    if args.specialist_report {
+        validate_specialist_review_report(&body)?;
+    }
 
     let mut diff_plan = None;
     let diff_checked = args.check_diff && !global.dry_run;
@@ -775,6 +841,7 @@ fn run_validate_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             present: body_present,
             bytes: body.len(),
             lines: body.lines().count(),
+            specialist_report: args.specialist_report,
         },
         review_threads: ReviewThreadValidation {
             count: thread_specs.len(),
@@ -825,6 +892,9 @@ fn validate_args_with_parent_fallbacks(
     }
     if validate_args.thread_file.is_none() {
         validate_args.thread_file = parent.thread_file.clone();
+    }
+    if !validate_args.specialist_report {
+        validate_args.specialist_report = parent.specialist_report;
     }
     validate_args
 }
@@ -2946,6 +3016,128 @@ fn build_issue_mirror_body(
     )
 }
 
+fn build_review_metadata_body(
+    provider: Provider,
+    pr_number: u64,
+    decision: PrReviewDecision,
+    lenses: &[String],
+    native_review_url: &str,
+) -> String {
+    let lenses = if lenses.is_empty() {
+        "unspecified".to_string()
+    } else {
+        lenses.join(", ")
+    };
+    let pr_ref = match provider {
+        Provider::GitLab => format!("!{pr_number}"),
+        _ => format!("#{pr_number}"),
+    };
+    format!(
+        "## Review metadata\n\n- pr: {pr_ref}\n- decision: {decision}\n- lenses: {lenses}\n- authoritative native review: {native_review_url}\n",
+        decision = decision.as_str(),
+    )
+}
+
+fn validate_native_review_url(
+    ctx: &ProviderContext,
+    id: u64,
+    native_review_url: &str,
+) -> Result<(), ForgeError> {
+    let repo = ctx.repo.as_deref().ok_or_else(|| {
+        ForgeError::validation(
+            schema_err(),
+            "repo_required",
+            "--metadata-only requires --repo owner/name or a recognised GitHub remote",
+            None,
+        )
+    })?;
+    let prefix = format!(
+        "https://{host}/{repo}/pull/{id}#pullrequestreview-",
+        host = ctx.host
+    );
+    let suffix = native_review_url.strip_prefix(&prefix).unwrap_or_default();
+    if suffix.is_empty() || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(ForgeError::validation(
+            schema_err(),
+            "invalid_native_review_url",
+            "--native-review-url must identify a native review on the selected GitHub repository and pull request",
+            None,
+        ));
+    }
+    Ok(())
+}
+
+fn validate_specialist_review_report(body: &str) -> Result<(), ForgeError> {
+    const MARKER: &str = "<!-- agent-kit:specialist-review-report:v1 -->";
+    const TABLE_HEADER: &str = "| Finding | Severity | Confidence | Evidence | Recommendation |";
+    const TABLE_SEPARATOR: &str = "| --- | --- | ---: | --- | --- |";
+    let lines = body.lines().map(str::trim).collect::<Vec<_>>();
+    let marker_count = body.matches(MARKER).count();
+    let heading_count = lines
+        .iter()
+        .filter(|line| **line == "## Review Report")
+        .count();
+    if marker_count != 1 || heading_count != 1 {
+        return Err(invalid_specialist_review_report(
+            "specialist report requires exactly one v1 marker and one Review Report heading",
+        ));
+    }
+
+    for field in [
+        "- Reviewable:",
+        "- Lens:",
+        "- Lens verdict:",
+        "- Scope:",
+        "- Evidence reviewed:",
+    ] {
+        let values = lines
+            .iter()
+            .filter_map(|line| line.strip_prefix(field).map(str::trim))
+            .collect::<Vec<_>>();
+        if values.len() != 1 || values[0].is_empty() {
+            return Err(invalid_specialist_review_report(&format!(
+                "specialist report requires exactly one non-empty {field} field"
+            )));
+        }
+    }
+
+    let verdict = lines
+        .iter()
+        .find_map(|line| line.strip_prefix("- Lens verdict:").map(str::trim))
+        .unwrap_or_default();
+    if !matches!(verdict, "pass" | "findings" | "blocked" | "follow-up-pass") {
+        return Err(invalid_specialist_review_report(
+            "specialist report lens verdict must be pass, findings, blocked, or follow-up-pass",
+        ));
+    }
+
+    let Some(header_index) = lines.iter().position(|line| *line == TABLE_HEADER) else {
+        return Err(invalid_specialist_review_report(
+            "specialist report requires the canonical findings table header",
+        ));
+    };
+    if lines.get(header_index + 1).copied() != Some(TABLE_SEPARATOR)
+        || !lines
+            .iter()
+            .skip(header_index + 2)
+            .any(|line| line.starts_with('|') && line.ends_with('|'))
+    {
+        return Err(invalid_specialist_review_report(
+            "specialist report requires the canonical table separator and at least one finding row",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid_specialist_review_report(message: &str) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "invalid_specialist_review_report",
+        message,
+        None,
+    )
+}
+
 /// Validation error raised when `--mirror-issue` is requested without the
 /// `--issue <ISSUE_NUMBER>` it mirrors into. Raised up front, before any
 /// backend mutation, so the failure can never leave a posted PR comment with no
@@ -3234,6 +3426,9 @@ mod tests {
             submit_review,
             expected_head: submit_review.then(|| "head-44".to_string()),
             thread_file: None,
+            specialist_report: false,
+            metadata_only: false,
+            native_review_url: None,
         }
     }
 

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -326,13 +326,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             || args.thread_file.is_some()
             || args.comment.is_some()
             || args.comment_file.is_some()
-            || args.expected_head.is_some()
             || args.specialist_report
         {
             return Err(ForgeError::validation(
                 schema_err(),
                 "metadata_only_conflict",
-                "--metadata-only cannot be combined with a review body, specialist validation, native submission, expected head, or thread file",
+                "--metadata-only cannot be combined with a review body, specialist validation, native submission, or thread file",
                 None,
             ));
         }
@@ -480,12 +479,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         None
     };
 
-    let expected_review_head = if args.submit_review {
+    let expected_review_head = if args.submit_review || args.metadata_only {
         Some(args.expected_head.as_deref().ok_or_else(|| {
             ForgeError::validation(
                 schema_err(),
                 "expected_review_head_required",
-                "--submit-review requires --expected-head <SHA> so the native review cannot attach to an unreviewed PR head",
+                "--submit-review and --metadata-only require --expected-head <SHA> so review publication cannot attach to an unreviewed PR head",
                 None,
             )
         })?)
@@ -494,7 +493,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             return Err(ForgeError::validation(
                 schema_err(),
                 "expected_review_head_requires_submit_review",
-                "--expected-head is only valid with --submit-review",
+                "--expected-head is only valid with --submit-review or --metadata-only",
                 None,
             ));
         }
@@ -548,7 +547,11 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         // The GitHub PR-existence guard is a live backend read; surface it in the
         // dry-run plan so wrappers inspecting dry-run output see every call.
         let guard_plan = (ctx.provider == Provider::GitHub).then(|| {
-            BackendCall::new(BackendProgram::Gh, github_pull_lookup_argv(&ctx, id)).plan_argv()
+            BackendCall::new(
+                BackendProgram::Gh,
+                github_pull_lookup_argv(&ctx, id, args.metadata_only),
+            )
+            .plan_argv()
         });
         let native_review_verification_plan = native_review_id.map(|review_id| {
             BackendCall::new(
@@ -711,7 +714,16 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     // issue. GitLab's `glab mr note` already fails on a non-MR id, so this guard
     // is GitHub-only.
     if ctx.provider == Provider::GitHub {
-        ensure_github_pull_request(runner, &ctx, id)?;
+        ensure_github_pull_request(
+            runner,
+            &ctx,
+            id,
+            if args.metadata_only {
+                Some(expected_review_head.expect("validated metadata-only review head"))
+            } else {
+                None
+            },
+        )?;
         if let (Some(review_id), Some(native_review_url), Some(native_review_author)) = (
             native_review_id,
             native_review_url.as_deref(),
@@ -721,10 +733,13 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 runner,
                 &ctx,
                 id,
-                review_id,
-                native_review_url,
-                native_review_author,
-                args.decision,
+                NativeReviewExpectation {
+                    review_id,
+                    url: native_review_url,
+                    author: native_review_author,
+                    decision: args.decision,
+                    head: expected_review_head.expect("validated metadata-only review head"),
+                },
             )?;
         }
         if args.submit_review && thread_specs.is_empty() {
@@ -3130,6 +3145,7 @@ struct GithubNativeReviewReadback {
     id: u64,
     html_url: String,
     state: String,
+    commit_id: String,
     user: GithubNativeReviewAuthor,
 }
 
@@ -3138,18 +3154,23 @@ struct GithubNativeReviewAuthor {
     login: String,
 }
 
+struct NativeReviewExpectation<'a> {
+    review_id: u64,
+    url: &'a str,
+    author: &'a str,
+    decision: PrReviewDecision,
+    head: &'a str,
+}
+
 fn ensure_github_native_review<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
     pr_id: u64,
-    review_id: u64,
-    expected_url: &str,
-    expected_author: &str,
-    decision: PrReviewDecision,
+    expected: NativeReviewExpectation<'_>,
 ) -> Result<(), ForgeError> {
     let call = BackendCall::new(
         BackendProgram::Gh,
-        github_native_review_lookup_argv(ctx, pr_id, review_id),
+        github_native_review_lookup_argv(ctx, pr_id, expected.review_id),
     );
     let output = runner.run(&call)?;
     let review: GithubNativeReviewReadback =
@@ -3158,19 +3179,28 @@ fn ensure_github_native_review<R: BackendRunner>(
                 "GitHub returned an invalid native review document: {error}"
             ))
         })?;
-    let expected_state = match decision {
+    let expected_state = match expected.decision {
         PrReviewDecision::CommentsOnly => "COMMENTED",
         PrReviewDecision::Approve => "APPROVED",
         PrReviewDecision::RequestChanges => "CHANGES_REQUESTED",
     };
-    if review.id != review_id
-        || review.html_url != expected_url
-        || !review.user.login.eq_ignore_ascii_case(expected_author)
+    if review.id != expected.review_id
+        || review.html_url != expected.url
+        || !review.user.login.eq_ignore_ascii_case(expected.author)
         || !review.state.eq_ignore_ascii_case(expected_state)
+        || review.commit_id != expected.head
     {
         return Err(native_review_verification_error(format!(
-            "expected id={review_id}, url={expected_url}, author={expected_author}, state={expected_state}; provider returned id={}, url={}, author={}, state={}",
-            review.id, review.html_url, review.user.login, review.state
+            "expected id={}, url={}, author={}, state={expected_state}, commit_id={}; provider returned id={}, url={}, author={}, state={}, commit_id={}",
+            expected.review_id,
+            expected.url,
+            expected.author,
+            expected.head,
+            review.id,
+            review.html_url,
+            review.user.login,
+            review.state,
+            review.commit_id
         )));
     }
     Ok(())
@@ -3328,10 +3358,27 @@ fn ensure_github_pull_request<R: BackendRunner>(
     runner: &R,
     ctx: &ProviderContext,
     id: u64,
+    expected_head: Option<&str>,
 ) -> Result<(), ForgeError> {
-    let call = BackendCall::new(BackendProgram::Gh, github_pull_lookup_argv(ctx, id));
+    let call = BackendCall::new(
+        BackendProgram::Gh,
+        github_pull_lookup_argv(ctx, id, expected_head.is_some()),
+    );
     let probe = runner.run_raw(&call)?;
     if probe.status_success {
+        if let Some(expected_head) = expected_head {
+            let provider_head = probe.stdout.trim();
+            if provider_head != expected_head {
+                return Err(ForgeError::validation(
+                    schema_err(),
+                    "github_review_head_changed",
+                    "the provider PR head differs from the head supplied for review publication",
+                    Some(format!(
+                        "expected_head={expected_head}; provider_head={provider_head}"
+                    )),
+                ));
+            }
+        }
         return Ok(());
     }
     let detail = probe.stderr.trim();
@@ -3462,10 +3509,11 @@ fn glab_note_form<R: BackendRunner>(runner: &R) -> GlabNoteForm {
     }
 }
 
-/// `gh api repos/{repo}/pulls/{id} --jq .number` — the read used to confirm
-/// `<id>` is a pull request. Mirrors [`github_issue_comment_argv`]'s endpoint
-/// shape (repo embedded in the path, hostname pushed for GitHub Enterprise).
-fn github_pull_lookup_argv(ctx: &ProviderContext, id: u64) -> Vec<OsString> {
+/// `gh api repos/{repo}/pulls/{id}` — confirm `<id>` is a pull request and,
+/// for metadata-only publication, read its current head SHA. Mirrors
+/// [`github_issue_comment_argv`]'s endpoint shape (repo embedded in the path,
+/// hostname pushed for GitHub Enterprise).
+fn github_pull_lookup_argv(ctx: &ProviderContext, id: u64, include_head: bool) -> Vec<OsString> {
     let endpoint = ctx
         .repo
         .as_deref()
@@ -3476,7 +3524,7 @@ fn github_pull_lookup_argv(ctx: &ProviderContext, id: u64) -> Vec<OsString> {
     argv.extend([
         OsString::from(endpoint),
         OsString::from("--jq"),
-        OsString::from(".number"),
+        OsString::from(if include_head { ".head.sha" } else { ".number" }),
     ]);
     argv
 }

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -86,6 +86,8 @@ pub struct PrReviewPayload {
     pub metadata_only: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub native_review_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub native_review_author: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub review_threads: Vec<CreatedReviewThread>,
     /// Number of finding threads skipped as cross-run idempotent duplicates:
@@ -136,6 +138,10 @@ struct PrReviewDryRunPayload {
     metadata_only: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     native_review_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    native_review_author: Option<String>,
+    /// GitHub native-review read-back performed before metadata mutation.
+    native_review_verification_plan: Option<Vec<String>>,
     planned_review_threads: usize,
     target_plan: Option<Vec<String>>,
     thread_plan: Vec<Vec<String>>,
@@ -308,7 +314,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     }
     let id = args.id.ok_or_else(review_id_required_err)?;
 
-    let native_review_url = if args.metadata_only {
+    let (native_review_url, native_review_author, native_review_id) = if args.metadata_only {
         if ctx.provider != Provider::GitHub {
             return Err(ForgeError::provider_unsupported(
                 schema_err(),
@@ -338,8 +344,20 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 None,
             )
         })?;
-        validate_native_review_url(&ctx, id, native_review_url)?;
-        Some(native_review_url.to_string())
+        let native_review_author = args.native_review_author.as_deref().ok_or_else(|| {
+            ForgeError::validation(
+                schema_err(),
+                "native_review_author_required",
+                "--metadata-only requires --native-review-author <LOGIN>",
+                None,
+            )
+        })?;
+        let native_review_id = validate_native_review_url(&ctx, id, native_review_url)?;
+        (
+            Some(native_review_url.to_string()),
+            Some(native_review_author.to_string()),
+            Some(native_review_id),
+        )
     } else {
         if args.native_review_url.is_some() {
             return Err(ForgeError::validation(
@@ -349,7 +367,15 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 None,
             ));
         }
-        None
+        if args.native_review_author.is_some() {
+            return Err(ForgeError::validation(
+                schema_err(),
+                "native_review_author_requires_metadata_only",
+                "--native-review-author is only valid with --metadata-only",
+                None,
+            ));
+        }
+        (None, None, None)
     };
 
     let thread_specs_requested = args.thread_file.is_some();
@@ -524,6 +550,13 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
         let guard_plan = (ctx.provider == Provider::GitHub).then(|| {
             BackendCall::new(BackendProgram::Gh, github_pull_lookup_argv(&ctx, id)).plan_argv()
         });
+        let native_review_verification_plan = native_review_id.map(|review_id| {
+            BackendCall::new(
+                BackendProgram::Gh,
+                github_native_review_lookup_argv(&ctx, id, review_id),
+            )
+            .plan_argv()
+        });
         let pending_review_guard_plan = if args.submit_review && ctx.provider == Provider::GitHub {
             let (owner, name) = github_owner_name(&ctx)?;
             Some(
@@ -598,6 +631,8 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
                 lenses: args.lenses.clone(),
                 metadata_only: args.metadata_only,
                 native_review_url: native_review_url.clone(),
+                native_review_author: native_review_author.clone(),
+                native_review_verification_plan,
                 planned_review_threads: thread_specs.len(),
                 target_plan,
                 thread_plan,
@@ -607,6 +642,12 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             |p| {
                 if let Some(guard) = p.guard_plan.as_ref() {
                     println!("would verify pull request: {plan}", plan = guard.join(" "));
+                }
+                if let Some(plan) = p.native_review_verification_plan.as_ref() {
+                    println!(
+                        "would verify authoritative native review: {plan}",
+                        plan = plan.join(" ")
+                    );
                 }
                 if let Some(guard) = p.pending_review_guard_plan.as_ref() {
                     println!(
@@ -671,6 +712,21 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
     // is GitHub-only.
     if ctx.provider == Provider::GitHub {
         ensure_github_pull_request(runner, &ctx, id)?;
+        if let (Some(review_id), Some(native_review_url), Some(native_review_author)) = (
+            native_review_id,
+            native_review_url.as_deref(),
+            native_review_author.as_deref(),
+        ) {
+            ensure_github_native_review(
+                runner,
+                &ctx,
+                id,
+                review_id,
+                native_review_url,
+                native_review_author,
+                args.decision,
+            )?;
+        }
         if args.submit_review && thread_specs.is_empty() {
             ensure_no_viewer_pending_github_review(
                 runner,
@@ -765,6 +821,7 @@ pub fn run_with<R: BackendRunner, F: Fn(&str) -> Option<String>>(
             lenses: args.lenses,
             metadata_only: args.metadata_only,
             native_review_url,
+            native_review_author,
             review_threads,
             threads_skipped_idempotent,
         },
@@ -3042,7 +3099,7 @@ fn validate_native_review_url(
     ctx: &ProviderContext,
     id: u64,
     native_review_url: &str,
-) -> Result<(), ForgeError> {
+) -> Result<u64, ForgeError> {
     let repo = ctx.repo.as_deref().ok_or_else(|| {
         ForgeError::validation(
             schema_err(),
@@ -3056,7 +3113,8 @@ fn validate_native_review_url(
         host = ctx.host
     );
     let suffix = native_review_url.strip_prefix(&prefix).unwrap_or_default();
-    if suffix.is_empty() || !suffix.bytes().all(|byte| byte.is_ascii_digit()) {
+    let review_id = suffix.parse::<u64>().ok().filter(|value| *value > 0);
+    if review_id.is_none() {
         return Err(ForgeError::validation(
             schema_err(),
             "invalid_native_review_url",
@@ -3064,7 +3122,67 @@ fn validate_native_review_url(
             None,
         ));
     }
+    Ok(review_id.expect("validated positive native review id"))
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubNativeReviewReadback {
+    id: u64,
+    html_url: String,
+    state: String,
+    user: GithubNativeReviewAuthor,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubNativeReviewAuthor {
+    login: String,
+}
+
+fn ensure_github_native_review<R: BackendRunner>(
+    runner: &R,
+    ctx: &ProviderContext,
+    pr_id: u64,
+    review_id: u64,
+    expected_url: &str,
+    expected_author: &str,
+    decision: PrReviewDecision,
+) -> Result<(), ForgeError> {
+    let call = BackendCall::new(
+        BackendProgram::Gh,
+        github_native_review_lookup_argv(ctx, pr_id, review_id),
+    );
+    let output = runner.run(&call)?;
+    let review: GithubNativeReviewReadback =
+        serde_json::from_str(output.stdout.trim()).map_err(|error| {
+            native_review_verification_error(format!(
+                "GitHub returned an invalid native review document: {error}"
+            ))
+        })?;
+    let expected_state = match decision {
+        PrReviewDecision::CommentsOnly => "COMMENTED",
+        PrReviewDecision::Approve => "APPROVED",
+        PrReviewDecision::RequestChanges => "CHANGES_REQUESTED",
+    };
+    if review.id != review_id
+        || review.html_url != expected_url
+        || !review.user.login.eq_ignore_ascii_case(expected_author)
+        || !review.state.eq_ignore_ascii_case(expected_state)
+    {
+        return Err(native_review_verification_error(format!(
+            "expected id={review_id}, url={expected_url}, author={expected_author}, state={expected_state}; provider returned id={}, url={}, author={}, state={}",
+            review.id, review.html_url, review.user.login, review.state
+        )));
+    }
     Ok(())
+}
+
+fn native_review_verification_error(detail: String) -> ForgeError {
+    ForgeError::validation(
+        schema_err(),
+        "native_review_verification_failed",
+        "the authoritative native review did not match the selected pull request, decision, and expected App author",
+        Some(detail),
+    )
 }
 
 fn validate_specialist_review_report(body: &str) -> Result<(), ForgeError> {
@@ -3116,17 +3234,46 @@ fn validate_specialist_review_report(body: &str) -> Result<(), ForgeError> {
             "specialist report requires the canonical findings table header",
         ));
     };
+    let rows = lines
+        .iter()
+        .skip(header_index + 2)
+        .take_while(|line| !line.is_empty())
+        .copied()
+        .collect::<Vec<_>>();
     if lines.get(header_index + 1).copied() != Some(TABLE_SEPARATOR)
-        || !lines
+        || rows.is_empty()
+        || rows
             .iter()
-            .skip(header_index + 2)
-            .any(|line| line.starts_with('|') && line.ends_with('|'))
+            .any(|row| markdown_table_cell_count(row) != Some(5))
     {
         return Err(invalid_specialist_review_report(
-            "specialist report requires the canonical table separator and at least one finding row",
+            "specialist report requires the canonical table separator and finding rows with exactly five cells",
         ));
     }
     Ok(())
+}
+
+fn markdown_table_cell_count(row: &str) -> Option<usize> {
+    if !row.starts_with('|') || !row.ends_with('|') {
+        return None;
+    }
+    let bytes = row.as_bytes();
+    let mut separators = 0usize;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte != b'|' {
+            continue;
+        }
+        let mut backslashes = 0usize;
+        let mut cursor = index;
+        while cursor > 0 && bytes[cursor - 1] == b'\\' {
+            backslashes += 1;
+            cursor -= 1;
+        }
+        if backslashes.is_multiple_of(2) {
+            separators += 1;
+        }
+    }
+    separators.checked_sub(1)
 }
 
 fn invalid_specialist_review_report(message: &str) -> ForgeError {
@@ -3334,6 +3481,24 @@ fn github_pull_lookup_argv(ctx: &ProviderContext, id: u64) -> Vec<OsString> {
     argv
 }
 
+/// Read one native review from the exact repository and pull request before
+/// metadata-only publication trusts its URL, state, or author.
+fn github_native_review_lookup_argv(
+    ctx: &ProviderContext,
+    pr_id: u64,
+    review_id: u64,
+) -> Vec<OsString> {
+    let endpoint = ctx
+        .repo
+        .as_deref()
+        .map(|repo| format!("repos/{repo}/pulls/{pr_id}/reviews/{review_id}"))
+        .unwrap_or_else(|| format!("repos/{{owner}}/{{repo}}/pulls/{pr_id}/reviews/{review_id}"));
+    let mut argv = vec![OsString::from("api")];
+    ctx.push_github_api_hostname(&mut argv);
+    argv.push(OsString::from(endpoint));
+    argv
+}
+
 fn first_url(stdout: &str) -> Option<String> {
     stdout.split_whitespace().find_map(|token| {
         let url = token.trim_matches(|ch: char| {
@@ -3429,6 +3594,7 @@ mod tests {
             specialist_report: false,
             metadata_only: false,
             native_review_url: None,
+            native_review_author: None,
         }
     }
 

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -215,6 +215,146 @@ fn pr_review_posts_outcome_and_mirrors_issue_activity() {
 }
 
 #[test]
+fn pr_review_validate_specialist_report_rejects_the_old_bullet_shape() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("gh-args.log");
+    let stub = stub.gh_stub(&github_review_stub(&capture.to_string_lossy()));
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "review",
+            "validate",
+            "--specialist-report",
+            "--comment",
+            "## Specialist Review Findings\n\n- **high** src/lib.rs:42: old bullet",
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "invalid_specialist_review_report");
+    assert_backend_not_invoked(&capture);
+}
+
+#[test]
+fn pr_review_validate_specialist_report_accepts_the_canonical_table_shape() {
+    let stub = StubEnv::new();
+    let report = "<!-- agent-kit:specialist-review-report:v1 -->\n## Review Report\n\n- Reviewable: PR #44\n- Lens: testing\n- Lens verdict: pass\n- Scope: review publication\n- Evidence reviewed: focused tests\n\n| Finding | Severity | Confidence | Evidence | Recommendation |\n| --- | --- | ---: | --- | --- |\n| No findings | none | 0.00 | No actionable or informational findings. | none |\n";
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "local",
+            "--format",
+            "json",
+            "pr",
+            "review",
+            "validate",
+            "--specialist-report",
+            "--comment",
+            report,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["data"]["comment"]["specialist_report"], true);
+}
+
+#[test]
+fn pr_review_metadata_only_posts_concise_pr_and_issue_breadcrumbs() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("gh-args.log");
+    let stub = stub.gh_stub(&github_review_stub(&capture.to_string_lossy()));
+    let native_review = "https://github.com/acme/widgets/pull/44#pullrequestreview-440";
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "review",
+            "44",
+            "--decision",
+            "approve",
+            "--lens",
+            "testing",
+            "--metadata-only",
+            "--native-review-url",
+            native_review,
+            "--issue",
+            "101",
+            "--mirror-issue",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["data"]["metadata_only"], true);
+    assert_eq!(env["data"]["native_review_url"], native_review);
+    let calls = fs::read_to_string(capture).expect("read captured calls");
+    assert!(
+        calls.contains("repos/acme/widgets/issues/44/comments"),
+        "{calls}"
+    );
+    assert!(
+        calls.contains("repos/acme/widgets/issues/101/comments"),
+        "{calls}"
+    );
+    assert!(calls.contains("Review metadata"), "{calls}");
+    assert!(calls.contains(native_review), "{calls}");
+    assert!(!calls.contains("## Review Report"), "{calls}");
+    assert!(
+        !calls.contains("agent-kit:specialist-review-report:v1"),
+        "{calls}"
+    );
+}
+
+#[test]
+fn pr_review_metadata_only_rejects_a_different_pr_review_url_before_backend() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("gh-args.log");
+    let stub = stub.gh_stub(&github_review_stub(&capture.to_string_lossy()));
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "review",
+            "44",
+            "--metadata-only",
+            "--native-review-url",
+            "https://github.com/acme/widgets/pull/45#pullrequestreview-440",
+        ],
+    );
+
+    assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["error"]["code"], "invalid_native_review_url");
+    assert_backend_not_invoked(&capture);
+}
+
+#[test]
 fn pr_review_posts_gitlab_outcome_and_issue_mirror() {
     let stub = StubEnv::new();
     let capture = stub.tempdir.path().join("glab-args.log");

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -31,6 +31,9 @@ case "$2" in
   repos/acme/widgets/pulls/44)
     echo "44"
     ;;
+  repos/acme/widgets/pulls/44/reviews/440)
+    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"APPROVED","user":{{"login":"review-bot[bot]"}}}}'
+    ;;
   repos/acme/widgets/issues/44/comments)
     echo "https://github.com/acme/widgets/pull/44#issuecomment-440"
     ;;
@@ -39,6 +42,27 @@ case "$2" in
     ;;
   *)
     echo "stub: unexpected gh api endpoint: $2" >&2
+    exit 99
+    ;;
+esac
+"#
+    )
+}
+
+fn github_native_review_mismatch_stub(capture: &str, state: &str, author: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> {capture:?}
+case "$2" in
+  repos/acme/widgets/pulls/44)
+    echo "44"
+    ;;
+  repos/acme/widgets/pulls/44/reviews/440)
+    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"{state}","user":{{"login":"{author}"}}}}'
+    ;;
+  *)
+    echo "stub: mutation must not run after failed native review verification: $*" >&2
     exit 99
     ;;
 esac
@@ -245,9 +269,46 @@ fn pr_review_validate_specialist_report_rejects_the_old_bullet_shape() {
 }
 
 #[test]
+fn pr_review_validate_specialist_report_rejects_malformed_table_rows() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("gh-args.log");
+    let stub = stub.gh_stub(&github_review_stub(&capture.to_string_lossy()));
+    let prefix = "<!-- agent-kit:specialist-review-report:v1 -->\n## Review Report\n\n- Reviewable: PR #44\n- Lens: testing\n- Lens verdict: findings\n- Scope: validation\n- Evidence reviewed: focused test\n\n| Finding | Severity | Confidence | Evidence | Recommendation |\n| --- | --- | ---: | --- | --- |\n";
+
+    for row in [
+        "| malformed |\n",
+        "| finding | medium | 0.90 | evidence | recommendation | extra |\n",
+    ] {
+        let report = format!("{prefix}{row}");
+        let out = run_forge_cli(
+            &stub,
+            &[
+                "--provider",
+                "github",
+                "--repo",
+                "acme/widgets",
+                "--format",
+                "json",
+                "pr",
+                "review",
+                "validate",
+                "--specialist-report",
+                "--comment",
+                &report,
+            ],
+        );
+
+        assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+        let env = parse_envelope(&out.stdout);
+        assert_eq!(env["error"]["code"], "invalid_specialist_review_report");
+    }
+    assert_backend_not_invoked(&capture);
+}
+
+#[test]
 fn pr_review_validate_specialist_report_accepts_the_canonical_table_shape() {
     let stub = StubEnv::new();
-    let report = "<!-- agent-kit:specialist-review-report:v1 -->\n## Review Report\n\n- Reviewable: PR #44\n- Lens: testing\n- Lens verdict: pass\n- Scope: review publication\n- Evidence reviewed: focused tests\n\n| Finding | Severity | Confidence | Evidence | Recommendation |\n| --- | --- | ---: | --- | --- |\n| No findings | none | 0.00 | No actionable or informational findings. | none |\n";
+    let report = "<!-- agent-kit:specialist-review-report:v1 -->\n## Review Report\n\n- Reviewable: PR #44\n- Lens: testing\n- Lens verdict: pass\n- Scope: review publication\n- Evidence reviewed: focused tests\n\n| Finding | Severity | Confidence | Evidence | Recommendation |\n| --- | --- | ---: | --- | --- |\n| No findings | none | 0.00 | No actionable \\| informational findings. | none |\n";
 
     let out = run_forge_cli(
         &stub,
@@ -296,6 +357,8 @@ fn pr_review_metadata_only_posts_concise_pr_and_issue_breadcrumbs() {
             "--metadata-only",
             "--native-review-url",
             native_review,
+            "--native-review-author",
+            "review-bot[bot]",
             "--issue",
             "101",
             "--mirror-issue",
@@ -317,6 +380,13 @@ fn pr_review_metadata_only_posts_concise_pr_and_issue_breadcrumbs() {
     );
     assert!(calls.contains("Review metadata"), "{calls}");
     assert!(calls.contains(native_review), "{calls}");
+    let verification = calls
+        .find("repos/acme/widgets/pulls/44/reviews/440")
+        .expect("native review verification call");
+    let mutation = calls
+        .find("repos/acme/widgets/issues/44/comments")
+        .expect("metadata mutation call");
+    assert!(verification < mutation, "{calls}");
     assert!(!calls.contains("## Review Report"), "{calls}");
     assert!(
         !calls.contains("agent-kit:specialist-review-report:v1"),
@@ -345,6 +415,8 @@ fn pr_review_metadata_only_rejects_a_different_pr_review_url_before_backend() {
             "--metadata-only",
             "--native-review-url",
             "https://github.com/acme/widgets/pull/45#pullrequestreview-440",
+            "--native-review-author",
+            "review-bot[bot]",
         ],
     );
 
@@ -352,6 +424,53 @@ fn pr_review_metadata_only_rejects_a_different_pr_review_url_before_backend() {
     let env = parse_envelope(&out.stdout);
     assert_eq!(env["error"]["code"], "invalid_native_review_url");
     assert_backend_not_invoked(&capture);
+}
+
+#[test]
+fn pr_review_metadata_only_rejects_a_mismatched_provider_review_before_mutation() {
+    for (state, author) in [
+        ("COMMENTED", "review-bot[bot]"),
+        ("APPROVED", "unexpected-bot[bot]"),
+    ] {
+        let stub = StubEnv::new();
+        let capture = stub.tempdir.path().join("gh-args.log");
+        let stub = stub.gh_stub(&github_native_review_mismatch_stub(
+            &capture.to_string_lossy(),
+            state,
+            author,
+        ));
+        let out = run_forge_cli(
+            &stub,
+            &[
+                "--provider",
+                "github",
+                "--repo",
+                "acme/widgets",
+                "--format",
+                "json",
+                "pr",
+                "review",
+                "44",
+                "--decision",
+                "approve",
+                "--metadata-only",
+                "--native-review-url",
+                "https://github.com/acme/widgets/pull/44#pullrequestreview-440",
+                "--native-review-author",
+                "review-bot[bot]",
+            ],
+        );
+
+        assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+        let env = parse_envelope(&out.stdout);
+        assert_eq!(env["error"]["code"], "native_review_verification_failed");
+        let calls = fs::read_to_string(&capture).expect("read captured calls");
+        assert!(
+            calls.contains("repos/acme/widgets/pulls/44/reviews/440"),
+            "{calls}"
+        );
+        assert!(!calls.contains("/comments"), "{calls}");
+    }
 }
 
 #[test]

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -29,10 +29,10 @@ if [ "$1" != "api" ]; then
 fi
 case "$2" in
   repos/acme/widgets/pulls/44)
-    echo "44"
+    echo "head-44"
     ;;
   repos/acme/widgets/pulls/44/reviews/440)
-    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"APPROVED","user":{{"login":"review-bot[bot]"}}}}'
+    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"APPROVED","commit_id":"head-44","user":{{"login":"review-bot[bot]"}}}}'
     ;;
   repos/acme/widgets/issues/44/comments)
     echo "https://github.com/acme/widgets/pull/44#issuecomment-440"
@@ -56,13 +56,34 @@ set -eu
 printf '%s\n' "$*" >> {capture:?}
 case "$2" in
   repos/acme/widgets/pulls/44)
-    echo "44"
+    echo "head-44"
     ;;
   repos/acme/widgets/pulls/44/reviews/440)
-    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"{state}","user":{{"login":"{author}"}}}}'
+    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"{state}","commit_id":"head-44","user":{{"login":"{author}"}}}}'
     ;;
   *)
     echo "stub: mutation must not run after failed native review verification: $*" >&2
+    exit 99
+    ;;
+esac
+"#
+    )
+}
+
+fn github_native_review_head_stub(capture: &str, current_head: &str, review_head: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> {capture:?}
+case "$2" in
+  repos/acme/widgets/pulls/44)
+    echo "{current_head}"
+    ;;
+  repos/acme/widgets/pulls/44/reviews/440)
+    printf '%s\n' '{{"id":440,"html_url":"https://github.com/acme/widgets/pull/44#pullrequestreview-440","state":"APPROVED","commit_id":"{review_head}","user":{{"login":"review-bot[bot]"}}}}'
+    ;;
+  *)
+    echo "stub: mutation must not run after failed native review head verification: $*" >&2
     exit 99
     ;;
 esac
@@ -408,6 +429,8 @@ fn pr_review_metadata_only_posts_concise_pr_and_issue_breadcrumbs() {
             "--lens",
             "testing",
             "--metadata-only",
+            "--expected-head",
+            "head-44",
             "--native-review-url",
             native_review,
             "--native-review-author",
@@ -507,6 +530,8 @@ fn pr_review_metadata_only_rejects_a_mismatched_provider_review_before_mutation(
                 "--decision",
                 "approve",
                 "--metadata-only",
+                "--expected-head",
+                "head-44",
                 "--native-review-url",
                 "https://github.com/acme/widgets/pull/44#pullrequestreview-440",
                 "--native-review-author",
@@ -522,6 +547,51 @@ fn pr_review_metadata_only_rejects_a_mismatched_provider_review_before_mutation(
             calls.contains("repos/acme/widgets/pulls/44/reviews/440"),
             "{calls}"
         );
+        assert!(!calls.contains("/comments"), "{calls}");
+    }
+}
+
+#[test]
+fn pr_review_metadata_only_rejects_stale_review_or_advanced_pr_head_before_mutation() {
+    for (current_head, review_head, expected_code) in [
+        ("head-44", "head-old", "native_review_verification_failed"),
+        ("head-new", "head-44", "github_review_head_changed"),
+    ] {
+        let stub = StubEnv::new();
+        let capture = stub.tempdir.path().join("gh-args.log");
+        let stub = stub.gh_stub(&github_native_review_head_stub(
+            &capture.to_string_lossy(),
+            current_head,
+            review_head,
+        ));
+        let out = run_forge_cli(
+            &stub,
+            &[
+                "--provider",
+                "github",
+                "--repo",
+                "acme/widgets",
+                "--format",
+                "json",
+                "pr",
+                "review",
+                "44",
+                "--decision",
+                "approve",
+                "--metadata-only",
+                "--expected-head",
+                "head-44",
+                "--native-review-url",
+                "https://github.com/acme/widgets/pull/44#pullrequestreview-440",
+                "--native-review-author",
+                "review-bot[bot]",
+            ],
+        );
+
+        assert_eq!(out.code, 65, "stdout={}\nstderr={}", out.stdout, out.stderr);
+        let env = parse_envelope(&out.stdout);
+        assert_eq!(env["error"]["code"], expected_code);
+        let calls = fs::read_to_string(&capture).unwrap_or_default();
         assert!(!calls.contains("/comments"), "{calls}");
     }
 }

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -332,6 +332,59 @@ fn pr_review_validate_specialist_report_accepts_the_canonical_table_shape() {
 }
 
 #[test]
+fn pr_review_validate_accepts_renderer_output_with_an_already_escaped_pipe() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let input = tmp.path().join("findings.jsonl");
+    fs::write(
+        &input,
+        r#"{"severity":"medium","confidence":0.9,"path":"src/lib.rs","line":7,"category":"correctness","summary":"Existing \\| pipe","evidence":"The evidence keeps \\| source text.","recommendation":"Preserve \\| safely.","specialist":"testing","actionable":true}"#,
+    )
+    .expect("write findings");
+    let bundle = tmp.path().join("bundle");
+    let render_code = agent_workflow_primitives::review_specialists::run_with_args([
+        "review-specialists".to_string(),
+        "bundle".to_string(),
+        "--input".to_string(),
+        input.to_string_lossy().into_owned(),
+        "--out-dir".to_string(),
+        bundle.to_string_lossy().into_owned(),
+        "--profile".to_string(),
+        "provider-review".to_string(),
+        "--reviewable".to_string(),
+        "PR #44".to_string(),
+        "--lens".to_string(),
+        "testing".to_string(),
+        "--lens-verdict".to_string(),
+        "findings".to_string(),
+        "--scope".to_string(),
+        "renderer-validator parity".to_string(),
+        "--evidence-reviewed".to_string(),
+        "end-to-end regression".to_string(),
+    ]);
+    assert_eq!(render_code, 0);
+    let report = bundle.join("provider-review.md");
+    let report_arg = report.to_string_lossy().into_owned();
+
+    let out = run_forge_cli(
+        &StubEnv::new(),
+        &[
+            "--provider",
+            "local",
+            "--format",
+            "json",
+            "pr",
+            "review",
+            "validate",
+            "--specialist-report",
+            "--comment-file",
+            &report_arg,
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+}
+
+#[test]
 fn pr_review_metadata_only_posts_concise_pr_and_issue_breadcrumbs() {
     let stub = StubEnv::new();
     let capture = stub.tempdir.path().join("gh-args.log");

--- a/docs/runbooks/review-specialists-primitive.md
+++ b/docs/runbooks/review-specialists-primitive.md
@@ -23,12 +23,15 @@ provider workflow for live PR or issue actions.
 Each finding is one JSON object per line:
 
 ```json
-{"severity":"high","confidence":0.82,"path":"src/api/users.rs","line":42,"category":"api-contract","summary":"Response shape changed without migration guidance.","evidence":"Diff removes a field while callers still read it.","recommendation":"Add compatibility handling or update callers and tests.","specialist":"api-contract","test_suggestion":"Add a contract test."}
+{"severity":"high","confidence":0.82,"path":"src/api/users.rs","line":42,"category":"api-contract","summary":"Response shape changed without migration guidance.","evidence":"Diff removes a field while callers still read it.","recommendation":"Add compatibility handling or update callers and tests.","specialist":"api-contract","test_suggestion":"Add a contract test.","actionable":true}
 ```
 
 Required fields are `severity`, `confidence`, `path`, `summary`, `evidence`,
 `recommendation`, and `specialist`. Optional fields are `line`, `category`,
-`fingerprint`, `root_cause_fingerprint`, and `test_suggestion`.
+`fingerprint`, `root_cause_fingerprint`, `test_suggestion`, and `actionable`.
+`actionable` defaults to `false`; set it only when the owner must make a code,
+doc, test, or config change and the provider flow should create a resolvable
+line/file thread.
 
 Severity aliases normalize to `critical`, `high`, `medium`, `low`, and `info`.
 Confidence must be `0.0..=1.0`. Unknown fields are rejected so fixture drift is
@@ -44,6 +47,10 @@ review-specialists scope --base main --format json
 review-specialists validate --input findings.jsonl --format json
 review-specialists merge --input findings.jsonl --summary-out review.md
 review-specialists merge --mode delivery --input findings.jsonl --format json
+review-specialists render --profile provider-review --input findings.merged.json \
+  --reviewable 'PR #123' --lens testing --lens-verdict findings \
+  --scope 'changed test paths' --evidence-reviewed 'focused tests and diff' \
+  --out review.md --thread-out review-threads.json
 review-specialists render --profile issue-body --input findings.merged.json \
   --repo sympoies/nils-cli --ref HEAD --out issue.md
 review-specialists bundle --input findings.jsonl --out-dir target/review-specialists/bundle \
@@ -80,6 +87,8 @@ not a disposition; `forge-cli` requires the explicit field or a repaired head.
 - `findings.merged.json`
 - `specialist-review.md`
 - one optional profile artifact such as `issue-body.md`
+- `review-threads.json` whenever the optional profile is `provider-review` or
+  its `pr-comment` compatibility alias
 
 Invalid input fails before bundle artifacts are written.
 
@@ -88,7 +97,10 @@ Invalid input fails before bundle artifacts are written.
 - `terminal`: compact summary for chat or local terminal output.
 - `report`: full specialist report sections.
 - `issue-body`: follow-up-oriented issue body.
-- `pr-comment`: review-oriented comment body.
+- `provider-review`: canonical marker, Review Report fields, findings table,
+  and optional actionable line/file thread artifact.
+- `pr-comment`: compatibility alias to `provider-review`; it cannot render the
+  retired bullet body.
 - `evidence`: compact JSON summary for evidence linking.
 
 Provider profiles are local renderers only. They do not post anything.


### PR DESCRIPTION
## Summary

- make `review-specialists` render one canonical provider Review Report table and derive explicitly actionable line/file thread artifacts from the same merged findings
- keep `pr-comment` as a compatibility alias for the canonical provider profile instead of a second bullet renderer
- add opt-in `forge-cli pr review --specialist-report` validation and exact-head-verified `--metadata-only --expected-head --native-review-url --native-review-author` publication so a personal identity records concise provenance without duplicating the GitHub App review body
- refresh the public contracts, runbook, goldens, integration coverage, and bash/zsh completions

Tracking plan: https://github.com/serenvia/local-scripts/issues/65

## Test plan

- [x] `cargo test -p nils-agent-workflow-primitives review_specialists_provider_review_writes_canonical_body_and_line_file_threads`
- [x] `cargo test -p nils-forge-cli --test integration pr_review_`
- [x] `bash scripts/ci/completion-freshness-audit.sh --bin forge-cli --bin review-specialists --skip-build`
- [x] `bash scripts/ci/completion-flag-parity-audit.sh --strict`
- [x] `cargo test -p nils-forge-cli --test integration pr_review_validate_accepts_renderer_output_with_an_already_escaped_pipe`
- [x] `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` (8,811 workspace tests passed)
