### PR TITLE
Avoid full-history Codex control reconnects

### DIFF
--- a/crates/agent-session/src/codex_app_server.rs
+++ b/crates/agent-session/src/codex_app_server.rs
@@ -1670,11 +1670,13 @@ pub(crate) fn loaded_threads_request(id: u64) -> Value {
     json!({ "id": id, "method": "thread/loaded/list", "params": {} })
 }
 
+/// Rejoin the bound thread for live control without hydrating its unbounded
+/// turn history into a single WebSocket response.
 pub(crate) fn resume_thread_request(id: u64, thread_id: &str, cwd: &str) -> Value {
     json!({
         "id": id,
         "method": "thread/resume",
-        "params": { "threadId": thread_id, "cwd": cwd }
+        "params": { "threadId": thread_id, "cwd": cwd, "excludeTurns": true }
     })
 }
 
@@ -8536,6 +8538,7 @@ printf '%s\n' '{"schema_version":"agent-session.codex-auth-broker.v1","account":
             let resume = receive_json(&mut socket).await;
             assert_eq!(resume["method"], "thread/resume");
             assert_eq!(resume["params"]["threadId"], "raw-thread-a");
+            assert_eq!(resume["params"]["excludeTurns"], true);
             respond(&mut socket, &resume, json!({})).await;
             for _ in 0..2 {
                 let usage = receive_json(&mut socket).await;


### PR DESCRIPTION
## Summary

Make the agent-session Codex control connection resume bound threads metadata-only so long thread history cannot exceed the WebSocket frame limit during reconnect.

## Problem

- Expected: a control reconnect rejoins the exact bound thread and receives live events regardless of the thread's history length.
- Actual: `thread/resume` hydrated every turn; a 21.3 MiB response exceeded the 16 MiB WebSocket frame default, causing a repeated reconnect loop and generic `-32001` busy failures after an interrupted turn.
- Impact: sufficiently long managed Codex sessions could not reliably start a new turn and repeatedly retried the oversized response.

## Reproduction

1. Resume a managed Codex thread whose full `thread/resume` response exceeds 16 MiB.
2. Interrupt the current turn with Esc.
3. Submit another prompt and observe repeated control reconnect failures followed by an agent-session busy error.

## Issues Found

Refs #1575

## Fix Approach

- Send `excludeTurns: true` on the control connection's `thread/resume` request, preserving exact thread binding and live notifications without hydrating historical turns.
- Assert the metadata-only contract in the existing control-reconnect owner test.

## Test-First Evidence

- Red: extended `control_reconnect_resumes_the_bound_loaded_thread` to require `excludeTurns: true`; the unchanged implementation returned null and the focused test exited 101.
- Green: added the metadata-only resume parameter and reran the focused test successfully.

## Test plan

- `cargo test -p nils-agent-session control_reconnect_resumes_the_bound_loaded_thread -- --nocapture`
- `cargo test -p nils-agent-session`
- `bash scripts/ci/nils-cli-checks-entrypoint.sh --local-fast`
- `agent-run exec --cwd . -- ./.agents/scripts/pre-pr.sh`

## Risk / Notes

- Low. `excludeTurns` is supported by the minimum compatible Codex app-server version and only changes control-connection hydration; the TUI proxy path and live notification stream are unchanged.
