### PR TITLE
fix(forge): normalize GitHub single-line review anchors

### DIFF
--- a/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
+++ b/crates/forge-cli/docs/specs/forge-cli-spec-v1.md
@@ -652,7 +652,14 @@ distinctions that cannot be proven offline.
   pending-snapshot-unverified`; a live submit reports its guarded digest with
   `snapshot_provenance: pending-cas+submitted-reconciled`. Provider-null
   side/range values on a `FILE` comment are normalized away when matching a
-  receipt; `LINE` and range anchors remain exact.
+  receipt. For a single-line `LINE` comment, GitHub's equivalent `startLine`
+  encodings (omitted or equal to `line` with no distinct start side, and
+  likewise for the original line) are canonicalized to omitted before snapshot
+  output, receipt matching, and `snapshot_digest` calculation. Non-equal range
+  starts, equal-number cross-side ranges, and all other `LINE` anchors remain
+  exact. When the pending-comment response cannot establish the line sides,
+  canonicalization is deferred until the exact review-thread recovery supplies
+  the authoritative sides.
 - `pr pending-review submit <id> --review <PRR_...> --expected-head <sha>
   --expected-commit <sha> --expected-snapshot <digest> --decision <decision>
   --confirm-unmarked-submit` emits `cli.forge-cli.pr.pending-review.submit.v1`.
@@ -919,7 +926,14 @@ distinctions that cannot be proven offline.
   every finding carry owned run/digest markers. An exact pending manifest must
   be an ordered prefix of the receipt manifest; the command adds only the
   missing suffix and performs a final complete snapshot before
-  `submitPullRequestReview`. Success requires an immediate exact-node read-back
+  `submitPullRequestReview`. During snapshot recovery, GitHub's equivalent
+  single-line encodings (`startLine` omitted or equal to `line` without a
+  distinct start side, and likewise for the original line) are canonicalized
+  before comparing the comment with its review thread; genuine ranges,
+  including equal-number cross-side ranges, must still match exactly. Success
+  requires an immediate exact-node read-back. Unknown sides in the pending
+  comment never prove a single-line anchor; the exact thread read owns that
+  decision.
   whose submitted state and complete receipt-bound manifest reconcile.
 
   Every interrupted stage is resumable: a lost create response, any lost inline

--- a/crates/forge-cli/src/ops/pr_review.rs
+++ b/crates/forge-cli/src/ops/pr_review.rs
@@ -2440,6 +2440,31 @@ fn validate_submitted_review_manifest<R: BackendRunner>(
     for expected in manifest {
         let matched = threads.threads.iter().any(|thread| {
             let marker = review_state::parse_finding_marker(&thread.body);
+            let thread_start_line = pr_reviews::canonical_review_start_line(
+                thread.subject_type.as_deref(),
+                thread.line,
+                thread.diff_side.as_deref(),
+                thread.start_line,
+                thread.start_diff_side.as_deref(),
+                true,
+            );
+            let expected_start_line = pr_reviews::canonical_review_start_line(
+                Some(expected.subject_type.as_str()),
+                expected.line,
+                Some(expected.side.as_str()),
+                expected.start_line,
+                expected.start_side.as_deref(),
+                false,
+            );
+            let start_side_matches = if thread.subject_type.as_deref() == Some("LINE")
+                && expected.subject_type == "LINE"
+                && thread_start_line.is_none()
+                && expected_start_line.is_none()
+            {
+                true
+            } else {
+                thread.start_diff_side == expected.start_side
+            };
             thread.author == viewer_login
                 && marker.as_ref().is_some_and(|(run_id, digest)| {
                     run_id == review_run_id && digest == &expected.body_digest
@@ -2447,8 +2472,8 @@ fn validate_submitted_review_manifest<R: BackendRunner>(
                 && thread.path == expected.path
                 && thread.line == expected.line
                 && thread.diff_side.as_deref() == Some(expected.side.as_str())
-                && thread.start_line == expected.start_line
-                && thread.start_diff_side == expected.start_side
+                && thread_start_line == expected_start_line
+                && start_side_matches
                 && thread.subject_type.as_deref() == Some(expected.subject_type.as_str())
         });
         if !matched {

--- a/crates/forge-cli/src/ops/pr_reviews.rs
+++ b/crates/forge-cli/src/ops/pr_reviews.rs
@@ -1018,22 +1018,43 @@ fn parse_github_pending_review_snapshot_page(
             let body_digest = review_state::sha256_digest(semantic_body.as_bytes());
             let line = optional_u32(comment, "/line");
             let original_line = optional_u32(comment, "/originalLine");
-            let start_line = optional_u32(comment, "/startLine");
-            let original_start_line = optional_u32(comment, "/originalStartLine");
             let subject_type = optional_string(comment, "/subjectType")
                 .unwrap_or_else(|| if line.is_some() { "LINE" } else { "FILE" }.to_string());
+            let raw_start_line = optional_u32(comment, "/startLine");
+            let raw_original_start_line = optional_u32(comment, "/originalStartLine");
             let diff_side = normalized_comment_side(
                 comment,
                 "/diffSide",
                 line.or(original_line),
                 &subject_type,
             )?;
-            let start_diff_side = normalized_comment_side(
+            let raw_start_diff_side = normalized_comment_side(
                 comment,
                 "/startDiffSide",
-                start_line.or(original_start_line),
+                raw_start_line.or(raw_original_start_line),
                 &subject_type,
             )?;
+            let start_line = canonical_review_start_line(
+                Some(subject_type.as_str()),
+                line,
+                diff_side.as_deref(),
+                raw_start_line,
+                raw_start_diff_side.as_deref(),
+                false,
+            );
+            let original_start_line = canonical_review_start_line(
+                Some(subject_type.as_str()),
+                original_line,
+                diff_side.as_deref(),
+                raw_original_start_line,
+                raw_start_diff_side.as_deref(),
+                false,
+            );
+            let start_diff_side = if start_line.is_none() && original_start_line.is_none() {
+                None
+            } else {
+                raw_start_diff_side
+            };
             Ok(PendingReviewInlineComment {
                 id: required_string(comment, "/id", "review.comment.id")?,
                 url: required_string(comment, "/url", "review.comment.url")?,
@@ -1099,6 +1120,27 @@ fn parse_github_pending_review_snapshot_page(
             snapshot_digest: String::new(),
         },
     }))
+}
+
+pub(super) fn canonical_review_start_line(
+    subject_type: Option<&str>,
+    line: Option<u32>,
+    diff_side: Option<&str>,
+    start_line: Option<u32>,
+    start_diff_side: Option<&str>,
+    allow_missing_start_side: bool,
+) -> Option<u32> {
+    let same_known_side = start_diff_side.is_some() && start_diff_side == diff_side;
+    let provider_omitted_start_side = allow_missing_start_side && start_diff_side.is_none();
+    if subject_type == Some("LINE")
+        && line.is_some()
+        && start_line == line
+        && (same_known_side || provider_omitted_start_side)
+    {
+        None
+    } else {
+        start_line
+    }
 }
 
 fn normalized_comment_side(
@@ -1195,11 +1237,43 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
                 Some(format!("comment_id={}", comment.id)),
             ));
         }
+        let anchor_start_line = canonical_review_start_line(
+            anchor.subject_type.as_deref(),
+            anchor.line,
+            anchor.diff_side.as_deref(),
+            anchor.start_line,
+            anchor.start_diff_side.as_deref(),
+            true,
+        );
+        let anchor_original_start_line = canonical_review_start_line(
+            anchor.subject_type.as_deref(),
+            anchor.original_line,
+            anchor.diff_side.as_deref(),
+            anchor.original_start_line,
+            anchor.start_diff_side.as_deref(),
+            true,
+        );
+        let comment_start_line = canonical_review_start_line(
+            Some(comment.subject_type.as_str()),
+            comment.line,
+            anchor.diff_side.as_deref(),
+            comment.start_line,
+            anchor.start_diff_side.as_deref(),
+            true,
+        );
+        let comment_original_start_line = canonical_review_start_line(
+            Some(comment.subject_type.as_str()),
+            comment.original_line,
+            anchor.diff_side.as_deref(),
+            comment.original_start_line,
+            anchor.start_diff_side.as_deref(),
+            true,
+        );
         if anchor.path != comment.path
             || anchor.line != comment.line
             || anchor.original_line != comment.original_line
-            || anchor.start_line != comment.start_line
-            || anchor.original_start_line != comment.original_start_line
+            || anchor_start_line != comment_start_line
+            || anchor_original_start_line != comment_original_start_line
             || anchor.subject_type.as_deref() != Some(comment.subject_type.as_str())
         {
             return Err(snapshot_incomplete(
@@ -1209,6 +1283,11 @@ fn hydrate_deferred_comment_sides<R: BackendRunner>(
         }
         if comment.subject_type != "LINE" {
             continue;
+        }
+        comment.start_line = comment_start_line;
+        comment.original_start_line = comment_original_start_line;
+        if comment.start_line.is_none() && comment.original_start_line.is_none() {
+            comment.start_diff_side = None;
         }
         let diff_side = anchor.diff_side.as_deref().ok_or_else(|| {
             snapshot_incomplete(
@@ -1855,6 +1934,61 @@ mod tests {
         assert_eq!(page.snapshot.inline_comments[0].diff_side, None);
     }
 
+    #[test]
+    fn pending_snapshot_preserves_equal_number_cross_side_ranges() {
+        let mut range = pending_snapshot_page(PendingSnapshotPageSpec {
+            head: "head-7",
+            id: "PRRC_cross_side",
+            path: "src/replaced.rs",
+            line: 10,
+            diff_side: "RIGHT",
+            start_line: Some(10),
+            start_diff_side: Some("LEFT"),
+            has_next_page: false,
+            end_cursor: None,
+        });
+        let mut range_value: serde_json::Value =
+            serde_json::from_str(&range.stdout).expect("snapshot fixture");
+        range_value["data"]["node"]["comments"]["totalCount"] = 1.into();
+        let comment = range_value
+            .pointer_mut("/data/node/comments/nodes/0")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("comment object");
+        comment.remove("diffSide");
+        comment.remove("startDiffSide");
+        comment.insert(
+            "diffHunk".into(),
+            "@@ -10,1 +10,1 @@\n-old value\n+new value".into(),
+        );
+        range.stdout = range_value.to_string();
+
+        let mut thread = truncated_comment_thread("src/replaced.rs", "PRRC_cross_side");
+        let mut thread_value: serde_json::Value =
+            serde_json::from_str(&thread.stdout).expect("thread fixture");
+        let anchor =
+            &mut thread_value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][0];
+        anchor["line"] = 10.into();
+        anchor["originalLine"] = 10.into();
+        anchor["startLine"] = 10.into();
+        anchor["originalStartLine"] = 10.into();
+        anchor["diffSide"] = "RIGHT".into();
+        anchor["startDiffSide"] = "LEFT".into();
+        anchor["comments"]["nodes"][0]["body"] = "finding PRRC_cross_side".into();
+        anchor["comments"]["nodes"][0]["url"] =
+            "https://github.com/acme/widgets/pull/7#discussion_PRRC_cross_side".into();
+        thread.stdout = thread_value.to_string();
+        let runner = ScriptedRunner::new(vec![range, thread]);
+
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("cross-side range recovers from the authoritative thread")
+            .expect("pending snapshot");
+        let comment = &snapshot.inline_comments[0];
+
+        assert_eq!(comment.start_line, Some(10));
+        assert_eq!(comment.start_diff_side.as_deref(), Some("LEFT"));
+        assert_eq!(comment.diff_side.as_deref(), Some("RIGHT"));
+    }
+
     fn truncated_pending_snapshot_page() -> BackendSuccess {
         let mut truncated = pending_snapshot_page(PendingSnapshotPageSpec {
             head: "head-7",
@@ -2021,6 +2155,51 @@ mod tests {
                 .iter()
                 .any(|call| call.contains("reviewThreads(first: 100")),
             "the exact provider thread snapshot must own the fallback side"
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_accepts_github_normalized_single_line_starts() {
+        let mut thread_response = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&thread_response.stdout).expect("thread fixture");
+        let thread = &mut value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][0];
+        thread["startLine"] = 982.into();
+        thread["originalStartLine"] = 982.into();
+        thread_response.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![truncated_pending_snapshot_page(), thread_response]);
+
+        let snapshot = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect("equivalent single-line anchors recover from review threads")
+            .expect("pending snapshot");
+
+        assert_eq!(snapshot.inline_comments[0].start_line, None);
+        assert_eq!(snapshot.inline_comments[0].original_start_line, None);
+        assert_eq!(
+            snapshot.inline_comments[0].diff_side.as_deref(),
+            Some("RIGHT")
+        );
+    }
+
+    #[test]
+    fn pending_snapshot_recovery_rejects_a_genuine_range_mismatch() {
+        let mut thread_response = truncated_comment_thread("src/new.rs", "PRRC_truncated");
+        let mut value: serde_json::Value =
+            serde_json::from_str(&thread_response.stdout).expect("thread fixture");
+        let thread = &mut value["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"][0];
+        thread["startLine"] = 970.into();
+        thread["originalStartLine"] = 970.into();
+        thread["startDiffSide"] = "RIGHT".into();
+        thread_response.stdout = value.to_string();
+        let runner = ScriptedRunner::new(vec![truncated_pending_snapshot_page(), thread_response]);
+
+        let error = compute_pending_snapshot(&runner, &github_ctx(), "PRR_pending")
+            .expect_err("non-single-line range mismatches must remain fail-closed");
+
+        assert_eq!(error.kind(), "review_snapshot_incomplete");
+        assert!(
+            error.to_string().contains("anchor differs"),
+            "unexpected error: {error}"
         );
     }
 

--- a/crates/forge-cli/tests/integration/pr_pending_review.rs
+++ b/crates/forge-cli/tests/integration/pr_pending_review.rs
@@ -813,6 +813,73 @@ esac
 }
 
 #[test]
+fn pr_pending_review_inspect_accepts_github_normalized_single_line_starts() {
+    let stub = StubEnv::new();
+    let capture = stub
+        .tempdir
+        .path()
+        .join("normalized-single-line-inspect.log");
+    let script = format!(
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> {capture:?}
+case "$1 $2" in
+  "pr view")
+    printf '%s\n' '{{"number":42,"url":"https://github.com/acme/widgets/pull/42","state":"OPEN","isDraft":false,"baseRefName":"main","headRefName":"feat/reviews","headRefOid":"head-new","title":"feat: reviews","body":""}}'
+    ;;
+  "api graphql")
+    case "$*" in
+      *"reviewThreads(first: 100"*)
+        printf '%s\n' '{{"data":{{"review":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary","viewerDidAuthor":true,"viewerCanDelete":true,"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}},"repository":{{"pullRequest":{{"headRefOid":"head-new","reviewThreads":{{"nodes":[{{"id":"PRRT_1","isResolved":false,"isOutdated":false,"path":"src/lib.rs","diffSide":"RIGHT","line":10,"originalLine":10,"startLine":10,"originalStartLine":10,"startDiffSide":null,"subjectType":"LINE","comments":{{"nodes":[{{"id":"PRRC_1","author":{{"login":"review-bot"}},"body":"first","createdAt":"2026-07-20T12:00:00Z","url":"https://github.com/acme/widgets/pull/42#discussion_r1"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}}}}}}}}}}'
+        ;;
+      *)
+        printf '%s\n' '{{"data":{{"node":{{"id":"PRR_pending","url":"https://github.com/acme/widgets/pull/42#pullrequestreview-102","author":{{"login":"review-bot"}},"state":"PENDING","commit":{{"oid":"head-new"}},"body":"Summary","viewerDidAuthor":true,"viewerCanDelete":true,"comments":{{"totalCount":1,"nodes":[{{"id":"PRRC_1","url":"https://github.com/acme/widgets/pull/42#discussion_r1","author":{{"login":"review-bot"}},"body":"first","createdAt":"2026-07-20T12:00:00Z","path":"src/lib.rs","diffHunk":"@@ -1,1 +1,1 @@\n-old\n+new","line":10,"originalLine":10,"startLine":null,"originalStartLine":null,"subjectType":"LINE"}}],"pageInfo":{{"hasNextPage":false,"endCursor":null}}}},"pullRequest":{{"number":42,"url":"https://github.com/acme/widgets/pull/42","headRefOid":"head-new"}}}}}}}}'
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected gh args: $*" >&2
+    exit 99
+    ;;
+esac
+"#
+    );
+    let stub = stub.gh_stub(&script);
+
+    let out = run_forge_cli(
+        &stub,
+        &[
+            "--provider",
+            "github",
+            "--repo",
+            "acme/widgets",
+            "--format",
+            "json",
+            "pr",
+            "pending-review",
+            "inspect",
+            "42",
+            "--review",
+            "PRR_pending",
+        ],
+    );
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], true);
+    assert_eq!(
+        env["data"]["snapshot"]["inline_comments"][0]["diff_side"],
+        "RIGHT"
+    );
+    assert_eq!(
+        env["data"]["snapshot"]["inline_comments"][0]["start_line"],
+        serde_json::Value::Null
+    );
+    let calls = fs::read_to_string(capture).expect("read gh calls");
+    assert!(calls.contains("reviewThreads(first: 100"), "{calls}");
+}
+
+#[test]
 fn pr_pending_review_resume_submit_rejects_an_incomplete_receipt_manifest() {
     let stub = StubEnv::new();
     let capture = stub.tempdir.path().join("resume-submit-calls.log");

--- a/crates/forge-cli/tests/integration/pr_review.rs
+++ b/crates/forge-cli/tests/integration/pr_review.rs
@@ -934,12 +934,26 @@ case "$*" in
     printf '%s\n' 'https://github.com/acme/widgets/issues/101#issuecomment-review'
     ;;
   *"reviewThreads(first: 100"*)
-    if [ -f "$submitted" ] && [ -f "$finding_body_0" ]; then
+    if [ -f "$finding_body_0" ] \
+      && { [ -f "$submitted" ] || [ "$failure" = "normalized-single-line" ]; }; then
       body=$(json_escape "$finding_body_0")
       path=$(json_escape "$finding_path_0")
       line=$(sed -n '1p' "$finding_line_0")
       [ -n "$line" ] || line=null
-      printf '{"data":{"repository":{"pullRequest":{"headRefOid":"head-44","reviewThreads":{"nodes":[{"id":"PRRT_created","isResolved":false,"isOutdated":false,"path":"%s","diffSide":"RIGHT","line":%s,"originalLine":%s,"originalStartLine":null,"startDiffSide":null,"startLine":null,"subjectType":"LINE","comments":{"nodes":[{"id":"PRRC_created","author":{"login":"review-bot"},"body":"%s","createdAt":"2026-07-20T12:00:00Z","url":"https://github.com/acme/widgets/pull/44#discussion_r42"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n' "$path" "$line" "$line" "$body"
+      thread_start_line=null
+      if [ "$failure" = "normalized-single-line" ]; then
+        thread_start_line=$line
+        review_body=$(json_escape "$pending_body")
+        review_state=PENDING
+        review_can_delete=true
+        if [ -f "$submitted" ]; then
+          review_state=COMMENTED
+          review_can_delete=false
+        fi
+        printf '{"data":{"review":{"id":"PRR_kwDOpending","url":"https://github.com/acme/widgets/pull/44#pullrequestreview-9900","author":{"login":"review-bot"},"state":"%s","commit":{"oid":"head-44"},"body":"%s","viewerDidAuthor":true,"viewerCanDelete":%s,"pullRequest":{"number":44,"url":"https://github.com/acme/widgets/pull/44","headRefOid":"head-44"}},"repository":{"pullRequest":{"headRefOid":"head-44","reviewThreads":{"nodes":[{"id":"PRRT_created","isResolved":false,"isOutdated":false,"path":"%s","diffSide":"RIGHT","line":%s,"originalLine":%s,"originalStartLine":null,"startDiffSide":null,"startLine":%s,"subjectType":"LINE","comments":{"nodes":[{"id":"PRRC_created_0","author":{"login":"review-bot"},"body":"%s","createdAt":"2026-07-20T12:00:00Z","url":"https://github.com/acme/widgets/pull/44#discussion_r42"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n' "$review_state" "$review_body" "$review_can_delete" "$path" "$line" "$line" "$thread_start_line" "$body"
+      else
+        printf '{"data":{"repository":{"pullRequest":{"headRefOid":"head-44","reviewThreads":{"nodes":[{"id":"PRRT_created","isResolved":false,"isOutdated":false,"path":"%s","diffSide":"RIGHT","line":%s,"originalLine":%s,"originalStartLine":null,"startDiffSide":null,"startLine":%s,"subjectType":"LINE","comments":{"nodes":[{"id":"PRRC_created","author":{"login":"review-bot"},"body":"%s","createdAt":"2026-07-20T12:00:00Z","url":"https://github.com/acme/widgets/pull/44#discussion_r42"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}\n' "$path" "$line" "$line" "$thread_start_line" "$body"
+      fi
     elif [ "@EXISTING_THREAD@" = "true" ]; then
       printf '%s\n' '{"data":{"repository":{"pullRequest":{"headRefOid":"head-44","reviewThreads":{"nodes":[{"id":"PRRT_existing","isResolved":@EXISTING_RESOLVED@,"isOutdated":@EXISTING_OUTDATED@,"path":"src/lib.rs","diffSide":"RIGHT","line":42,"originalLine":42,"originalStartLine":null,"startDiffSide":null,"startLine":null,"subjectType":"LINE","comments":{"nodes":[{"id":"PRRC_existing","author":{"login":"quality-bot"},"body":"Duplicate finding body.","createdAt":"2026-07-14T04:00:00Z","url":"https://github.com/acme/widgets/pull/44#discussion_r1"}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
     else
@@ -981,7 +995,11 @@ case "$*" in
       path=$(json_escape "$finding_path_0")
       line=$(sed -n '1p' "$finding_line_0")
       [ -n "$line" ] || line=null
-      comments=$(printf '{"id":"PRRC_created_0","url":"https://github.com/acme/widgets/pull/44#discussion_r42","author":{"login":"review-bot"},"body":"%s","createdAt":"2026-07-20T12:00:00Z","path":"%s","line":%s,"originalLine":%s,"diffSide":"RIGHT","startLine":null,"originalStartLine":null,"startDiffSide":null,"subjectType":"LINE"}' "$comment" "$path" "$line" "$line")
+      anchor_fields='"diffSide":"RIGHT",'
+      if [ "$failure" = "normalized-single-line" ]; then
+        anchor_fields='"diffHunk":"@@ -42,1 +42,1 @@\n-old\n+new",'
+      fi
+      comments=$(printf '{"id":"PRRC_created_0","url":"https://github.com/acme/widgets/pull/44#discussion_r42","author":{"login":"review-bot"},"body":"%s","createdAt":"2026-07-20T12:00:00Z","path":"%s","line":%s,"originalLine":%s,%s"startLine":null,"originalStartLine":null,"startDiffSide":null,"subjectType":"LINE"}' "$comment" "$path" "$line" "$line" "$anchor_fields")
       total=1
     fi
     if [ -f "$finding_body_1" ]; then
@@ -1334,6 +1352,44 @@ fn pr_review_thread_file_creates_resolvable_github_review_thread() {
             && calls.contains("Add coverage for the rejected profile URL path."),
         "{calls}"
     );
+}
+
+#[test]
+fn pr_review_accepts_github_normalized_single_line_thread_start() {
+    let stub = StubEnv::new();
+    let capture = stub.tempdir.path().join("normalized-single-line.log");
+    let thread_file = stub.tempdir.path().join("review-threads.json");
+    fs::write(
+        &thread_file,
+        r#"[{"path":"src/lib.rs","line":42,"side":"RIGHT","body":"Single-line finding."}]"#,
+    )
+    .expect("write thread specs");
+    let stub = stub.gh_stub(&github_resumable_thread_stub(
+        &capture.to_string_lossy(),
+        false,
+        false,
+        false,
+        "normalized-single-line",
+        false,
+    ));
+
+    let out = run_resumable_thread_review(&stub, &thread_file);
+
+    assert_eq!(out.code, 0, "stdout={}\nstderr={}", out.stdout, out.stderr);
+    let env = parse_envelope(&out.stdout);
+    assert_eq!(env["ok"], true);
+    assert_eq!(env["data"]["submitted_review"], true);
+
+    let rerun = run_resumable_thread_review(&stub, &thread_file);
+
+    assert_eq!(
+        rerun.code, 0,
+        "stdout={}\nstderr={}",
+        rerun.stdout, rerun.stderr
+    );
+    let rerun_env = parse_envelope(&rerun.stdout);
+    assert_eq!(rerun_env["ok"], true);
+    assert_eq!(rerun_env["data"]["submitted_review"], false);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Normalize GitHub's two equivalent representations of a single-line review anchor before pending-review snapshot comparison. The change is limited to `LINE` anchors whose `startLine` equals `line` (and the corresponding original lines); real ranged comments remain exact-match guarded.

## Problem

- Expected: a pending review whose thread reports `startLine == line` while its comment omits `startLine` can be inspected and submitted.
- Actual: forge-cli returned `review_snapshot_incomplete` after creating the valid pending review.
- Impact: governed recovery was unavailable and required a raw GitHub GraphQL submission.

## Reproduction

1. Create a GitHub pending review containing a single-line thread.
2. Return the thread anchor with `line=42,startLine=42` and its comment with `line=42,startLine=null`.
3. Run `pr review --submit-review --thread-file ...` or `pr pending-review inspect`.
4. Before this fix, snapshot hydration exits 65 with `pending review comment anchor differs from its review thread`.

## Issues Found

Closes #1569

## Fix Approach

- Canonicalize a start equal to its end line only when authoritative side data proves it has no distinct side (or the same side), for both current and original anchors.
- Defer pending-response classification when side fields are unavailable, then use exact review-thread recovery as the authoritative source.
- Apply the same canonicalization to thread anchors before cross-read comparison.
- Reuse that canonicalization when reconciling an already-submitted review on an exact rerun.
- Preserve non-equal and equal-number cross-side ranges with exact start-side validation.
- Document the provider normalization boundary.

## Test-First Evidence

- RED: `cargo test -p nils-forge-cli --test integration integration::pr_review::pr_review_accepts_github_normalized_single_line_thread_start -- --exact` failed with exit 65 and `review_snapshot_incomplete: pending review comment anchor differs from its review thread`.
- GREEN: the same command passes after canonicalization.
- RED (review follow-up): extending that fixture to run the identical command twice failed on the rerun with exit 65 and `review_state_conflict` in submitted-review manifest validation.
- GREEN (review follow-up): the same test now passes both the initial submit and the idempotent rerun, which reports `submitted_review=false`.
- RED (red-team follow-up): `cargo test -p nils-forge-cli pending_snapshot_preserves_equal_number_cross_side_ranges` failed because `LEFT:10 → RIGHT:10` was collapsed to no start.
- GREEN (red-team follow-up): the same test now preserves the equal-number cross-side range exactly.
- RED (provider-shaped follow-up): after removing side fields from the pending-comment fixture, the cross-side test failed with `review_snapshot_incomplete` while comparing the deferred comment to its exact thread.
- GREEN (provider-shaped follow-up): recovery now applies the authoritative thread sides to both representations before comparison, preserving the cross-side range while still canonicalizing a true single-line anchor.
- Added direct recovery coverage proving `pr pending-review inspect` accepts the same provider representation.
- Added unit coverage proving a non-equal range start still fails closed.

## Test plan

- `cargo test -p nils-forge-cli --test integration integration::pr_review::pr_review_accepts_github_normalized_single_line_thread_start -- --exact` — pass; covers initial submit and exact idempotent rerun
- `cargo test -p nils-forge-cli --test integration integration::pr_pending_review::pr_pending_review_inspect_accepts_github_normalized_single_line_starts -- --exact` — pass
- `cargo test -p nils-forge-cli pending_snapshot_recovery_` — 7 passed
- `cargo test -p nils-forge-cli pending_snapshot_preserves_equal_number_cross_side_ranges` — pass
- `cargo test -p nils-forge-cli` — pass
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast` — pass; clippy/docs gates clean and 1,403 tests passed

## Risk / Notes

- Low and narrowly bounded: only redundant starts equal to their endpoint without a distinct side are canonicalized. Dedicated negative coverage retains fail-closed behavior for non-equal ranges and preserves equal-number cross-side ranges.
