### PR TITLE
chore(license): unify copyright holder to Sympoies contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 sympoies
+Copyright (c) 2026 Sympoies contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Unify the LICENSE copyright holder across the public Sympoies repositories.

Some repositories declared the holder as `sympoies` while others already used
`Sympoies contributors`. This change settles on `Sympoies contributors`, which
matches the wording already in `dsh-runtime-kit`.

```diff
-Copyright (c) <year> sympoies
+Copyright (c) <year> Sympoies contributors
```

## Scope

- Holder wording only. The existing copyright year in each repository is left
  untouched, so the recorded first-publication year stays accurate.
- One line in `LICENSE`; no other file is touched.
- The MIT license terms themselves are unchanged.

## Test plan

This is a licence-text change with no executable surface, so there is no
behavioural test to add. Verification is by inspection:

- `git show --stat HEAD` confirms the commit touches only `LICENSE`, one line
  changed.
- `git diff` on `LICENSE` shows the holder substitution and no other edit, with
  the year left as-is.
- `grep -rn 'Copyright (c) 20[0-9][0-9] sympoies'` over the repository returns
  no remaining lowercase-holder occurrence.
- Repository CI runs unchanged on this branch.
